### PR TITLE
Links color change and WikiPreviewCard to match Designs

### DIFF
--- a/src/components/Profile/SidebarFilter/constants.ts
+++ b/src/components/Profile/SidebarFilter/constants.ts
@@ -4,8 +4,8 @@ export const FILTER_SIDEBAR_SIZE = {
 } as const
 
 export const COLLECTIONS_DISPLAY_SIZES = {
-  LARGE: '320px',
-  SMALL: '207px',
+  LARGE: '390px',
+  SMALL: '257px',
 } as const
 
 export const STATUS_FILTERS = {

--- a/src/components/Wiki/WikiAccordion/AccordionWidget.tsx
+++ b/src/components/Wiki/WikiAccordion/AccordionWidget.tsx
@@ -31,7 +31,7 @@ const AccordionWidget = ({ type, title, titleTag, content }: WikiInsights) => {
       return (
         <Link
           target="_blank"
-          color="blue.600"
+          color="brand.500"
           fontSize="14px"
           href={contentURL}
         >

--- a/src/components/Wiki/WikiPage/InsightComponents/WikiDetails.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/WikiDetails.tsx
@@ -119,7 +119,7 @@ export const WikiDetails = ({
               <Link
                 target="_blank"
                 href={`https://ipfs.everipedia.org/ipfs/${ipfsHash}`}
-                color="blue.400"
+                color="brand.500"
               >
                 {shortenAccount(ipfsHash || '')}
               </Link>
@@ -136,7 +136,7 @@ export const WikiDetails = ({
               <Link
                 target="_blank"
                 href={`${config.blockExplorerUrl}/tx/${txHash}`}
-                color="blue.400"
+                color="brand.500"
               >
                 {shortenAccount(txHash || '')}
               </Link>
@@ -147,7 +147,7 @@ export const WikiDetails = ({
             <Td>
               <HStack>
                 <DisplayAvatar address={lastEditor} />
-                <Link href={`/account/${lastEditor}`} color="blue.400">
+                <Link href={`/account/${lastEditor}`} color="brand.500">
                   {username || shortenAccount(lastEditor || '')}
                 </Link>
               </HStack>

--- a/src/components/Wiki/WikiPage/WikiReferences.tsx
+++ b/src/components/Wiki/WikiPage/WikiReferences.tsx
@@ -44,7 +44,7 @@ const WikiReferences = ({ references }: WikiReferencesProps) => {
             id={`cite-id-${ref.id}`}
             bg={
               currentLocationHash === `#cite-id-${ref.id}`
-                ? 'blue.50'
+                ? 'pink.50'
                 : 'transparent'
             }
             _dark={{
@@ -65,11 +65,16 @@ const WikiReferences = ({ references }: WikiReferencesProps) => {
               },
             }}
           >
-            <Text color="blue.500">[{index + 1}] </Text>
+            <Text color="brand.500">[{index + 1}] </Text>
             <Box>
               <Flex flexWrap="wrap" gap={2}>
-                <Tag colorScheme="blue" as="h3" size="sm" fontWeight="500">
-                  <LinkOverlay rel="nofollow" p="0 !important" href={ref.url}>
+                <Tag colorScheme="brand" as="h3" size="sm">
+                  <LinkOverlay
+                    fontWeight="500"
+                    rel="nofollow"
+                    p="0 !important"
+                    href={ref.url}
+                  >
                     {new URL(ref.url).hostname}
                   </LinkOverlay>
                 </Tag>
@@ -78,7 +83,7 @@ const WikiReferences = ({ references }: WikiReferencesProps) => {
                     Array.from(Array(citeMarks[ref.id])).map((_, i) => (
                       <Link
                         href={`#cite-mark-${ref.id}-${i + 1}`}
-                        color="blue.500"
+                        color="brand.500"
                         ml="0 !important"
                         fontWeight="medium"
                         fontSize="sm"

--- a/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
+++ b/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import {
   Box,
-  Center,
   HStack,
   LinkBox,
   LinkOverlay,
@@ -18,44 +17,52 @@ import Link from 'next/link'
 import { useENSData } from '@/hooks/useENSData'
 import shortenAccount from '@/utils/shortenAccount'
 
-const WikiPreviewCard = ({ wiki }: { wiki: Wiki }) => {
+const WikiPreviewCard = ({
+  wiki,
+  showLatestEditor = false,
+}: {
+  wiki: Wiki
+  showLatestEditor?: boolean
+}) => {
   const { updated, title, id } = wiki
   const [, username] = useENSData(wiki.user?.id || '')
   return (
-    <Center cursor="pointer">
-      <LinkBox>
-        <Box
-          bgColor="cardBg"
-          w={390}
-          boxShadow="xl"
-          rounded="xl"
-          overflow="hidden"
-        >
-          <WikiImage h={200} imageURL={getWikiImageUrl(wiki)} layout="fill" />
-          <Stack spacing={3} p={4}>
-            <LinkOverlay href={`/wiki/${id}`}>
-              <Text fontSize="2xl" fontWeight="bold">
-                {title}
-              </Text>
-            </LinkOverlay>
-            <Text fontSize="md" opacity={0.7} h={14}>
-              {getWikiSummary(wiki, WikiSummarySize.Small)}
-            </Text>
-            <HStack justify="space-between">
-              <HStack fontSize="sm" color="brand.500">
+    <LinkBox
+      w="100%"
+      h="100%"
+      bgColor="cardBg"
+      boxShadow="xl"
+      rounded="xl"
+      overflow="hidden"
+      cursor="pointer"
+    >
+      <WikiImage h={200} imageURL={getWikiImageUrl(wiki)} layout="fill" />
+      <Stack spacing={3} p={4}>
+        <LinkOverlay href={`/wiki/${id}`}>
+          <Text fontSize="2xl" fontWeight="bold">
+            {title}
+          </Text>
+        </LinkOverlay>
+        <Box>
+          <Text fontSize="md" opacity={0.7}>
+            {getWikiSummary(wiki, WikiSummarySize.Small)}
+          </Text>
+          <HStack flexWrap="wrap" mt={2} justify="space-between">
+            {showLatestEditor && (
+              <HStack fontSize="sm" py={2} color="brand.500">
                 <DisplayAvatar address={wiki.user?.id} />
                 <Link href={`/account/${wiki.user?.id}`}>
                   {username || shortenAccount(wiki.user?.id || '')}
                 </Link>
               </HStack>
-              <Text color="gray.400" fontSize="sm">
-                Last Edited {updated && getReadableDate(updated)}
-              </Text>
-            </HStack>
-          </Stack>
+            )}
+            <Text py={2} m="0px !important" color="gray.400" fontSize="sm">
+              Last Edited {updated && getReadableDate(updated)}
+            </Text>
+          </HStack>
         </Box>
-      </LinkBox>
-    </Center>
+      </Stack>
+    </LinkBox>
   )
 }
 

--- a/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
+++ b/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
@@ -1,37 +1,60 @@
 import React from 'react'
-import { Box, Center, Stack, Text } from '@chakra-ui/react'
+import {
+  Box,
+  Center,
+  HStack,
+  LinkBox,
+  LinkOverlay,
+  Stack,
+  Text,
+} from '@chakra-ui/react'
 import { Wiki } from '@/types/Wiki'
 import { getReadableDate } from '@/utils/getFormattedDate'
-import NextLink from 'next/link'
 import { WikiImage } from '@/components/WikiImage'
 import { getWikiSummary, WikiSummarySize } from '@/utils/getWikiSummary'
 import { getWikiImageUrl } from '@/utils/getWikiImageUrl'
+import DisplayAvatar from '@/components/Elements/Avatar/Avatar'
+import Link from 'next/link'
+import { useENSData } from '@/hooks/useENSData'
+import shortenAccount from '@/utils/shortenAccount'
 
 const WikiPreviewCard = ({ wiki }: { wiki: Wiki }) => {
   const { updated, title, id } = wiki
+  const [, username] = useENSData(wiki.user?.id || '')
   return (
-    <Center py={6} cursor="pointer">
-      <NextLink href={`/wiki/${id}`} passHref>
-        <Box w={390} minH={390} boxShadow="xl" rounded="md" overflow="hidden">
-          <WikiImage
-            h={200}
-            mb={3}
-            imageURL={getWikiImageUrl(wiki)}
-            layout="fill"
-          />
+    <Center cursor="pointer">
+      <LinkBox>
+        <Box
+          bgColor="cardBg"
+          w={390}
+          boxShadow="xl"
+          rounded="xl"
+          overflow="hidden"
+        >
+          <WikiImage h={200} imageURL={getWikiImageUrl(wiki)} layout="fill" />
           <Stack spacing={3} p={4}>
-            <Text fontSize="2xl" fontWeight="bold">
-              {title}
-            </Text>
-            <Text color="gray.600" fontSize="md">
+            <LinkOverlay href={`/wiki/${id}`}>
+              <Text fontSize="2xl" fontWeight="bold">
+                {title}
+              </Text>
+            </LinkOverlay>
+            <Text fontSize="md" opacity={0.7} h={14}>
               {getWikiSummary(wiki, WikiSummarySize.Small)}
             </Text>
-            <Text color="gray.400" fontSize="sm">
-              Last Edited {updated && getReadableDate(updated)}
-            </Text>
+            <HStack justify="space-between">
+              <HStack fontSize="sm" color="brand.500">
+                <DisplayAvatar address={wiki.user?.id} />
+                <Link href={`/account/${wiki.user?.id}`}>
+                  {username || shortenAccount(wiki.user?.id || '')}
+                </Link>
+              </HStack>
+              <Text color="gray.400" fontSize="sm">
+                Last Edited {updated && getReadableDate(updated)}
+              </Text>
+            </HStack>
           </Stack>
         </Box>
-      </NextLink>
+      </LinkBox>
     </Center>
   )
 }

--- a/src/config/wagmi.ts
+++ b/src/config/wagmi.ts
@@ -9,10 +9,7 @@ import { publicProvider } from 'wagmi/providers/public'
 import { AlchemyProvider, Network } from '@ethersproject/providers'
 import config from './index'
 
-type Connector =
-  | MetaMaskConnector
-  | WalletConnectConnector
-  | MagicConnector
+type Connector = MetaMaskConnector | WalletConnectConnector | MagicConnector
 
 export const { chains, provider } = configureChains(
   [chain.polygon, chain.polygonMumbai],

--- a/src/editor-plugins/cite/frame/index.tsx
+++ b/src/editor-plugins/cite/frame/index.tsx
@@ -24,12 +24,12 @@ const FrameTab = ({ children }: { children: React.ReactNode }) => (
   <Tab
     border="unset"
     _selected={{
-      borderBottom: '2px solid #4ba6f8 !important',
-      color: '#4ba6f8 !important',
+      borderBottom: '2px solid  !important',
+      color: '#ea3b87 !important',
       _dark: {
         bgColor: '#2e3445 !important',
-        color: '#4ba6f8 !important',
-        borderBottom: '2px solid #4ba6f8 !important',
+        color: '#dc6fa6 !important',
+        borderBottom: '2px solid #dc6fa6 !important',
       },
     }}
     h="unset !important"

--- a/src/editor-plugins/wikiLink/styles.css
+++ b/src/editor-plugins/wikiLink/styles.css
@@ -82,7 +82,7 @@
 .toastui-editor-ok-button[disabled] {
   cursor: not-allowed;
   filter: brightness(80%);
-  background-color: #999999 !important;
+  background-color: #ec67a8 !important;
 }
 .wikiLink__noResultsMsg {
   text-align: center;

--- a/src/pages/categories/[category].tsx
+++ b/src/pages/categories/[category].tsx
@@ -135,7 +135,8 @@ const CategoryPage = ({ categoryData, wikis }: CategoryPageProps) => {
             <>
               <SimpleGrid
                 columns={{ base: 1, sm: 2, lg: 3 }}
-                width="min(90%, 1200px)"
+                width="min(90%, 1300px)"
+                minChildWidth="390px"
                 mx="auto"
                 my={12}
                 gap={8}

--- a/src/pages/categories/[category].tsx
+++ b/src/pages/categories/[category].tsx
@@ -136,14 +136,13 @@ const CategoryPage = ({ categoryData, wikis }: CategoryPageProps) => {
               <SimpleGrid
                 columns={{ base: 1, sm: 2, lg: 3 }}
                 width="min(90%, 1300px)"
-                minChildWidth="390px"
                 mx="auto"
                 my={12}
                 gap={8}
               >
                 {wikisInCategory.map((wiki, i) => (
-                  <Box key={i} w="100%">
-                    <WikiPreviewCard wiki={wiki} />
+                  <Box key={i} w="390px">
+                    <WikiPreviewCard wiki={wiki} showLatestEditor />
                   </Box>
                 ))}
               </SimpleGrid>

--- a/src/pages/static/assets/global.css
+++ b/src/pages/static/assets/global.css
@@ -87,7 +87,9 @@ html {
 .toastui-editor-dark .undo__toolbarBtn {
   background-image: url(/images/editor-toolbar/undo-icon-dark.png) !important;
 }
-
+.toastui-editor-ok-button {
+  background-color: #ec67a8 !important;
+}
 /* EDITOR CONTENT STYLES */
 .toastui-editor-contents * {
   font-family: poppins, sans-serif !important;
@@ -100,8 +102,7 @@ html {
   line-height: 1.25;
   scroll-margin-top: 80px;
 }
-.toastui-editor-contents h1,
-.toastui-editor-contents h2 {
+.toastui-editor-contents :where(h1, h2) {
   font-weight: 500 !important;
 }
 .toastui-editor-contents h1 {
@@ -117,6 +118,10 @@ html {
 .toastui-editor-contents ul > li::before {
   height: 0 !important;
   width: 0 !important;
+}
+
+.toastui-editor-contents a {
+  color: #ec67a8 !important;
 }
 
 .toastui-editor-contents blockquote {


### PR DESCRIPTION
Closes https://github.com/EveripediaNetwork/issues/issues/355

# Changes
- Updated Link colors in wiki page
- Updated Editor colors and links with brand color (Except active icons which are images)
- Updated WikiPreviewCard to match design
- Updated the displaySize of profile collection to better fit the wikiPreviewCard

# Links
- https://monopedia-ui-git-links-color-change-prediqt.vercel.app/wiki/sushiswap
- https://monopedia-ui-git-links-color-change-prediqt.vercel.app/create-wiki?slug=sushiswap
- https://monopedia-ui-git-links-color-change-prediqt.vercel.app/categories/defi
- https://monopedia-ui-git-links-color-change-prediqt.vercel.app/account/0x1dfC530A9B3955d62D16359110E3cf385d47b1a9

# Screenshots
![Frame 176](https://user-images.githubusercontent.com/52039218/170765463-3a8963f5-8d85-4ee8-9813-856e4a7caffa.png)

