### PR TITLE
Remove infinite scroll on smaller item

### DIFF
--- a/src/components/Profile/Collected.tsx
+++ b/src/components/Profile/Collected.tsx
@@ -36,7 +36,7 @@ const Collected = () => {
             const updatedWiki = [...wikis, ...data]
             setWikis(updatedWiki)
             setOffset(fetchOffset)
-            if(data.length < ITEM_PER_PAGE){
+            if (data.length < ITEM_PER_PAGE) {
               setLoading(false)
               setHasMore(false)
             }

--- a/src/components/Profile/Collected.tsx
+++ b/src/components/Profile/Collected.tsx
@@ -36,7 +36,10 @@ const Collected = () => {
             const updatedWiki = [...wikis, ...data]
             setWikis(updatedWiki)
             setOffset(fetchOffset)
-            setLoading(false)
+            if(data.length < ITEM_PER_PAGE){
+              setLoading(false)
+              setHasMore(false)
+            }
           } else {
             setHasMore(false)
             setLoading(false)

--- a/src/pages/categories/[category].tsx
+++ b/src/pages/categories/[category].tsx
@@ -66,6 +66,10 @@ const CategoryPage = ({ categoryData, wikis }: CategoryPageProps) => {
           const updatedWiki = [...wikisInCategory, ...data]
           setWikisInCategory(updatedWiki)
           setOffset(updatedOffset)
+          if (data.length < ITEM_PER_PAGE) {
+            setHasMore(false)
+            setLoading(false)
+          }
         } else {
           setHasMore(false)
           setLoading(false)

--- a/src/pages/tags/[tag].tsx
+++ b/src/pages/tags/[tag].tsx
@@ -37,7 +37,7 @@ const TagPage: NextPage<TagPageProps> = ({ tagId, wikis }: TagPageProps) => {
     setHasMore(true)
     setOffset(0)
     setWikisByTag(wikis)
-    if(wikis.length < ITEM_PER_PAGE){
+    if (wikis.length < ITEM_PER_PAGE) {
       setHasMore(false)
       setLoading(false)
     }
@@ -59,7 +59,7 @@ const TagPage: NextPage<TagPageProps> = ({ tagId, wikis }: TagPageProps) => {
           const updatedWiki = [...wikisByTag, ...data]
           setWikisByTag(updatedWiki)
           setOffset(updatedOffset)
-          if(data.length < ITEM_PER_PAGE){
+          if (data.length < ITEM_PER_PAGE) {
             setHasMore(false)
             setLoading(false)
           }

--- a/src/pages/tags/[tag].tsx
+++ b/src/pages/tags/[tag].tsx
@@ -37,6 +37,10 @@ const TagPage: NextPage<TagPageProps> = ({ tagId, wikis }: TagPageProps) => {
     setHasMore(true)
     setOffset(0)
     setWikisByTag(wikis)
+    if(wikis.length < ITEM_PER_PAGE){
+      setHasMore(false)
+      setLoading(false)
+    }
   }, [tag])
 
   const fetchMoreWikis = () => {
@@ -55,6 +59,10 @@ const TagPage: NextPage<TagPageProps> = ({ tagId, wikis }: TagPageProps) => {
           const updatedWiki = [...wikisByTag, ...data]
           setWikisByTag(updatedWiki)
           setOffset(updatedOffset)
+          if(data.length < ITEM_PER_PAGE){
+            setHasMore(false)
+            setLoading(false)
+          }
         } else {
           setHasMore(false)
           setLoading(false)


### PR DESCRIPTION
#Remove infinite scroll on smaller item

## How should this be tested?

1. Go to categories, user, or tags page
2. try to scroll
3. The spinner should not display when the length of the previously fetched data is less than the ITEM_PER_PAGE


fixes https://github.com/EveripediaNetwork/issues/issues/332
