### PR TITLE
Wikis API Migrate and Wiki Type Change

### DIFF
--- a/src/components/Layout/Editor/Highlights/Highlights.tsx
+++ b/src/components/Layout/Editor/Highlights/Highlights.tsx
@@ -28,7 +28,7 @@ const Highlights = () => {
   const handleDispatch = (object: Partial<Content>) =>
     dispatch({
       type: 'wiki/setCurrentWiki',
-      payload: { content: { ...object } },
+      payload: object,
     })
 
   const handleSetImage = (value: string | ArrayBuffer | null) =>
@@ -65,7 +65,7 @@ const Highlights = () => {
               title: event.target.value,
             })
           }}
-          value={currentWiki.content.title}
+          value={currentWiki.title}
           placeholder="Title goes here"
         />
       </Flex>
@@ -113,7 +113,7 @@ const Highlights = () => {
             justify="space-evenly"
             w="full"
           >
-            {currentWiki.content.categories.map((c: BaseCategory) => (
+            {currentWiki.categories.map((c: BaseCategory) => (
               <Badge variant="outline" m="1">
                 {c.title}
               </Badge>

--- a/src/components/Layout/Editor/Highlights/HighlightsModal/HighlightsModal.tsx
+++ b/src/components/Layout/Editor/Highlights/HighlightsModal/HighlightsModal.tsx
@@ -54,12 +54,9 @@ const HighlightsModal = ({
   const handleSetWikiMetadata = (ob: MData) => {
     setWiki((prev: Wiki) => ({
       ...prev,
-      content: {
-        ...prev.content,
-        metadata: prev.content.metadata.map((m: MData) =>
-          m.id === ob.id ? { ...m, value: ob.value } : m,
-        ),
-      },
+      metadata: prev.metadata.map((m: MData) =>
+        m.id === ob.id ? { ...m, value: ob.value } : m,
+      ),
     }))
   }
 
@@ -73,31 +70,23 @@ const HighlightsModal = ({
   const handleAddCategory = (category: string) => {
     if (!category) return
 
-    if (
-      !wiki.content.categories.find((c: BaseCategory) => c.title === category)
-    )
+    if (!wiki.categories.find((c: BaseCategory) => c.title === category))
       setWiki((prev: Wiki) => ({
         ...prev,
-        content: {
-          ...prev.content,
-          images: [...currentWiki.content.images],
-          categories: [
-            ...prev.content.categories,
-            { id: slugify(category.toLowerCase()), title: category },
-          ],
-        },
+        images: [...currentWiki.images],
+        categories: [
+          ...prev.categories,
+          { id: slugify(category.toLowerCase()), title: category },
+        ],
       }))
   }
 
   const handleDeleteCategory = (category: string) => {
     setWiki({
       ...wiki,
-      content: {
-        ...wiki.content,
-        categories: wiki.content.categories.filter(
-          (c: BaseCategory) => c.title !== category,
-        ),
-      },
+      categories: wiki.categories.filter(
+        (c: BaseCategory) => c.title !== category,
+      ),
     })
   }
 
@@ -130,8 +119,7 @@ const HighlightsModal = ({
               })
           }}
           value={String(
-            wiki.content.metadata.find((m: MData) => m.id === 'page-type')
-              ?.value,
+            wiki.metadata.find((m: MData) => m.id === 'page-type')?.value,
           )}
           placeholder="Choose a page type"
         >
@@ -164,7 +152,7 @@ const HighlightsModal = ({
           alignItems="center"
           gridColumn="1/3"
         >
-          {wiki.content.categories.map((c: BaseCategory) => (
+          {wiki.categories.map((c: BaseCategory) => (
             <Badge
               variant="outline"
               display="flex"

--- a/src/components/Wiki/WikiCard/WikiCard.tsx
+++ b/src/components/Wiki/WikiCard/WikiCard.tsx
@@ -103,14 +103,14 @@ const WikiCard = ({ wiki }: WikiCardProps) => (
       justifyContent="center"
       marginTop={{ base: '3', sm: '0' }}
     >
-      <BlogTags tags={wiki.content.tags} />
+      <BlogTags tags={wiki.tags} />
       <Heading marginTop="1">
         <Link
           href={`/wiki/${wiki.id}`}
           textDecoration="none"
           _hover={{ textDecoration: 'none' }}
         >
-          {wiki.content.title}
+          {wiki.title}
         </Link>
       </Heading>
       <Text
@@ -120,10 +120,10 @@ const WikiCard = ({ wiki }: WikiCardProps) => (
         _dark={{ color: 'gray.200' }}
         fontSize="lg"
       >
-        {wiki.content.content}
+        {wiki.content}
       </Text>
       <BlogAuthor
-        name={shortenAccount(wiki?.content?.user?.id || '')}
+        name={shortenAccount(wiki?.user?.id || '')}
         date={new Date('2021-04-06T19:01:27Z')}
       />
     </Box>

--- a/src/pages/api/ipfs/index.ts
+++ b/src/pages/api/ipfs/index.ts
@@ -6,8 +6,7 @@ import { Wiki } from '@/types/Wiki'
 const pinToPinata = async (payload: Wiki): Promise<string> => {
   const body = {
     pinataMetadata: {
-      name:
-        (<Wiki>payload).content !== undefined ? payload.content.title : 'image',
+      name: (<Wiki>payload).content !== undefined ? payload.title : 'image',
     },
     pinataContent: {
       ...payload,

--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -57,7 +57,7 @@ const CreateWiki = () => {
 
   const saveImage = async () => {
     const formData = new FormData()
-    const blob = new Blob([wiki.content.images[0].type as ArrayBuffer], {
+    const blob = new Blob([wiki.images[0].type as ArrayBuffer], {
       type: 'multipart/form-data',
     })
 
@@ -99,17 +99,14 @@ const CreateWiki = () => {
 
       let tmp = { ...wiki }
 
-      tmp.id = slugify(String(wiki.content.title).toLowerCase())
+      tmp.id = slugify(String(wiki.title).toLowerCase())
       tmp = {
         ...tmp,
-        content: {
-          ...tmp.content,
-          content: String(md),
-          user: {
-            id: accountData.address,
-          },
-          images: [{ id: imageHash, type: 'image/jpeg, image/png' }],
+        content: String(md),
+        user: {
+          id: accountData.address,
         },
+        images: [{ id: imageHash, type: 'image/jpeg, image/png' }],
       }
 
       const {
@@ -121,7 +118,7 @@ const CreateWiki = () => {
   }
 
   const disableSaveButton = () =>
-    wiki.content.images.length === 0 || submittingWiki || !accountData?.address
+    wiki.images.length === 0 || submittingWiki || !accountData?.address
 
   const handleOnEditorChanges = (val: string | undefined) => {
     if (val) setMd(val)

--- a/src/services/wikis/index.ts
+++ b/src/services/wikis/index.ts
@@ -6,7 +6,7 @@ import {
   GET_WIKI_BY_ID,
   GET_WIKIS,
 } from '@/services/wikis/queries'
-import { Content, Wiki } from '@/types/Wiki'
+import { Wiki } from '@/types/Wiki'
 import config from '@/config'
 
 type GetWikisResponse = {
@@ -18,8 +18,8 @@ type GetWikiResponse = {
 }
 
 type GetUserWikiResponse = {
-  user: {
-    contents: Content[]
+  userById: {
+    wikis: Wiki[]
   }
 }
 
@@ -31,7 +31,7 @@ export const wikiApi = createApi({
     }
     return null
   },
-  baseQuery: graphqlRequestBaseQuery({ url: config.thegraph }),
+  baseQuery: graphqlRequestBaseQuery({ url: config.graphqlUrl }),
   endpoints: builder => ({
     getWikis: builder.query<Wiki[], void>({
       query: () => ({ document: GET_WIKIS }),
@@ -41,13 +41,13 @@ export const wikiApi = createApi({
       query: (id: string) => ({ document: GET_WIKI_BY_ID, variables: { id } }),
       transformResponse: (response: GetWikiResponse) => response.wiki,
     }),
-    getUserWikis: builder.query<Content[], string>({
+    getUserWikis: builder.query<Wiki[], string>({
       query: (id: string) => ({
         document: GET_USER_WIKIS_BY_ID,
         variables: { id },
       }),
       transformResponse: (response: GetUserWikiResponse) =>
-        response.user.contents,
+        response.userById.wikis,
     }),
   }),
 })

--- a/src/services/wikis/queries.ts
+++ b/src/services/wikis/queries.ts
@@ -4,28 +4,26 @@ export const GET_WIKI_BY_ID = gql`
   query GetWiki($id: String!) {
     wiki(id: $id) {
       id
-      content {
-        createdAt
+      created
+      title
+      content
+      categories {
+        id
         title
-        content
-        categories {
-          id
-          title
-        }
-        tags {
-          id
-        }
-        images {
-          id
-          type
-        }
-        metadata {
-          id
-          value
-        }
-        user {
-          id
-        }
+      }
+      tags {
+        id
+      }
+      images {
+        id
+        type
+      }
+      metadata {
+        id
+        value
+      }
+      user {
+        id
       }
     }
   }
@@ -35,28 +33,26 @@ export const GET_WIKIS = gql`
   query GetWikis {
     wikis {
       id
-      content {
-        createdAt
+      content
+      created
+      title
+      content
+      categories {
+        id
         title
-        content
-        categories {
-          id
-          title
-        }
-        tags {
-          id
-        }
-        images {
-          id
-          type
-        }
-        metadata {
-          id
-          value
-        }
-        user {
-          id
-        }
+      }
+      tags {
+        id
+      }
+      images {
+        id
+        type
+      }
+      metadata {
+        id
+      }
+      user {
+        id
       }
     }
   }
@@ -64,10 +60,10 @@ export const GET_WIKIS = gql`
 
 export const GET_USER_WIKIS_BY_ID = gql`
   query GetUserWikis($id: String!) {
-    user(id: $id) {
-      contents(first: 10, orderBy: createdAt, orderDirection: desc) {
-        createdAt
+    userById(id: $id) {
+      wikis {
         title
+        created
         content
         categories {
           id

--- a/src/store/slices/wiki.slice.ts
+++ b/src/store/slices/wiki.slice.ts
@@ -5,19 +5,17 @@ const initialState: Wiki = {
   id: '',
   version: 1,
   language: LanguagesISOEnum.EN,
-  content: {
-    title: 'Wiki title',
-    content: '',
-    categories: [{ id: 'first-category', title: 'First Category' }],
-    tags: [{ id: 'hello' }, { id: 'world' }],
-    images: [],
-    metadata: [
-      {
-        id: 'page-type',
-        value: 'Place / Location',
-      },
-    ],
-  },
+  title: 'Wiki title',
+  content: '',
+  categories: [{ id: 'first-category', title: 'First Category' }],
+  tags: [{ id: 'hello' }, { id: 'world' }],
+  images: [],
+  metadata: [
+    {
+      id: 'page-type',
+      value: 'Place / Location',
+    },
+  ],
 }
 
 const wikiSlice = createSlice({
@@ -28,7 +26,6 @@ const wikiSlice = createSlice({
       const newState = {
         ...state,
         ...action.payload,
-        content: { ...state.content, ...action.payload.content },
       }
       return newState
     },

--- a/src/types/Wiki.ts
+++ b/src/types/Wiki.ts
@@ -73,22 +73,12 @@ export const Languages: LanguagesType = {
 export interface Wiki {
   id: string
   title: string
-  created: string
   content: string
-  categories: {
-    id: string
-    title: string
-  }
+  categories: BaseCategory[]
   tags: Tag[]
-  images: {
-    id: string
-    type: string | ArrayBuffer | null
-  }
-  metadata: {
-    id: string
-    value: string
-  }
-  user: {
-    id: string
-  }
+  images: Image[]
+  metadata: MData[]
+  user?: User
+  version: number
+  language: LanguagesISOEnum
 }

--- a/src/types/Wiki.ts
+++ b/src/types/Wiki.ts
@@ -72,7 +72,23 @@ export const Languages: LanguagesType = {
 
 export interface Wiki {
   id: string
-  version: number
-  content: Content
-  language: LanguagesISOEnum
+  title: string
+  created: string
+  content: string
+  categories: {
+    id: string
+    title: string
+  }
+  tags: Tag[]
+  images: {
+    id: string
+    type: string | ArrayBuffer | null
+  }
+  metadata: {
+    id: string
+    value: string
+  }
+  user: {
+    id: string
+  }
 }

--- a/src/utils/browserStorage.ts
+++ b/src/utils/browserStorage.ts
@@ -27,10 +27,10 @@ export function saveState(state: RootState) {
       const providerNetwork = { detectedProvider: null }
       updatedState = { ...state, providerNetwork }
     }
-    if (state.wiki.content.images.length > 0) {
+    if (state.wiki.images.length > 0) {
       const wiki = {
         ...state.wiki,
-        content: { ...state.wiki.content, images: [] },
+        images: [],
       }
       updatedState = { ...state, wiki }
     }

--- a/src/utils/getWikiFields.ts
+++ b/src/utils/getWikiFields.ts
@@ -1,7 +1,7 @@
 import { BaseCategory, MData, Wiki } from '@/types/Wiki'
 
 export const getWikiMetadataById = (wiki: Wiki, id: string) =>
-  wiki.content.metadata.find((m: MData) => m.id === id)
+  wiki.metadata.find((m: MData) => m.id === id)
 
 export const getCategoryById = (wiki: Wiki, id: string) =>
-  wiki.content.categories.find((c: BaseCategory) => c.id === id)
+  wiki.categories.find((c: BaseCategory) => c.id === id)


### PR DESCRIPTION
# Changes
1. Changes wiki RTK query to use Graphql API instead of theGraph 
2. ⚠️ Changes the type of ```Wiki``` to match the data from backend
3. ⚠️ Changes the structure of data stored in ```wiki.slice.ts``` to match new wiki type
4. ⚠️ Made Changes at all places to accommodate the new wiki type that uses wiki slice or wiki RTK query 

## Difference between old and new wiki type
basically spreads the old contents object in to wiki type

![screely-1647865123673](https://user-images.githubusercontent.com/52039218/159259407-acf7d824-8a07-4699-abcb-9c492c8957e2.png)

This removes lot of destructing inside destructing for content. 

