### PR TITLE
Improve buttons on wiki process dialog box

### DIFF
--- a/src/components/Elements/Modal/WikiProcessModal.tsx
+++ b/src/components/Elements/Modal/WikiProcessModal.tsx
@@ -127,9 +127,7 @@ const WikiProcessModal = ({
                   }
                   variant="link"
                   fontWeight="semibold"
-                  size="xs"
-                  _hover={{ textDecoration: 'none' }}
-                  color="link"
+                  fontSize='xs'
                 >
                   View on Block Explorer
                 </Button>

--- a/src/components/Elements/Modal/WikiProcessModal.tsx
+++ b/src/components/Elements/Modal/WikiProcessModal.tsx
@@ -17,6 +17,7 @@ import { Step, Steps } from 'chakra-ui-steps'
 import config from '@/config'
 import { useRouter } from 'next/router'
 
+
 const steps = [
   { label: 'Signed Wiki' },
   { label: 'Sent to Relayer' },
@@ -47,7 +48,7 @@ const WikiProcessModal = ({
   const cancelRef = React.useRef<FocusableElement>(null)
   const router = useRouter()
   const handleBlockExplorer = () => {
-    if (activeStep === 3) {
+    if (activeStep === 3 && txHash) {
       window.open(`${config.blockExplorerUrl}tx/${txHash}`)
     }
   }
@@ -122,7 +123,7 @@ const WikiProcessModal = ({
                   fontSize="xs"
                   fontWeight="semibold"
                   variant="outline"
-                  disabled={!(activeStep === 3)}
+                  disabled={wikiHash ? false: true}
                 >
                   See on IPFS
                 </Button>

--- a/src/components/Elements/Modal/WikiProcessModal.tsx
+++ b/src/components/Elements/Modal/WikiProcessModal.tsx
@@ -130,7 +130,6 @@ const WikiProcessModal = ({
                   size="xs"
                   _hover={{ textDecoration: 'none' }}
                   color="link"
-
                 >
                   View on Block Explorer
                 </Button>

--- a/src/components/Elements/Modal/WikiProcessModal.tsx
+++ b/src/components/Elements/Modal/WikiProcessModal.tsx
@@ -114,13 +114,23 @@ const WikiProcessModal = ({
                   fontWeight="semibold"
                   variant="outline"
                   disabled={!wikiHash}
-                  onClick={()=> window.open(`${config.pinataBaseUrl}${wikiHash}`)}
+                  onClick={() =>
+                    window.open(`${config.pinataBaseUrl}${wikiHash}`)
+                  }
                 >
                   See on IPFS
                 </Button>
-                <Button disabled={(activeStep === 3 && txHash)? false: true} onClick={()=> window.open(`${config.blockExplorerUrl}tx/${txHash}`)
-  } variant='link' fontWeight="semibold" size='xs' _hover={{textDecoration: "none"}}>
-                    View on Block Explorer
+                <Button
+                  disabled={!(activeStep === 3 && txHash)}
+                  onClick={() =>
+                    window.open(`${config.blockExplorerUrl}tx/${txHash}`)
+                  }
+                  variant="link"
+                  fontWeight="semibold"
+                  size="xs"
+                  _hover={{ textDecoration: 'none' }}
+                >
+                  View on Block Explorer
                 </Button>
               </Stack>
             </Center>

--- a/src/components/Elements/Modal/WikiProcessModal.tsx
+++ b/src/components/Elements/Modal/WikiProcessModal.tsx
@@ -127,7 +127,7 @@ const WikiProcessModal = ({
                   }
                   variant="link"
                   fontWeight="semibold"
-                  fontSize='xs'
+                  fontSize="xs"
                 >
                   View on Block Explorer
                 </Button>

--- a/src/components/Elements/Modal/WikiProcessModal.tsx
+++ b/src/components/Elements/Modal/WikiProcessModal.tsx
@@ -17,7 +17,6 @@ import { Step, Steps } from 'chakra-ui-steps'
 import config from '@/config'
 import { useRouter } from 'next/router'
 
-
 const steps = [
   { label: 'Signed Wiki' },
   { label: 'Sent to Relayer' },
@@ -123,7 +122,7 @@ const WikiProcessModal = ({
                   fontSize="xs"
                   fontWeight="semibold"
                   variant="outline"
-                  disabled={wikiHash ? false: true}
+                  disabled={!wikiHash}
                 >
                   See on IPFS
                 </Button>

--- a/src/components/Elements/Modal/WikiProcessModal.tsx
+++ b/src/components/Elements/Modal/WikiProcessModal.tsx
@@ -129,6 +129,8 @@ const WikiProcessModal = ({
                   fontWeight="semibold"
                   size="xs"
                   _hover={{ textDecoration: 'none' }}
+                  color="link"
+
                 >
                   View on Block Explorer
                 </Button>

--- a/src/components/Elements/Modal/WikiProcessModal.tsx
+++ b/src/components/Elements/Modal/WikiProcessModal.tsx
@@ -46,11 +46,6 @@ const WikiProcessModal = ({
 }: WikiProcessType) => {
   const cancelRef = React.useRef<FocusableElement>(null)
   const router = useRouter()
-  const handleBlockExplorer = () => {
-    if (activeStep === 3 && txHash) {
-      window.open(`${config.blockExplorerUrl}tx/${txHash}`)
-    }
-  }
 
   return (
     <AlertDialog
@@ -115,26 +110,18 @@ const WikiProcessModal = ({
                   View Wiki
                 </Button>
                 <Button
-                  as="a"
-                  href={`${config.pinataBaseUrl}${wikiHash}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
                   fontSize="xs"
                   fontWeight="semibold"
                   variant="outline"
                   disabled={!wikiHash}
+                  onClick={()=> window.open(`${config.pinataBaseUrl}${wikiHash}`)}
                 >
                   See on IPFS
                 </Button>
-                <Text
-                  cursor="pointer"
-                  fontSize="xs"
-                  fontWeight="semibold"
-                  pt={2}
-                  onClick={handleBlockExplorer}
-                >
-                  View on Block Explorer
-                </Text>
+                <Button disabled={(activeStep === 3 && txHash)? false: true} onClick={()=> window.open(`${config.blockExplorerUrl}tx/${txHash}`)
+  } variant='link' fontWeight="semibold" size='xs' _hover={{textDecoration: "none"}}>
+                    View on Block Explorer
+                </Button>
               </Stack>
             </Center>
           </Flex>

--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -380,6 +380,7 @@ const CreateWiki = () => {
       const wikiResult: any = await store.dispatch(
         postWiki.initiate({ data: finalWiki }),
       )
+
       if (wikiResult) saveHashInTheBlockchain(String(wikiResult.data))
 
       // clear all edit based metadata from redux state
@@ -720,7 +721,6 @@ const CreateWiki = () => {
             </Center>
           </Skeleton>
         </Box>
-
         <WikiProcessModal
           wikiId={wikiId}
           msg={msg}

--- a/src/theme/components/Button.ts
+++ b/src/theme/components/Button.ts
@@ -37,7 +37,7 @@ export const Button = {
       px: 10,
     }),
     link: ({ colorMode }: ThemeProps) => ({
-      color: colorMode === 'dark' ? 'grey.200': 'gray.600',
+      color: colorMode === 'dark' ? 'grey.200' : 'gray.600',
       _hover: { textDecoration: 'none' },
     }),
   },

--- a/src/theme/components/Button.ts
+++ b/src/theme/components/Button.ts
@@ -36,5 +36,9 @@ export const Button = {
       },
       px: 10,
     }),
+    link: ({ colorMode }: ThemeProps) => ({
+      color: colorMode === 'dark' ? 'grey.200': 'gray.600',
+      _hover: { textDecoration: 'none' },
+    }),
   },
 }


### PR DESCRIPTION
# Improve buttons on the wiki process dialog box

_Once JSON is sent to our API button for view, IPFS should be active (once we get the Ipfs hash returned from API)
view on the blockchain should only be clickable when it's in the last step and we have TxId

## How should this be tested?

1. Navigate to the create-wiki page
2. Try to create a wiki
3. On the wiki process dialog box, the Ipfs button is active when the Ipfs hash is returned and the block explorer button is clickable when it's in the last step and we have TxId


## Linked issues
fixes https://github.com/EveripediaNetwork/issues/issues/274
