### PR TITLE
Made TOC Links to Shareable 

### DIFF
--- a/src/components/Wiki/WikiPage/WikiTableOfContents.tsx
+++ b/src/components/Wiki/WikiPage/WikiTableOfContents.tsx
@@ -81,7 +81,7 @@ const WikiTableOfContents = ({ toc }: WikiTableOfContentsProps) => {
     headingElements.forEach(element => observer.observe(element))
 
     return () => observer.disconnect()
-  }, [setActiveId])
+  }, [setActiveId, toc])
 
   React.useEffect(() => {
     if (!activeId) setActiveId(toc[0].id)

--- a/src/pages/wiki/[slug].tsx
+++ b/src/pages/wiki/[slug].tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useRouter } from 'next/router'
 import { skipToken } from '@reduxjs/toolkit/query'
 import { NextSeo } from 'next-seo'
@@ -29,6 +29,17 @@ const Wiki = () => {
   })
   const { isLoading, error, data: wiki } = result
   const [isTocEmpty, setIsTocEmpty] = React.useState<boolean>(true)
+
+  // get the link id if available to scroll to the correct position
+  useEffect(() => {
+    if (!isTocEmpty) {
+      const linkId = window.location.hash.replace('#', '')
+      if (linkId) {
+        router.push(`/wiki/${slug}#${linkId}`)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isTocEmpty])
 
   // here toc is not state variable since there seems to be some issue
   // with in react-markdown that is causing infinite loop if toc is state variable

--- a/src/pages/wiki/[slug].tsx
+++ b/src/pages/wiki/[slug].tsx
@@ -51,11 +51,14 @@ const Wiki = () => {
   }: React.PropsWithChildren<HeadingProps>) => {
     const level = Number(props.node.tagName.match(/h(\d)/)?.slice(1))
     if (level && children && typeof children[0] === 'string') {
-      const id = `${children[0]
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')}-${Math.random()
-        .toString(36)
-        .substring(2, 5)}`
+      // id for each heading to be used in table of contents
+      const id = `${children[0].toLowerCase().replace(/[^a-z0-9]+/g, '-')}-${
+        toc.length
+      }`
+
+      // TODO: Find out why this is happening
+      // if the last item in toc is same as current item, remove the last item
+      // to avoid duplicate items
       if (toc[toc.length - 1]?.title === children[0]) {
         toc.pop()
       }


### PR DESCRIPTION
Fixes https://github.com/EveripediaNetwork/issues/issues/252

# Links

**Page**
https://monopedia-ui-git-toc-improvements-prediqt.vercel.app/wiki/long-sample-wiki

**Few TOC Links**
https://monopedia-ui-git-toc-improvements-prediqt.vercel.app/wiki/long-sample-wiki#vivamus-vulputate-5
https://monopedia-ui-git-toc-improvements-prediqt.vercel.app/wiki/long-sample-wiki#vivamus-vulputate-12
https://monopedia-ui-git-toc-improvements-prediqt.vercel.app/wiki/long-sample-wiki#tristique-tincidunt--22

# Changes
1. Made heading ids fixed all the time instead of using random
2. Made the wiki page navigate to a heading if there is a link id in the url
3. fixed intersection observer useEffect dependency to re-initiate the observer when toc changes