### PR TITLE
Fixes to Revision Page

### DIFF
--- a/src/components/Wiki/WikiPage/WikiInsights.tsx
+++ b/src/components/Wiki/WikiPage/WikiInsights.tsx
@@ -12,9 +12,10 @@ import CurrencyConverter from './InsightComponents/CurrencyConverter'
 
 interface WikiInsightsProps {
   wiki: Wiki
+  ipfs?: string
 }
 
-const WikiInsights = ({ wiki }: WikiInsightsProps) => (
+const WikiInsights = ({ wiki, ipfs }: WikiInsightsProps) => (
   <VStack
     maxW="500px"
     borderLeftWidth={{ base: 0, md: '1px' }}
@@ -28,7 +29,7 @@ const WikiInsights = ({ wiki }: WikiInsightsProps) => (
       wikiTitle={wiki}
       categories={wiki.categories}
       lastEdited={wiki.updated || wiki?.created}
-      ipfsHash={wiki.ipfs}
+      ipfsHash={ipfs || wiki.ipfs}
       lastEditor={wiki.user?.id}
       imgSrc={getWikiImageUrl(wiki)}
     />

--- a/src/pages/revision/[id].tsx
+++ b/src/pages/revision/[id].tsx
@@ -10,7 +10,7 @@ import {
   HeadingProps,
   ReactMarkdownProps,
 } from 'react-markdown/lib/ast-to-react'
-import { HStack, Flex, Spinner, VStack, Text, Button } from '@chakra-ui/react'
+import { HStack, Flex, Spinner, Text, Button, Box } from '@chakra-ui/react'
 import WikiActionBar from '@/components/Wiki/WikiPage/WikiActionBar'
 import WikiMainContent from '@/components/Wiki/WikiPage/WikiMainContent'
 import WikiInsights from '@/components/Wiki/WikiPage/WikiInsights'
@@ -19,21 +19,37 @@ import { getWikiImageUrl } from '@/utils/getWikiImageUrl'
 import { getWikiSummary } from '@/utils/getWikiSummary'
 import WikiPreviewHover from '@/components/Wiki/WikiPage/WikiPreviewHover'
 import WikiNotFound from '@/components/Wiki/WIkiNotFound/WikiNotFound'
-import { getActivityById, useGetActivityByIdQuery } from '@/services/activities'
+import {
+  getActivityById,
+  getLatestIPFSByWiki,
+  useGetActivityByIdQuery,
+  useGetLatestIPFSByWikiQuery,
+} from '@/services/activities'
 import Link from 'next/link'
 
 const Wiki = () => {
   const router = useRouter()
 
   const { id: ActivityId } = router.query
-  const result = useGetActivityByIdQuery(
+  const {
+    isLoading,
+    error,
+    data: wiki,
+  } = useGetActivityByIdQuery(
     typeof ActivityId === 'string' ? ActivityId : skipToken,
     {
       skip: router.isFallback,
     },
   )
-  const { isLoading, error, data: wiki } = result
   const [isTocEmpty, setIsTocEmpty] = React.useState<boolean>(true)
+  const [isLatest, setIsLatest] = React.useState<boolean>(true)
+
+  const { data: latestIPFS } = useGetLatestIPFSByWikiQuery(
+    typeof ActivityId === 'string' ? ActivityId : skipToken,
+    {
+      skip: router.isFallback,
+    },
+  )
 
   // get the link id if available to scroll to the correct position
   useEffect(() => {
@@ -46,6 +62,12 @@ const Wiki = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isTocEmpty])
 
+  useEffect(() => {
+    if (latestIPFS === wiki?.ipfs) {
+      setIsLatest(true)
+    }
+  }, [latestIPFS, wiki?.ipfs])
+
   // here toc is not state variable since there seems to be some issue
   // with in react-markdown that is causing infinite loop if toc is state variable
   // (so using useEffect to update toc length for now)
@@ -55,6 +77,7 @@ const Wiki = () => {
     id: string
     title: string
   }[] = []
+
   React.useEffect(() => {
     setIsTocEmpty(toc.length === 0)
   }, [toc])
@@ -140,39 +163,41 @@ const Wiki = () => {
             <Spinner size="xl" />
           </Flex>
         ) : (
-          <VStack mt={-2}>
-            <Flex
-              flexDir={{ base: 'column', lg: 'row' }}
-              justify="center"
-              align="center"
-              gap={2}
-              bgColor="red.200"
-              _dark={{ bgColor: 'red.500' }}
-              w="100%"
-              p={2}
-            >
-              <Text textAlign="center">
-                You are seeing an older version of this wiki.
-              </Text>
-              <Link href={`/wiki/${wiki?.content[0].id}`} passHref>
-                <Button
-                  as="a"
-                  maxW="120px"
-                  variant="solid"
-                  bgColor="dimColor"
-                  sx={{
-                    '&:hover, &:focus, &:active': {
-                      bgColor: 'dimColor',
-                      textDecoration: 'underline',
-                    },
-                  }}
-                  px={4}
-                  size="sm"
-                >
-                  View Latest
-                </Button>
-              </Link>
-            </Flex>
+          <Box mt={-2}>
+            {!isLatest && (
+              <Flex
+                flexDir={{ base: 'column', lg: 'row' }}
+                justify="center"
+                align="center"
+                gap={2}
+                bgColor="red.200"
+                _dark={{ bgColor: 'red.500' }}
+                w="100%"
+                p={2}
+              >
+                <Text textAlign="center">
+                  You are seeing an older version of this wiki.
+                </Text>
+                <Link href={`/wiki/${wiki?.content[0].id}`} passHref>
+                  <Button
+                    as="a"
+                    maxW="120px"
+                    variant="solid"
+                    bgColor="dimColor"
+                    sx={{
+                      '&:hover, &:focus, &:active': {
+                        bgColor: 'dimColor',
+                        textDecoration: 'underline',
+                      },
+                    }}
+                    px={4}
+                    size="sm"
+                  >
+                    View Latest
+                  </Button>
+                </Link>
+              </Flex>
+            )}
             <HStack m="0 !important" align="stretch" justify="stretch">
               <Flex
                 w="100%"
@@ -188,7 +213,7 @@ const Wiki = () => {
                       addWikiPreview={addWikiPreview}
                       editedTimestamp={wiki.datetime}
                     />
-                    <WikiInsights wiki={wiki.content[0]} />
+                    <WikiInsights wiki={wiki.content[0]} ipfs={wiki.ipfs} />
                   </>
                 ) : (
                   <WikiNotFound />
@@ -196,7 +221,7 @@ const Wiki = () => {
               </Flex>
               {!isTocEmpty && <WikiTableOfContents toc={toc} isAlertAtTop />}
             </HStack>
-          </VStack>
+          </Box>
         )}
       </main>
     </>
@@ -205,8 +230,10 @@ const Wiki = () => {
 
 export const getServerSideProps: GetServerSideProps = async context => {
   const id = context.params?.id
-  if (typeof id === 'string') store.dispatch(getActivityById.initiate(id))
-
+  if (typeof id === 'string') {
+    store.dispatch(getActivityById.initiate(id))
+    store.dispatch(getLatestIPFSByWiki.initiate(id))
+  }
   await Promise.all(getRunningOperationPromises())
   return {
     props: {},

--- a/src/services/activities/index.ts
+++ b/src/services/activities/index.ts
@@ -5,6 +5,7 @@ import {
   GET_ACTIVITIES,
   GET_ACTIVITIES_BY_ID,
   GET_ACTIVITIES_BY_WIKI,
+  GET_LATEST_ACTIVITY_BY_WIKI,
 } from '@/services/activities/queries'
 import config from '@/config'
 import { Activity } from '@/types/ActivityDataType'
@@ -17,6 +18,13 @@ type GetActivityByIdResponse = {
 }
 type GetActivityByWikiResponse = {
   activitiesByWikId: Activity[]
+}
+type GetLatestActivityByWikiResponse = {
+  activitiesByWikId: [
+    {
+      ipfs: string
+    },
+  ]
 }
 
 type ActivitiesArg = {
@@ -52,6 +60,14 @@ export const activitiesApi = createApi({
       transformResponse: (response: GetActivityByIdResponse) =>
         response.activityById,
     }),
+    getLatestIPFSByWiki: builder.query<string, string>({
+      query: (wikiId: string) => ({
+        document: GET_LATEST_ACTIVITY_BY_WIKI,
+        variables: { wikiId },
+      }),
+      transformResponse: (response: GetLatestActivityByWikiResponse) =>
+        response.activitiesByWikId[0].ipfs,
+    }),
     getActivityByWiki: builder.query<Activity[], string>({
       query: (id: string) => ({
         document: GET_ACTIVITIES_BY_WIKI,
@@ -67,8 +83,13 @@ export const {
   useGetLatestActivitiesQuery,
   useGetActivityByWikiQuery,
   useGetActivityByIdQuery,
+  useGetLatestIPFSByWikiQuery,
   util: { getRunningOperationPromises },
 } = activitiesApi
 
-export const { getLatestActivities, getActivityByWiki, getActivityById } =
-  activitiesApi.endpoints
+export const {
+  getLatestActivities,
+  getActivityByWiki,
+  getLatestIPFSByWiki,
+  getActivityById,
+} = activitiesApi.endpoints

--- a/src/services/activities/queries.ts
+++ b/src/services/activities/queries.ts
@@ -30,6 +30,17 @@ export const GET_ACTIVITIES = gql`
     }
   }
 `
+
+export const GET_LATEST_ACTIVITY_BY_WIKI = gql`
+  query GetLatestActivityByWiki($wikiId: String!) {
+    {
+      activitiesByWikId(wikiId: $wikiId, limit:1) {
+        ipfs
+      }
+    }
+  }
+`
+
 export const GET_ACTIVITIES_BY_WIKI = gql`
   query GetActivitiesByWiki($id: String!) {
     activitiesByWikId(wikiId: $id) {

--- a/src/types/ActivityDataType.ts
+++ b/src/types/ActivityDataType.ts
@@ -6,4 +6,5 @@ export type Activity = {
   type: string
   content: Wiki[]
   datetime: string
+  ipfs?: string
 }


### PR DESCRIPTION
Fixes https://github.com/EveripediaNetwork/issues/issues/307

# Changes
1. Made the old wiki message to show only on non latest revisions
2. fixed IPFS not showing on wiki insights in revision page
3. fixed layout for https://alpha.everipedia.org/revision/a7804015-efd2-4a44-8f29-5e1462f4629c