### PR TITLE
Implements infinite scroll

### DIFF
--- a/src/components/Profile/Collected.tsx
+++ b/src/components/Profile/Collected.tsx
@@ -1,43 +1,80 @@
+import useInfiniteScroll from 'react-infinite-scroll-hook'
 import { FilterLayout } from '@/components/Profile/FilterLayout'
 import { useProfileContext } from '@/components/Profile/utils'
-import { useGetUserWikisQuery } from '@/services/wikis'
-import { Center, SimpleGrid } from '@chakra-ui/react'
-import React from 'react'
-import { skipToken } from '@reduxjs/toolkit/query'
+import { getUserWikis} from '@/services/wikis'
+import { Center, SimpleGrid, Text, Spinner } from '@chakra-ui/react'
+import React, {useState, useEffect} from 'react'
 import { useRouter } from 'next/router'
 import { EmptyState } from '@/components/Profile/EmptyState'
 import WikiPreviewCard from '../Wiki/WikiPreviewCard/WikiPreviewCard'
+import { Wiki } from '@/types/Wiki'
+import { FETCH_DELAY_TIME, ITEM_PER_PAGE } from '@/data/Constants'
+import { store } from '@/store/store'
+
 
 export const Collected = () => {
   const { displaySize } = useProfileContext()
   const router = useRouter()
-  const { profile: address } = router.query
+  const address = router.query.profile as string
+  const [hasMore, setHasMore] = useState<boolean>(true)
+  const [wikis, setWikis] = useState<Wiki[] | []>([])
+  const [offset, setOffset] = useState<number>(0)
+  const [loading, setLoading] = useState<boolean>(true)
 
-  const result = useGetUserWikisQuery(
-    typeof address === 'string' ? address : skipToken,
-    {
-      skip: router.isFallback,
-    },
-  )
-  const { isLoading, data } = result
+  const fetchMoreWikis = () => {
+    const updatedOffset = offset + ITEM_PER_PAGE
+    setTimeout(() => {
+      const fetchNewWikis = async () => {
+        const result = await store.dispatch(
+          getUserWikis.initiate({ id: address, limit: ITEM_PER_PAGE, offset: updatedOffset }),
+        )
+        if (result.data && result.data?.length > 0) {
+          const data = result.data || []
+          const updatedWiki = [...wikis, ...data]
+          setWikis(updatedWiki)
+          setOffset(updatedOffset)
+          setLoading(false)
+        } else {
+          setHasMore(false)
+          setLoading(false)
+        }
+      }
+      fetchNewWikis()
+   }, FETCH_DELAY_TIME)
+  }
+
+  useEffect(()=> {
+    if(address){
+      fetchMoreWikis()
+    }
+  }, [address])
+
+  const [sentryRef] = useInfiniteScroll({
+    loading,
+    hasNextPage: hasMore,
+    onLoadMore: fetchMoreWikis,
+  })
 
   return (
     <FilterLayout>
-      {isLoading ? (
-        <Center>Loading Wikis</Center>
-      ) : (
-        <>
-          {!data?.length && (
-            <Center>
-              <EmptyState />
-            </Center>
-          )}
-          <SimpleGrid minChildWidth={displaySize} w="full" spacing="4">
-            {data?.map((item, i) => (
-              <WikiPreviewCard wiki={item} key={i} />
-            ))}
-          </SimpleGrid>
-        </>
+      {(wikis.length < 1 && !hasMore) && (
+        <Center>
+          <EmptyState />
+        </Center>
+      )}
+      <SimpleGrid ref={sentryRef}  minChildWidth={displaySize} w="full" spacing="4">
+        {wikis.map((item, i) => (
+          <WikiPreviewCard wiki={item} key={i} />
+        ))}
+      </SimpleGrid>
+      { (loading||hasMore) ? (
+          <Center ref={sentryRef}  w="full" h="16">
+            <Spinner size="xl" />
+          </Center>) 
+          : (
+          <Center mt="10">
+            <Text fontWeight="semibold">Yay! You have seen it all 🥳 </Text>
+          </Center>
       )}
     </FilterLayout>
   )

--- a/src/components/Profile/Collected.tsx
+++ b/src/components/Profile/Collected.tsx
@@ -1,16 +1,15 @@
 import useInfiniteScroll from 'react-infinite-scroll-hook'
 import { FilterLayout } from '@/components/Profile/FilterLayout'
 import { useProfileContext } from '@/components/Profile/utils'
-import { getUserWikis} from '@/services/wikis'
+import { getUserWikis } from '@/services/wikis'
 import { Center, SimpleGrid, Text, Spinner } from '@chakra-ui/react'
-import React, {useState, useEffect} from 'react'
+import React, { useState, useEffect } from 'react'
 import { useRouter } from 'next/router'
 import { EmptyState } from '@/components/Profile/EmptyState'
-import WikiPreviewCard from '../Wiki/WikiPreviewCard/WikiPreviewCard'
 import { Wiki } from '@/types/Wiki'
 import { FETCH_DELAY_TIME, ITEM_PER_PAGE } from '@/data/Constants'
 import { store } from '@/store/store'
-
+import WikiPreviewCard from '../Wiki/WikiPreviewCard/WikiPreviewCard'
 
 export const Collected = () => {
   const { displaySize } = useProfileContext()
@@ -26,7 +25,11 @@ export const Collected = () => {
     setTimeout(() => {
       const fetchNewWikis = async () => {
         const result = await store.dispatch(
-          getUserWikis.initiate({ id: address, limit: ITEM_PER_PAGE, offset: updatedOffset }),
+          getUserWikis.initiate({
+            id: address,
+            limit: ITEM_PER_PAGE,
+            offset: updatedOffset,
+          }),
         )
         if (result.data && result.data?.length > 0) {
           const data = result.data || []
@@ -40,11 +43,11 @@ export const Collected = () => {
         }
       }
       fetchNewWikis()
-   }, FETCH_DELAY_TIME)
+    }, FETCH_DELAY_TIME)
   }
 
-  useEffect(()=> {
-    if(address){
+  useEffect(() => {
+    if (address) {
       fetchMoreWikis()
     }
   }, [address])
@@ -57,24 +60,29 @@ export const Collected = () => {
 
   return (
     <FilterLayout>
-      {(wikis.length < 1 && !hasMore) && (
+      {wikis.length < 1 && !hasMore && (
         <Center>
           <EmptyState />
         </Center>
       )}
-      <SimpleGrid ref={sentryRef}  minChildWidth={displaySize} w="full" spacing="4">
+      <SimpleGrid
+        ref={sentryRef}
+        minChildWidth={displaySize}
+        w="full"
+        spacing="4"
+      >
         {wikis.map((item, i) => (
           <WikiPreviewCard wiki={item} key={i} />
         ))}
       </SimpleGrid>
-      { (loading||hasMore) ? (
-          <Center ref={sentryRef}  w="full" h="16">
-            <Spinner size="xl" />
-          </Center>) 
-          : (
-          <Center mt="10">
-            <Text fontWeight="semibold">Yay! You have seen it all 🥳 </Text>
-          </Center>
+      {loading || hasMore ? (
+        <Center ref={sentryRef} w="full" h="16">
+          <Spinner size="xl" />
+        </Center>
+      ) : (
+        <Center mt="10">
+          <Text fontWeight="semibold">Yay! You have seen it all 🥳 </Text>
+        </Center>
       )}
     </FilterLayout>
   )

--- a/src/components/Wiki/WikiPage/InsightComponents/RelatedWikis.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/RelatedWikis.tsx
@@ -59,14 +59,16 @@ export const RelatedWikis = ({
   const [wikis, setWikis] = React.useState<Wiki[] | []>([])
   useEffect(() => {
     categories?.forEach(category => {
-      store.dispatch(getWikisByCategory.initiate({category:category.id})).then(res => {
-        setWikis(prev => [
-          ...prev,
-          ...(res?.data?.filter(wiki => {
-            return !prev.some(w => w.id === wiki.id)
-          }) || []),
-        ])
-      })
+      store
+        .dispatch(getWikisByCategory.initiate({ category: category.id }))
+        .then(res => {
+          setWikis(prev => [
+            ...prev,
+            ...(res?.data?.filter(wiki => {
+              return !prev.some(w => w.id === wiki.id)
+            }) || []),
+          ])
+        })
     })
   }, [categories])
   return (

--- a/src/components/Wiki/WikiPage/InsightComponents/RelatedWikis.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/RelatedWikis.tsx
@@ -59,7 +59,7 @@ export const RelatedWikis = ({
   const [wikis, setWikis] = React.useState<Wiki[] | []>([])
   useEffect(() => {
     categories?.forEach(category => {
-      store.dispatch(getWikisByCategory.initiate(category.id)).then(res => {
+      store.dispatch(getWikisByCategory.initiate({category:category.id})).then(res => {
         setWikis(prev => [
           ...prev,
           ...(res?.data?.filter(wiki => {

--- a/src/pages/categories/[category].tsx
+++ b/src/pages/categories/[category].tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useState, useEffect} from 'react'
 import { NextPage, GetServerSideProps } from 'next'
 import {
   Divider,
@@ -8,8 +8,9 @@ import {
   Icon,
   Flex,
   Text,
-  Button,
+  Button, Center, Spinner
 } from '@chakra-ui/react'
+import useInfiniteScroll from 'react-infinite-scroll-hook'
 import { Image } from '@/components/Elements/Image/Image'
 import ToggleText from '@/components/Elements/ToggleText/ToggleText'
 import {
@@ -23,17 +24,59 @@ import WikiPreviewCard from '@/components/Wiki/WikiPreviewCard/WikiPreviewCard'
 import { getWikisByCategory } from '@/services/wikis'
 import { Wiki } from '@/types/Wiki'
 import { useRouter } from 'next/router'
+import { FETCH_DELAY_TIME, ITEM_PER_PAGE } from '@/data/Constants'
 
-interface CategoryPageProps {
+type CategoryPageProps = NextPage & {
   categoryData: Category
   wikis: Wiki[]
-}
-const CategoryPage: NextPage<CategoryPageProps> = ({
-  categoryData,
-  wikis,
-}: CategoryPageProps) => {
+}  
+
+const CategoryPage = ({ categoryData, wikis }: CategoryPageProps) => {
   const categoryIcon = getBootStrapIcon(categoryData.icon)
+  const [wikisInCategory, setWikisInCategory] = useState<Wiki[]|[]>([])
   const router = useRouter()
+  const category = router.query.category as string
+  const [hasMore, setHasMore] = useState<boolean>(true)
+  const [offset, setOffset] = useState<number>(0)
+  const [loading, setLoading] = useState<boolean>(false)
+
+  useEffect(()=> {
+    setHasMore(true)
+    setOffset(0)
+    setWikisInCategory(wikis)
+  }, [category])
+
+  const fetchMoreWikis = () => {
+    const updatedOffset = offset + ITEM_PER_PAGE
+    setTimeout(() => {
+      const fetchNewWikis = async () => {
+        const result = await store.dispatch(
+          getWikisByCategory.initiate({
+            category,
+            limit: ITEM_PER_PAGE,
+            offset: updatedOffset,
+          }),
+        )
+        if (result.data && result.data?.length > 0) {
+          const data = result.data
+          const updatedWiki = [...wikisInCategory, ...data]
+          setWikisInCategory(updatedWiki)
+          setOffset(updatedOffset)
+        } else {
+          setHasMore(false)
+          setLoading(false)
+        }
+      }
+      fetchNewWikis()
+    }, FETCH_DELAY_TIME)
+  }
+
+  const [sentryRef] = useInfiniteScroll({
+    loading,
+    hasNextPage: hasMore,
+    onLoadMore: fetchMoreWikis,
+  })
+
   return (
     <Box mt="-3" bgColor="pageBg" pb={12}>
       <Image
@@ -64,20 +107,31 @@ const CategoryPage: NextPage<CategoryPageProps> = ({
         <Heading fontSize={25} textAlign="center">
           Wikis in this category
         </Heading>
-        {wikis.length > 0 ? (
-          <SimpleGrid
-            columns={{ base: 1, sm: 2, lg: 3 }}
-            width="min(90%, 1200px)"
-            mx="auto"
-            my={12}
-            gap={8}
-          >
-            {wikis.map((wiki, i) => (
-              <Box key={i} w="100%">
-                <WikiPreviewCard wiki={wiki} />
-              </Box>
-            ))}
-          </SimpleGrid>
+        {wikisInCategory.length > 0 ? (
+          <>
+            <SimpleGrid
+              columns={{ base: 1, sm: 2, lg: 3 }}
+              width="min(90%, 1200px)"
+              mx="auto"
+              my={12}
+              gap={8}
+            >
+              {wikisInCategory.map((wiki, i) => (
+                <Box key={i} w="100%">
+                  <WikiPreviewCard wiki={wiki} />
+                </Box>
+              ))}
+            </SimpleGrid>
+            {loading || hasMore ? (
+              <Center ref={sentryRef} mt="10" w="full" h="16">
+                <Spinner size="xl" />
+              </Center>
+            ) : (
+              <Center mt="10">
+                <Text fontWeight="semibold">Yay! You have seen it all 🥳 </Text>
+              </Center>
+            )}
+          </>
         ) : (
           <Box textAlign="center" py={10} px={6}>
             <Text fontSize="lg" mt={3} mb={3}>
@@ -102,7 +156,11 @@ export const getServerSideProps: GetServerSideProps = async context => {
   const categoryId: string = context.params?.category as string
   const result = await store.dispatch(getCategoriesById.initiate(categoryId))
   const wikisByCategory = await store.dispatch(
-    getWikisByCategory.initiate(categoryId),
+    getWikisByCategory.initiate({
+      category: categoryId,
+      limit: ITEM_PER_PAGE,
+      offset: 0,
+    }),
   )
   await Promise.all(getRunningOperationPromises())
   return {
@@ -112,4 +170,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
     },
   }
 }
+
+CategoryPage.noFooter = true
+
 export default CategoryPage

--- a/src/pages/categories/[category].tsx
+++ b/src/pages/categories/[category].tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react'
+import React, { useState, useEffect } from 'react'
 import { NextPage, GetServerSideProps } from 'next'
 import {
   Divider,
@@ -8,7 +8,9 @@ import {
   Icon,
   Flex,
   Text,
-  Button, Center, Spinner
+  Button,
+  Center,
+  Spinner,
 } from '@chakra-ui/react'
 import useInfiniteScroll from 'react-infinite-scroll-hook'
 import { Image } from '@/components/Elements/Image/Image'
@@ -29,18 +31,18 @@ import { FETCH_DELAY_TIME, ITEM_PER_PAGE } from '@/data/Constants'
 type CategoryPageProps = NextPage & {
   categoryData: Category
   wikis: Wiki[]
-}  
+}
 
 const CategoryPage = ({ categoryData, wikis }: CategoryPageProps) => {
   const categoryIcon = getBootStrapIcon(categoryData.icon)
-  const [wikisInCategory, setWikisInCategory] = useState<Wiki[]|[]>([])
+  const [wikisInCategory, setWikisInCategory] = useState<Wiki[] | []>([])
   const router = useRouter()
   const category = router.query.category as string
   const [hasMore, setHasMore] = useState<boolean>(true)
   const [offset, setOffset] = useState<number>(0)
   const [loading, setLoading] = useState<boolean>(false)
 
-  useEffect(()=> {
+  useEffect(() => {
     setHasMore(true)
     setOffset(0)
     setWikisInCategory(wikis)
@@ -58,7 +60,7 @@ const CategoryPage = ({ categoryData, wikis }: CategoryPageProps) => {
           }),
         )
         if (result.data && result.data?.length > 0) {
-          const data = result.data
+          const { data } = result
           const updatedWiki = [...wikisInCategory, ...data]
           setWikisInCategory(updatedWiki)
           setOffset(updatedOffset)

--- a/src/pages/wiki/[slug].tsx
+++ b/src/pages/wiki/[slug].tsx
@@ -173,7 +173,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
   if (typeof slug === 'string') {
     store.dispatch(getWiki.initiate(slug)).then(res => {
       res?.data?.categories.map(category =>
-        getWikisByCategory.initiate(category.id),
+        getWikisByCategory.initiate({category: category.id}),
       )
     })
   }

--- a/src/pages/wiki/[slug].tsx
+++ b/src/pages/wiki/[slug].tsx
@@ -173,7 +173,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
   if (typeof slug === 'string') {
     store.dispatch(getWiki.initiate(slug)).then(res => {
       res?.data?.categories.map(category =>
-        getWikisByCategory.initiate({category: category.id}),
+        getWikisByCategory.initiate({ category: category.id }),
       )
     })
   }

--- a/src/services/wikis/index.ts
+++ b/src/services/wikis/index.ts
@@ -51,6 +51,12 @@ type UserWikiArg = {
   offset?: number
 }
 
+type WikisByCategoryArg = {
+  category: string
+  limit?: number
+  offset?: number
+}
+
 export const wikiApi = createApi({
   reducerPath: 'wikiApi',
   extractRehydrationInfo(action, { reducerPath }) {
@@ -101,10 +107,18 @@ export const wikiApi = createApi({
       transformResponse: (response: GetUserWikiResponse) =>
         response.userById.wikis,
     }),
-    getWikisByCategory: builder.query<Wiki[], string>({
-      query: (category: string) => ({
+    getWikisByCategory: builder.query<Wiki[], WikisByCategoryArg>({
+      query: ({
+        category,
+        limit,
+        offset,
+      }: {
+        category: string
+        limit?: number
+        offset?: number
+      }) => ({
         document: GET_WIKIS_BY_CATEGORY,
-        variables: { category },
+        variables: { category, limit, offset },
       }),
       transformResponse: (response: GetWikisByCategoryResponse) =>
         response.wikisByCategory,

--- a/src/services/wikis/index.ts
+++ b/src/services/wikis/index.ts
@@ -45,6 +45,12 @@ type PostWikiResponse = {
   }
 }
 
+type UserWikiArg = {
+  id: string
+  limit?: number
+  offset?: number
+}
+
 export const wikiApi = createApi({
   reducerPath: 'wikiApi',
   extractRehydrationInfo(action, { reducerPath }) {
@@ -77,11 +83,21 @@ export const wikiApi = createApi({
       query: (id: string) => ({ document: GET_WIKI_BY_ID, variables: { id } }),
       transformResponse: (response: GetWikiResponse) => response.wiki,
     }),
-    getUserWikis: builder.query<Wiki[], string>({
-      query: (id: string) => ({
-        document: GET_USER_WIKIS_BY_ID,
-        variables: { id },
-      }),
+    getUserWikis: builder.query<Wiki[], UserWikiArg>({
+      query: ({
+        id,
+        limit,
+        offset,
+      }: {
+        id: string
+        limit: number
+        offset: number
+      }) => {
+        return {
+          document: GET_USER_WIKIS_BY_ID,
+          variables: { id, limit, offset },
+        }
+      },
       transformResponse: (response: GetUserWikiResponse) =>
         response.userById.wikis,
     }),

--- a/src/services/wikis/queries.ts
+++ b/src/services/wikis/queries.ts
@@ -144,8 +144,8 @@ export const GET_USER_WIKIS_BY_ID = gql`
 `
 
 export const GET_WIKIS_BY_CATEGORY = gql`
-  query GetUserWikisByCategory($category: String!) {
-    wikisByCategory(category: $category) {
+  query GetUserWikisByCategory($category: String!, $offset: Int, $limit: Int) {
+    wikisByCategory(category: $category, offset: $offset, limit: $limit) {
       id
       ipfs
       content

--- a/src/services/wikis/queries.ts
+++ b/src/services/wikis/queries.ts
@@ -110,9 +110,9 @@ export const GET_PROMOTED_WIKIS = gql`
 `
 
 export const GET_USER_WIKIS_BY_ID = gql`
-  query GetUserWikis($id: String!) {
+  query GetUserWikis($id: String!, $limit: Int, $offset: Int) {
     userById(id: $id) {
-      wikis {
+      wikis(offset: $offset, limit: $limit) {
         id
         ipfs
         title


### PR DESCRIPTION
#Infinite scroll feature implementation

_ Implementation of infinite scroll feature on user profile and wikis by category page. The feature allows fetching chunks of wikis on page scroll.

## How should this be tested?

1. Navigate to the user profile or categories page (https://monopedia-ui-git-implements-infinite-scroll-prediqt.vercel.app/categories/events) .
2. scroll down on the page  to fetch more wikis

![image](https://user-images.githubusercontent.com/70170061/163949783-225cce6b-57e0-4491-9cfb-4004cc049e6a.png)

![image](https://user-images.githubusercontent.com/70170061/163949936-200283e2-f6a9-445b-a467-177dca098de7.png)

## Linked issues

fixes https://github.com/EveripediaNetwork/issues/issues/175
