### PR TITLE
Optimized Activity page. 

### DIFF
--- a/src/pages/activity/index.tsx
+++ b/src/pages/activity/index.tsx
@@ -98,7 +98,7 @@ export const getServerSideProps: GetServerSideProps = async () => {
   )
   await Promise.all(getRunningOperationPromises())
   return {
-    props: { activities: activities.data },
+    props: { activities: activities.status !== 'fulfilled' ? [] : activities.data },
   }
 }
 

--- a/src/pages/activity/index.tsx
+++ b/src/pages/activity/index.tsx
@@ -98,7 +98,9 @@ export const getServerSideProps: GetServerSideProps = async () => {
   )
   await Promise.all(getRunningOperationPromises())
   return {
-    props: { activities: activities.status !== 'fulfilled' ? [] : activities.data },
+    props: {
+      activities: activities.status !== 'fulfilled' ? [] : activities.data,
+    },
   }
 }
 


### PR DESCRIPTION
Returning the activity data only when it's `status` is `fulfilled` because if one of the activity returned is badly formatted it causes an error that affects the activity page. 


## Linked issues

closes #317, closes #317, closes https://github.com/EveripediaNetwork/issues/issues/317
