### PR TITLE
Fix no wiki on profile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ NEXT_PUBLIC_ALCHEMY_API_KEY=key key key key
 NEXT_PUBLIC_EP_API=https://api.dev.braindao.org/
 NEXT_PUBLIC_ENS_RPC=https://eth-mainnet.alchemyapi.io/v2/xxx
 NEXT_PUBLIC_ALCHEMY_CHAIN=maticmum
+NEXT_PUBLIC_GOOGLE_ANALYTICS=

--- a/src/components/Profile/Collected.tsx
+++ b/src/components/Profile/Collected.tsx
@@ -11,7 +11,7 @@ import { FETCH_DELAY_TIME, ITEM_PER_PAGE } from '@/data/Constants'
 import { store } from '@/store/store'
 import WikiPreviewCard from '../Wiki/WikiPreviewCard/WikiPreviewCard'
 
-export const Collected = () => {
+const Collected = () => {
   const { displaySize } = useProfileContext()
   const router = useRouter()
   const address = router.query.profile as string
@@ -19,23 +19,21 @@ export const Collected = () => {
   const [wikis, setWikis] = useState<Wiki[] | []>([])
   const [offset, setOffset] = useState<number>(0)
   const [loading, setLoading] = useState<boolean>(true)
-
-  const fetchMoreWikis = () => {
-    const updatedOffset = offset + ITEM_PER_PAGE
+  const fetchMoreWikis = (fetchOffset: number) => {
     setTimeout(() => {
       const fetchNewWikis = async () => {
         const result = await store.dispatch(
           getUserWikis.initiate({
             id: address,
             limit: ITEM_PER_PAGE,
-            offset: updatedOffset,
+            offset: fetchOffset,
           }),
         )
         if (result.data && result.data?.length > 0) {
           const data = result.data || []
           const updatedWiki = [...wikis, ...data]
           setWikis(updatedWiki)
-          setOffset(updatedOffset)
+          setOffset(fetchOffset)
           setLoading(false)
         } else {
           setHasMore(false)
@@ -48,14 +46,14 @@ export const Collected = () => {
 
   useEffect(() => {
     if (address) {
-      fetchMoreWikis()
+      fetchMoreWikis(offset)
     }
   }, [address])
 
   const [sentryRef] = useInfiniteScroll({
     loading,
     hasNextPage: hasMore,
-    onLoadMore: fetchMoreWikis,
+    onLoadMore: () => fetchMoreWikis(offset + ITEM_PER_PAGE),
   })
 
   return (
@@ -87,3 +85,5 @@ export const Collected = () => {
     </FilterLayout>
   )
 }
+
+export default Collected

--- a/src/components/Profile/Collections.tsx
+++ b/src/components/Profile/Collections.tsx
@@ -1,4 +1,4 @@
-import { Collected } from '@/components/Profile/Collected'
+import Collected from '@/components/Profile/Collected'
 import { ChevronDownIcon } from '@chakra-ui/icons'
 import {
   Tabs,


### PR DESCRIPTION
# Fixes Profile wikis not showing

_wikis on profile are fetched in chunks giving the offset and fetch limit. some of the wikis are not shown because the offset starts from 12 instead of 0.

## How should this be tested?

1. Navigate to the profile page
2. try to scroll, wikis should be fetched in chunks and the offset should start from zero

![image](https://user-images.githubusercontent.com/70170061/165062387-e0eb3032-3059-46be-ad56-ac5d7f42a835.png)

## Linked issues
fixes https://github.com/EveripediaNetwork/issues/issues/278