### PR TITLE
Fix not possible to upload images

### DIFF
--- a/src/components/Elements/Modal/WikiProcessModal.tsx
+++ b/src/components/Elements/Modal/WikiProcessModal.tsx
@@ -55,6 +55,7 @@ const WikiProcessModal = ({
       isOpen={isOpen}
       isCentered
       size="2xl"
+      closeOnOverlayClick={false}
     >
       <AlertDialogOverlay />
       <AlertDialogContent>

--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -120,7 +120,7 @@ const CreateWikiContent = () => {
 
   const getImageHash = async () =>
     isWikiBeingEdited ? ipfsHash : saveImage(image)
- 
+
   const getWikiSlug = () => slugify(String(wiki.title).toLowerCase())
 
   const getImageArrayBufferLength = () =>
@@ -189,7 +189,7 @@ const CreateWikiContent = () => {
       // Build the wiki object
       const imageHash = await getImageHash()
 
-      if(!imageHash){
+      if (!imageHash) {
         setIsLoading('error')
         setMsg(errorMessage)
         return

--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -66,6 +66,7 @@ import {
   useGetSignedHash,
   useCreateWikiEffects,
   useCreateWikiContext,
+  errorMessage,
 } from '@/utils/create-wiki'
 
 const Editor = dynamic(() => import('@/components/Layout/Editor/Editor'), {
@@ -119,7 +120,7 @@ const CreateWikiContent = () => {
 
   const getImageHash = async () =>
     isWikiBeingEdited ? ipfsHash : saveImage(image)
-
+ 
   const getWikiSlug = () => slugify(String(wiki.title).toLowerCase())
 
   const getImageArrayBufferLength = () =>
@@ -187,6 +188,12 @@ const CreateWikiContent = () => {
 
       // Build the wiki object
       const imageHash = await getImageHash()
+
+      if(!imageHash){
+        setIsLoading('error')
+        setMsg(errorMessage)
+        return
+      }
 
       let interWiki = { ...wiki }
       if (interWiki.id === '') interWiki.id = getWikiSlug()

--- a/src/utils/create-wiki.ts
+++ b/src/utils/create-wiki.ts
@@ -48,7 +48,7 @@ export const MINIMUM_WORDS = 150
 export const saveImage = async (image: Image) => {
   const formData = new FormData()
   const blob = new Blob([image.type], {
-    type: 'image/jpeg', // TODO: find proper type for now its forced to bypass API enforcements
+    type: 'imagess/jpeg', // TODO: find proper type for now its forced to bypass API enforcements
   })
 
   formData.append('operations', POST_IMG)
@@ -56,15 +56,20 @@ export const saveImage = async (image: Image) => {
   formData.append('map', map)
   formData.append('0', blob)
 
-  const {
-    data: {
+  try{
+    const {
       data: {
-        pinImage: { IpfsHash },
+        data: {
+          pinImage: { IpfsHash },
+        },
       },
-    },
-  } = await axios.post(config.graphqlUrl, formData, {})
+    } = await axios.post(config.graphqlUrl, formData, {})
 
-  return IpfsHash
+    return IpfsHash
+  }
+  catch(err){
+    return null
+  }  
 }
 
 export const [CreateWikiProvider, useCreateWikiContext] =

--- a/src/utils/create-wiki.ts
+++ b/src/utils/create-wiki.ts
@@ -48,7 +48,7 @@ export const MINIMUM_WORDS = 150
 export const saveImage = async (image: Image) => {
   const formData = new FormData()
   const blob = new Blob([image.type], {
-    type: 'imagess/jpeg', // TODO: find proper type for now its forced to bypass API enforcements
+    type: 'image/jpeg', // TODO: find proper type for now its forced to bypass API enforcements
   })
 
   formData.append('operations', POST_IMG)
@@ -56,7 +56,7 @@ export const saveImage = async (image: Image) => {
   formData.append('map', map)
   formData.append('0', blob)
 
-  try{
+  try {
     const {
       data: {
         data: {
@@ -66,10 +66,9 @@ export const saveImage = async (image: Image) => {
     } = await axios.post(config.graphqlUrl, formData, {})
 
     return IpfsHash
-  }
-  catch(err){
+  } catch (err) {
     return null
-  }  
+  }
 }
 
 export const [CreateWikiProvider, useCreateWikiContext] =

--- a/src/utils/postSignature.ts
+++ b/src/utils/postSignature.ts
@@ -1,7 +1,6 @@
 import { GraphQLClient, gql } from 'graphql-request'
 import config from '@/config'
 
-
 export const submitVerifiableSignature = async (
   signedData: string,
   wikiHash: string,


### PR DESCRIPTION
# Fix issue relating to Image Upload when creating a wiki

_When creating a wiki, there is a need to upload an image. errors relating to Image upload were not properly handled, as a result, the wiki upload progress dialog keeps uploading without showing information.

## Notes or observations
To fix this issue, I tried to wrap the Image upload function with try and catch so as to handle any error that might come up. and inside the create wiki component, I'm checking if there is a value for the Ipfs before proceeding with the other process.

## Linked issues

fixes https://github.com/EveripediaNetwork/issues/issues/304
fixes https://github.com/EveripediaNetwork/issues/issues/309