### PR TITLE
Handle wiki dialog box error

### DIFF
--- a/src/components/Elements/Modal/WikiProcessModal.tsx
+++ b/src/components/Elements/Modal/WikiProcessModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import {
   Box,
   AlertDialog,
@@ -51,6 +51,7 @@ const WikiProcessModal = ({
       window.open(`${config.blockExplorerUrl}tx/${txHash}`)
     }
   }
+
   return (
     <AlertDialog
       motionPreset="slideInBottom"

--- a/src/components/Elements/Modal/WikiProcessModal.tsx
+++ b/src/components/Elements/Modal/WikiProcessModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import {
   Box,
   AlertDialog,

--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -352,6 +352,13 @@ const CreateWiki = () => {
     if (txHash) verifyTrxHash(txHash)
   }, [txHash])
 
+  const handlePopupClose = () => {
+    setMsg(initialMsg)
+    setIsLoading("loading")
+    setActiveStep(0)
+    setOpenTxDetailsDialog(false)
+  }
+
   return (
     <Box maxW="1900px" mx="auto" mb={8}>
       <HStack
@@ -429,7 +436,7 @@ const CreateWiki = () => {
           activeStep={activeStep}
           state={loadingState}
           isOpen={openTxDetailsDialog}
-          onClose={() => setOpenTxDetailsDialog(false)}
+          onClose={() => handlePopupClose()}
         />
       </Flex>
 

--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -354,7 +354,7 @@ const CreateWiki = () => {
 
   const handlePopupClose = () => {
     setMsg(initialMsg)
-    setIsLoading("loading")
+    setIsLoading('loading')
     setActiveStep(0)
     setOpenTxDetailsDialog(false)
   }


### PR DESCRIPTION
# Handle wiki dialog box error

_ If any error occurs during wiki creation processes and the user has to close the wiki dialog box and recreate the wiki, the wiki process dialog box still retains its previous state instead of its default state.

## How should this be tested?

1. Try to create a wiki 
2. cancel the Metamask transaction signing and close the wiki process dialog box
3. try to recreate the wiki
4.  the wiki process dialog box should restart the process with its default state and not the previous state.

fixes https://github.com/EveripediaNetwork/issues/issues/223
