### PR TITLE
Infinite scroll on tags page

### DIFF
--- a/src/pages/tags/[tag].tsx
+++ b/src/pages/tags/[tag].tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react'
+import React, { useState, useEffect } from 'react'
 import { NextPage, GetServerSideProps } from 'next'
 import {
   Divider,
@@ -6,7 +6,9 @@ import {
   Heading,
   SimpleGrid,
   Text,
-  Button,Center, Spinner
+  Button,
+  Center,
+  Spinner,
 } from '@chakra-ui/react'
 import useInfiniteScroll from 'react-infinite-scroll-hook'
 import { getRunningOperationPromises } from '@/services/categories'
@@ -28,7 +30,7 @@ const TagPage: NextPage<TagPageProps> = ({ tagId, wikis }: TagPageProps) => {
   const [hasMore, setHasMore] = useState<boolean>(true)
   const [offset, setOffset] = useState<number>(0)
   const [loading, setLoading] = useState<boolean>(false)
-  
+
   useEffect(() => {
     setHasMore(true)
     setOffset(0)

--- a/src/pages/tags/[tag].tsx
+++ b/src/pages/tags/[tag].tsx
@@ -14,6 +14,7 @@ import WikiPreviewCard from '@/components/Wiki/WikiPreviewCard/WikiPreviewCard'
 import { getTagWikis } from '@/services/wikis'
 import { Wiki } from '@/types/Wiki'
 import { useRouter } from 'next/router'
+import { ITEM_PER_PAGE } from '@/data/Constants'
 
 interface TagPageProps {
   tagId: string
@@ -68,7 +69,7 @@ const TagPage: NextPage<TagPageProps> = ({ tagId, wikis }: TagPageProps) => {
 
 export const getServerSideProps: GetServerSideProps = async context => {
   const tagId: string = context.params?.tag as string
-  const tagWikis = await store.dispatch(getTagWikis.initiate(tagId))
+  const tagWikis = await store.dispatch(getTagWikis.initiate({id:tagId, offset: 0, limit: ITEM_PER_PAGE}))
 
   await Promise.all(getRunningOperationPromises())
   return {

--- a/src/pages/tags/[tag].tsx
+++ b/src/pages/tags/[tag].tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useState, useEffect} from 'react'
 import { NextPage, GetServerSideProps } from 'next'
 import {
   Divider,
@@ -6,22 +6,66 @@ import {
   Heading,
   SimpleGrid,
   Text,
-  Button,
+  Button,Center, Spinner
 } from '@chakra-ui/react'
+import useInfiniteScroll from 'react-infinite-scroll-hook'
 import { getRunningOperationPromises } from '@/services/categories'
 import { store } from '@/store/store'
 import WikiPreviewCard from '@/components/Wiki/WikiPreviewCard/WikiPreviewCard'
 import { getTagWikis } from '@/services/wikis'
 import { Wiki } from '@/types/Wiki'
 import { useRouter } from 'next/router'
-import { ITEM_PER_PAGE } from '@/data/Constants'
+import { ITEM_PER_PAGE, FETCH_DELAY_TIME } from '@/data/Constants'
 
 interface TagPageProps {
   tagId: string
   wikis: Wiki[]
 }
 const TagPage: NextPage<TagPageProps> = ({ tagId, wikis }: TagPageProps) => {
+  const [wikisByTag, setWikisByTag] = useState<Wiki[] | []>([])
   const router = useRouter()
+  const tag = router.query.tag as string
+  const [hasMore, setHasMore] = useState<boolean>(true)
+  const [offset, setOffset] = useState<number>(0)
+  const [loading, setLoading] = useState<boolean>(false)
+  
+  useEffect(() => {
+    setHasMore(true)
+    setOffset(0)
+    setWikisByTag(wikis)
+  }, [tag])
+
+  const fetchMoreWikis = () => {
+    const updatedOffset = offset + ITEM_PER_PAGE
+    setTimeout(() => {
+      const fetchNewWikis = async () => {
+        const result = await store.dispatch(
+          getTagWikis.initiate({
+            id: tag,
+            limit: ITEM_PER_PAGE,
+            offset: updatedOffset,
+          }),
+        )
+        if (result.data && result.data?.length > 0) {
+          const { data } = result
+          const updatedWiki = [...wikisByTag, ...data]
+          setWikisByTag(updatedWiki)
+          setOffset(updatedOffset)
+        } else {
+          setHasMore(false)
+          setLoading(false)
+        }
+      }
+      fetchNewWikis()
+    }, FETCH_DELAY_TIME)
+  }
+
+  const [sentryRef] = useInfiniteScroll({
+    loading,
+    hasNextPage: hasMore,
+    onLoadMore: fetchMoreWikis,
+  })
+
   return (
     <Box bgColor="pageBg" border="solid 1px transparent" pb={12}>
       <Heading fontSize={40} textAlign="center" mt={4}>
@@ -34,19 +78,30 @@ const TagPage: NextPage<TagPageProps> = ({ tagId, wikis }: TagPageProps) => {
           Wikis with this tag
         </Heading>
         {wikis.length > 0 ? (
-          <SimpleGrid
-            columns={{ base: 1, sm: 2, lg: 3 }}
-            width="min(90%, 1200px)"
-            mx="auto"
-            my={12}
-            gap={8}
-          >
-            {wikis.map((wiki, i) => (
-              <Box key={i} w="100%">
-                <WikiPreviewCard wiki={wiki} />
-              </Box>
-            ))}
-          </SimpleGrid>
+          <>
+            <SimpleGrid
+              columns={{ base: 1, sm: 2, lg: 3 }}
+              width="min(90%, 1200px)"
+              mx="auto"
+              my={12}
+              gap={8}
+            >
+              {wikisByTag.map((wiki, i) => (
+                <Box key={i} w="100%">
+                  <WikiPreviewCard wiki={wiki} />
+                </Box>
+              ))}
+            </SimpleGrid>
+            {loading || hasMore ? (
+              <Center ref={sentryRef} mt="10" w="full" h="16">
+                <Spinner size="xl" />
+              </Center>
+            ) : (
+              <Center mt="10">
+                <Text fontWeight="semibold">Yay! You have seen it all 🥳 </Text>
+              </Center>
+            )}
+          </>
         ) : (
           <Box textAlign="center" py={10} px={6}>
             <Text fontSize="lg" mt={3} mb={3}>
@@ -69,7 +124,9 @@ const TagPage: NextPage<TagPageProps> = ({ tagId, wikis }: TagPageProps) => {
 
 export const getServerSideProps: GetServerSideProps = async context => {
   const tagId: string = context.params?.tag as string
-  const tagWikis = await store.dispatch(getTagWikis.initiate({id:tagId, offset: 0, limit: ITEM_PER_PAGE}))
+  const tagWikis = await store.dispatch(
+    getTagWikis.initiate({ id: tagId, offset: 0, limit: ITEM_PER_PAGE }),
+  )
 
   await Promise.all(getRunningOperationPromises())
   return {

--- a/src/services/wikis/index.ts
+++ b/src/services/wikis/index.ts
@@ -62,6 +62,12 @@ type WikisByCategoryArg = {
   offset?: number
 }
 
+type WikisByTagArg = {
+  id: string
+  limit?: number
+  offset?: number
+}
+
 export const wikiApi = createApi({
   reducerPath: 'wikiApi',
   extractRehydrationInfo(action, { reducerPath }) {
@@ -112,10 +118,10 @@ export const wikiApi = createApi({
       transformResponse: (response: GetUserWikiResponse) =>
         response.userById.wikis,
     }),
-    getTagWikis: builder.query<Wiki[], string>({
-      query: (id: string) => ({
+    getTagWikis: builder.query<Wiki[], WikisByTagArg>({
+      query: ({id, limit, offset}: {id: string, limit?:number, offset?:number}) => ({
         document: GET_TAG_WIKIS_BY_ID,
-        variables: { id },
+        variables: { id, limit, offset },
       }),
       transformResponse: (response: GetWikisByTagResponse) =>
         response.tagById.wikis,

--- a/src/services/wikis/index.ts
+++ b/src/services/wikis/index.ts
@@ -119,7 +119,15 @@ export const wikiApi = createApi({
         response.userById.wikis,
     }),
     getTagWikis: builder.query<Wiki[], WikisByTagArg>({
-      query: ({id, limit, offset}: {id: string, limit?:number, offset?:number}) => ({
+      query: ({
+        id,
+        limit,
+        offset,
+      }: {
+        id: string
+        limit?: number
+        offset?: number
+      }) => ({
         document: GET_TAG_WIKIS_BY_ID,
         variables: { id, limit, offset },
       }),

--- a/src/services/wikis/index.ts
+++ b/src/services/wikis/index.ts
@@ -50,7 +50,7 @@ type PostWikiResponse = {
   }
 }
 
-type UserWikiArg = {
+type WikiArg = {
   id: string
   limit?: number
   offset?: number
@@ -58,12 +58,6 @@ type UserWikiArg = {
 
 type WikisByCategoryArg = {
   category: string
-  limit?: number
-  offset?: number
-}
-
-type WikisByTagArg = {
-  id: string
   limit?: number
   offset?: number
 }
@@ -100,16 +94,12 @@ export const wikiApi = createApi({
       query: (id: string) => ({ document: GET_WIKI_BY_ID, variables: { id } }),
       transformResponse: (response: GetWikiResponse) => response.wiki,
     }),
-    getUserWikis: builder.query<Wiki[], UserWikiArg>({
+    getUserWikis: builder.query<Wiki[], WikiArg>({
       query: ({
         id,
         limit,
         offset,
-      }: {
-        id: string
-        limit: number
-        offset: number
-      }) => {
+      }: WikiArg) => {
         return {
           document: GET_USER_WIKIS_BY_ID,
           variables: { id, limit, offset },
@@ -118,16 +108,12 @@ export const wikiApi = createApi({
       transformResponse: (response: GetUserWikiResponse) =>
         response.userById.wikis,
     }),
-    getTagWikis: builder.query<Wiki[], WikisByTagArg>({
+    getTagWikis: builder.query<Wiki[], WikiArg>({
       query: ({
         id,
         limit,
         offset,
-      }: {
-        id: string
-        limit?: number
-        offset?: number
-      }) => ({
+      }: WikiArg) => ({
         document: GET_TAG_WIKIS_BY_ID,
         variables: { id, limit, offset },
       }),

--- a/src/services/wikis/index.ts
+++ b/src/services/wikis/index.ts
@@ -95,11 +95,7 @@ export const wikiApi = createApi({
       transformResponse: (response: GetWikiResponse) => response.wiki,
     }),
     getUserWikis: builder.query<Wiki[], WikiArg>({
-      query: ({
-        id,
-        limit,
-        offset,
-      }: WikiArg) => {
+      query: ({ id, limit, offset }: WikiArg) => {
         return {
           document: GET_USER_WIKIS_BY_ID,
           variables: { id, limit, offset },
@@ -109,11 +105,7 @@ export const wikiApi = createApi({
         response.userById.wikis,
     }),
     getTagWikis: builder.query<Wiki[], WikiArg>({
-      query: ({
-        id,
-        limit,
-        offset,
-      }: WikiArg) => ({
+      query: ({ id, limit, offset }: WikiArg) => ({
         document: GET_TAG_WIKIS_BY_ID,
         variables: { id, limit, offset },
       }),

--- a/src/services/wikis/queries.ts
+++ b/src/services/wikis/queries.ts
@@ -175,9 +175,9 @@ export const GET_WIKIS_BY_CATEGORY = gql`
 `
 
 export const GET_TAG_WIKIS_BY_ID = gql`
-  query GetTagWikis($id: String!) {
+  query GetTagWikis($id: String!, $limit: Int, $offset: Int) {
     tagById(id: $id) {
-      wikis {
+      wikis(offset: $offset, limit: $limit) {
         id
         ipfs
         content

--- a/src/services/wikis/queries.ts
+++ b/src/services/wikis/queries.ts
@@ -182,6 +182,7 @@ export const GET_TAG_WIKIS_BY_ID = gql`
         ipfs
         content
         created
+        updated
         title
         summary
         content


### PR DESCRIPTION
# Implementation of Infinite scroll on tag's page

_Instead of fetching wikis that have a particular tag at once, we could fetch them in chunks as the user scrolls down the page. By so doing, the performance of the page is much improved.

## How should this be tested?

1. Navigate to https://alpha.everipedia.org/tags/hello
2. scroll down on the page, wikis with the tag "hello" are fetched in chunks as you scroll down 

![image](https://user-images.githubusercontent.com/70170061/164147674-96f0d6f5-014d-4875-8ff5-bbe479d68938.png)

## Linked issues

fixes https://github.com/EveripediaNetwork/issues/issues/260