### PR TITLE
Trail to fix API request flood

### DIFF
--- a/src/components/Layout/WalletDrawer/Connectors.tsx
+++ b/src/components/Layout/WalletDrawer/Connectors.tsx
@@ -45,7 +45,7 @@ const Connectors = () => {
     useState<boolean>(true)
 
   useEffect(() => {
-    if (address && !walletDetails && accountData) {
+    if (address && !walletDetails && accountData?.address) {
       const payload = {
         address,
         connector: undefined,
@@ -64,7 +64,14 @@ const Connectors = () => {
         dispatch(updateWalletDetails(response))
       })
     }
-  }, [address, getBalance, dispatch, walletDetails, accountData])
+  }, [
+    address,
+    getBalance,
+    dispatch,
+    walletDetails,
+    accountData?.address,
+    accountData?.ens,
+  ])
 
   useEffect(() => {
     if (walletDetails) {


### PR DESCRIPTION
Fixes https://github.com/EveripediaNetwork/issues/issues/133

It seems like the accountData is getting triggered recursively inside useEffect in `src/components/Layout/WalletDrawer/Connectors.tsx` I updated the dependencies to be more specific that are used in useEffect body

## Before

https://user-images.githubusercontent.com/52039218/158016519-a0107614-26bc-460b-bccc-1d7bda260e13.mp4

## After 

https://user-images.githubusercontent.com/52039218/158016527-9cf02704-a029-4d43-ba94-2bbbbca172db.mp4


