### PR TITLE
Allow account access using ens name

### DIFF
--- a/src/components/Profile/Collected.tsx
+++ b/src/components/Profile/Collected.tsx
@@ -19,6 +19,7 @@ const Collected = () => {
   const [wikis, setWikis] = useState<Wiki[] | []>([])
   const [offset, setOffset] = useState<number>(0)
   const [loading, setLoading] = useState<boolean>(true)
+
   const fetchMoreWikis = (fetchOffset: number) => {
     setTimeout(() => {
       const fetchNewWikis = async () => {

--- a/src/hooks/useENSData.ts
+++ b/src/hooks/useENSData.ts
@@ -4,6 +4,7 @@ import { AvatarResolver } from '@ensdomains/ens-avatar'
 import config from '@/config'
 import { useAppDispatch, useAppSelector } from '@/store/hook'
 import { addENSAddress } from '@/store/slices/ens-slice'
+import { validateAddress } from '@/utils/validateAddress'
 
 export const useENSData = (address: string | undefined | null) => {
   const [avatar, setAvatar] = useState<string>()
@@ -14,8 +15,13 @@ export const useENSData = (address: string | undefined | null) => {
 
   useEffect(() => {
     const getAvatar = async (addrs: string) => {
+      let lookupAddress = addrs
       const provider: BaseProvider = new StaticJsonRpcProvider(config.ensRPC)
-      const name = await provider.lookupAddress(addrs)
+      if (!validateAddress(addrs)) {
+        const resolved = (await provider.resolveName(addrs)) as string
+        lookupAddress = resolved
+      }
+      const name = await provider.lookupAddress(lookupAddress)
       let avatarURI
       if (name) {
         setUsername(name)
@@ -28,7 +34,7 @@ export const useENSData = (address: string | undefined | null) => {
       setLoading(false)
       dispatch(
         addENSAddress({
-          address: addrs,
+          address: lookupAddress,
           username: name || null,
           avatar: avatarURI || null,
         }),

--- a/src/hooks/useENSData.ts
+++ b/src/hooks/useENSData.ts
@@ -18,8 +18,8 @@ export const useENSData = (address: string | undefined | null) => {
       let lookupAddress = addrs
       const provider: BaseProvider = new StaticJsonRpcProvider(config.ensRPC)
       if (!validateAddress(addrs)) {
-        const resolved = (await provider.resolveName(addrs)) as string
-        lookupAddress = resolved
+        const resolvedAddress = (await provider.resolveName(addrs)) as string
+        lookupAddress = resolvedAddress
       }
       const name = await provider.lookupAddress(lookupAddress)
       let avatarURI

--- a/src/utils/validateAddress.ts
+++ b/src/utils/validateAddress.ts
@@ -1,0 +1,3 @@
+export const validateAddress = (address: string) => {
+  return address.startsWith('0x')
+}


### PR DESCRIPTION
# Allow Account Access Using ENS Name

_Page should detect if address starts by 0x or by a different thing, and try to reverse from ENS address to their real eth address.

## How should this be tested?

1. Navigate to /account/kesar.eth
2. The page should be able to reverse the ENS name to its address and fetch user's wiki based on the  address.

Before 
![image](https://user-images.githubusercontent.com/70170061/165621243-6c35e032-664b-4321-a73e-790f69aa4a30.png)

After
![image](https://user-images.githubusercontent.com/70170061/165620947-d54dcc64-9b2e-4079-939d-b7f6f0379de4.png)


## Linked issues

fixes https://github.com/EveripediaNetwork/issues/issues/212