### PR TITLE
Fixes issues#156- Implementing Localstorage expiry 

### DIFF
--- a/src/utils/browserStorage.ts
+++ b/src/utils/browserStorage.ts
@@ -1,16 +1,16 @@
 import type { RootState } from '@/store/store'
 
 const storageKey = 'serializedState'
-const currentDate = new Date();
-const expiryTimeline = 86400;
+const currentDate = new Date()
+const expiryTimeline = 86400
 
 export const loadState = () => {
   try {
     const serializedInitialState = localStorage.getItem(storageKey)
-    const setExpiry = JSON.parse(localStorage.getItem(storageKey) || "{}");
+    const setExpiry = JSON.parse(localStorage.getItem(storageKey) || '{}')
     if (!serializedInitialState) return undefined
 
-    if(currentDate.getTime() > setExpiry) { 
+    if (currentDate.getTime() > setExpiry) {
       localStorage.removeItem(storageKey)
     }
     return JSON.parse(serializedInitialState)
@@ -19,14 +19,17 @@ export const loadState = () => {
   }
 }
 
-export function saveState(state: RootState) {  
+export function saveState(state: RootState) {
   if (typeof window !== 'undefined') {
     let updatedState = state
     if (state.providerNetwork) {
       const providerNetwork = { detectedProvider: null }
-      updatedState = { ...state, providerNetwork}
-    } 
-    const preSerializedState = {updatedState, expiry: currentDate.getTime()+expiryTimeline}
+      updatedState = { ...state, providerNetwork }
+    }
+    const preSerializedState = {
+      updatedState,
+      expiry: currentDate.getTime() + expiryTimeline,
+    }
     const serializedState = JSON.stringify(preSerializedState)
     localStorage.setItem(storageKey, serializedState)
   }

--- a/src/utils/browserStorage.ts
+++ b/src/utils/browserStorage.ts
@@ -1,25 +1,33 @@
 import type { RootState } from '@/store/store'
 
 const storageKey = 'serializedState'
+const currentDate = new Date();
+const expiryTimeline = 86400;
 
 export const loadState = () => {
   try {
     const serializedInitialState = localStorage.getItem(storageKey)
+    const setExpiry = JSON.parse(localStorage.getItem(storageKey) || "{}");
     if (!serializedInitialState) return undefined
+
+    if(currentDate.getTime() > setExpiry) { 
+      localStorage.removeItem(storageKey)
+    }
     return JSON.parse(serializedInitialState)
   } catch (e) {
     return undefined
   }
 }
 
-export function saveState(state: RootState) {
+export function saveState(state: RootState) {  
   if (typeof window !== 'undefined') {
     let updatedState = state
     if (state.providerNetwork) {
       const providerNetwork = { detectedProvider: null }
-      updatedState = { ...state, providerNetwork }
-    }
-    const serializedState = JSON.stringify(updatedState)
+      updatedState = { ...state, providerNetwork}
+    } 
+    const preSerializedState = {updatedState, expiry: currentDate.getTime()+expiryTimeline}
+    const serializedState = JSON.stringify(preSerializedState)
     localStorage.setItem(storageKey, serializedState)
   }
 }


### PR DESCRIPTION
# Fixes issues#156- Implementing Localstorage expiry 

_This makes sure cache for localstorage gets invalidated over the period of 1day._

## How should this be tested?

1. Clear cache or run a hard-reload
2. Check for expiry object inside of the localStorage tab in the Applications tab. 

## Notes or observations

_jot down something here_

## Linked issues

closes #00, closes #001, closes https://github.com/EveripediaNetwork/issues/issues/156
