### PR TITLE
Fixes issues#157- User address is shorted when creating the IPFS in create wiki

### DIFF
--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -107,9 +107,7 @@ const CreateWiki = () => {
           ...tmp.content,
           content: String(md),
           user: {
-            id: accountData.ens
-              ? accountData.ens.name
-              : shortenAccount(accountData.address),
+            id: accountData.address
           },
           images: [{ id: imageHash, type: 'image/jpeg, image/png' }],
         },

--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -24,7 +24,6 @@ import { useAppSelector } from '@/store/hook'
 import { authenticatedRoute } from '@/components/AuthenticatedRoute'
 import { getWikiMetadataById } from '@/utils/getWikiFields'
 import { PageTemplate } from '@/constant/pageTemplate'
-import shortenAccount from '@/utils/shortenAccount'
 import { WikiAbi } from '../../abi/Wiki.abi'
 
 const Editor = dynamic(() => import('@/components/Layout/Editor/Editor'), {
@@ -107,7 +106,7 @@ const CreateWiki = () => {
           ...tmp.content,
           content: String(md),
           user: {
-            id: accountData.address
+            id: accountData.address,
           },
           images: [{ id: imageHash, type: 'image/jpeg, image/png' }],
         },


### PR DESCRIPTION
# User address is shorted when creating the IPFS in create wiki

User address is short on the user object- this PR fixes that by passing the address directly without using the `shortenAddress` func. 

## How should this be tested?

1. Step one
2. Step two
3. ...

## Notes or observations

_jot down something here_

## Linked issues

closes #00, closes #001, closes https://github.com/EveripediaNetwork/issues/issues/ISSUE_NUMBER_GOES_HERE
