### PR TITLE
Improvement on activity policy page

### DIFF
--- a/src/components/Activity/ActivityCard.tsx
+++ b/src/components/Activity/ActivityCard.tsx
@@ -8,7 +8,6 @@ import {
   Tag,
   useBreakpointValue,
   Flex,
-  chakra,
 } from '@chakra-ui/react'
 import NextLink from 'next/link'
 import shortenAccount from '@/utils/shortenAccount'
@@ -164,14 +163,18 @@ const ActivityCard = ({
                 w={{ base: '50%', md: '70%' }}
               >
                 {title}
-                
               </Heading>
             </NextLink>
             {type && (
-                <Text fontSize="sm" color="brand.500" fontWeight="medium"  mb="8px !important">
-                  {type === 'CREATED' ? 'New' : 'Edited'}
-                </Text>
-              )}
+              <Text
+                fontSize="sm"
+                color="brand.500"
+                fontWeight="medium"
+                mb="8px !important"
+              >
+                {type === 'CREATED' ? 'New' : 'Edited'}
+              </Text>
+            )}
           </HStack>
           {wiki.categories.length && (
             <NextLink href={`/categories/${wiki.categories[0].id}`} passHref>

--- a/src/components/Activity/ActivityCard.tsx
+++ b/src/components/Activity/ActivityCard.tsx
@@ -8,7 +8,7 @@ import {
   Tag,
   useBreakpointValue,
   Flex,
-  Badge,
+  chakra,
 } from '@chakra-ui/react'
 import NextLink from 'next/link'
 import shortenAccount from '@/utils/shortenAccount'
@@ -151,25 +151,28 @@ const ActivityCard = ({
       </NextLink>
       <Box w="90%" px={4} p={{ base: 1, lg: 4 }} mx="auto">
         <Flex mb={{ base: 0, md: 2 }} justifyContent="space-between">
-          <NextLink href={activityCardLinkRoute} passHref>
-            <Heading
-              cursor="pointer"
-              as="h2"
-              fontSize={{ base: '16px', md: '20px' }}
-              letterSpacing="wide"
-              overflow="hidden"
-              whiteSpace="nowrap"
-              textOverflow="ellipsis"
-              w={{ base: '50%', md: '70%' }}
-            >
-              {title}
-              {type && (
-                <Badge ml="1" fontSize="0.5em" colorScheme="pink">
+          <HStack>
+            <NextLink href={activityCardLinkRoute} passHref>
+              <Heading
+                cursor="pointer"
+                as="h2"
+                fontSize={{ base: '16px', md: '20px' }}
+                letterSpacing="wide"
+                overflow="hidden"
+                whiteSpace="nowrap"
+                textOverflow="ellipsis"
+                w={{ base: '50%', md: '70%' }}
+              >
+                {title}
+                
+              </Heading>
+            </NextLink>
+            {type && (
+                <Text fontSize="sm" color="brand.500" fontWeight="medium"  mb="8px !important">
                   {type === 'CREATED' ? 'New' : 'Edited'}
-                </Badge>
+                </Text>
               )}
-            </Heading>
-          </NextLink>
+          </HStack>
           {wiki.categories.length && (
             <NextLink href={`/categories/${wiki.categories[0].id}`} passHref>
               <Text

--- a/src/pages/static/guidelines.tsx
+++ b/src/pages/static/guidelines.tsx
@@ -5,12 +5,13 @@ import {
   Flex,
   UnorderedList,
   ListItem,
+  Container
 } from '@chakra-ui/react'
 import React from 'react'
 import RelatedTopics from '@/components/Elements/RelatedTopics/RelatedTopics'
 
 const Privacy = () => (
-  <Box w="min(90%, 1200px)" mx="auto" my={{ base: '10', lg: '16' }}>
+  <Container w="min(90%, 1200px)" maxW={{ base: '7xl', xl: '6xl', '2xl': '80%' }}   my={{ base: '10', lg: '16' }}>
     <Heading my={8} as="h1" size="3xl" letterSpacing="wide">
       Guidelines
     </Heading>
@@ -175,7 +176,7 @@ const Privacy = () => (
         />
       </Box>
     </Flex>
-  </Box>
+  </Container>
 )
 
 export default Privacy

--- a/src/pages/static/guidelines.tsx
+++ b/src/pages/static/guidelines.tsx
@@ -5,13 +5,17 @@ import {
   Flex,
   UnorderedList,
   ListItem,
-  Container
+  Container,
 } from '@chakra-ui/react'
 import React from 'react'
 import RelatedTopics from '@/components/Elements/RelatedTopics/RelatedTopics'
 
 const Privacy = () => (
-  <Container w="min(90%, 1200px)" maxW={{ base: '7xl', xl: '6xl', '2xl': '80%' }}   my={{ base: '10', lg: '16' }}>
+  <Container
+    w="min(90%, 1200px)"
+    maxW={{ base: '7xl', xl: '6xl', '2xl': '80%' }}
+    my={{ base: '10', lg: '16' }}
+  >
     <Heading my={8} as="h1" size="3xl" letterSpacing="wide">
       Guidelines
     </Heading>

--- a/src/pages/static/guidelines.tsx
+++ b/src/pages/static/guidelines.tsx
@@ -171,7 +171,7 @@ const Privacy = () => (
           </UnorderedList>
         </Text>
       </Flex>
-      <Box flex="1">
+      <Box>
         <RelatedTopics
           topics={[
             { name: 'Terms of Service', url: '/static/terms' },

--- a/src/pages/static/privacy.tsx
+++ b/src/pages/static/privacy.tsx
@@ -526,7 +526,7 @@ const Privacy = () => (
           page.
         </Text>
       </Flex>
-      <Box >
+      <Box>
         <RelatedTopics
           topics={[
             { name: 'Terms of Service', url: '/static/terms' },

--- a/src/pages/static/privacy.tsx
+++ b/src/pages/static/privacy.tsx
@@ -526,7 +526,7 @@ const Privacy = () => (
           page.
         </Text>
       </Flex>
-      <Box flex="1">
+      <Box >
         <RelatedTopics
           topics={[
             { name: 'Terms of Service', url: '/static/terms' },

--- a/src/pages/static/privacy.tsx
+++ b/src/pages/static/privacy.tsx
@@ -13,12 +13,13 @@ import {
   Td,
   UnorderedList,
   ListItem,
+  Container
 } from '@chakra-ui/react'
 import React from 'react'
 import RelatedTopics from '@/components/Elements/RelatedTopics/RelatedTopics'
 
 const Privacy = () => (
-  <Box w="min(90%, 1200px)" mx="auto" my={{ base: '10', lg: '16' }}>
+  <Container w="min(90%, 1200px)" maxW={{ base: '7xl', xl: '6xl', '2xl': '80%' }}   my={{ base: '10', lg: '16' }}>
     <Heading my={8} as="h1" size="3xl" letterSpacing="wide">
       Privacy Policy
     </Heading>
@@ -530,7 +531,7 @@ const Privacy = () => (
         />
       </Box>
     </Flex>
-  </Box>
+  </Container>
 )
 
 export default Privacy

--- a/src/pages/static/privacy.tsx
+++ b/src/pages/static/privacy.tsx
@@ -13,13 +13,17 @@ import {
   Td,
   UnorderedList,
   ListItem,
-  Container
+  Container,
 } from '@chakra-ui/react'
 import React from 'react'
 import RelatedTopics from '@/components/Elements/RelatedTopics/RelatedTopics'
 
 const Privacy = () => (
-  <Container w="min(90%, 1200px)" maxW={{ base: '7xl', xl: '6xl', '2xl': '80%' }}   my={{ base: '10', lg: '16' }}>
+  <Container
+    w="min(90%, 1200px)"
+    maxW={{ base: '7xl', xl: '6xl', '2xl': '80%' }}
+    my={{ base: '10', lg: '16' }}
+  >
     <Heading my={8} as="h1" size="3xl" letterSpacing="wide">
       Privacy Policy
     </Heading>

--- a/src/pages/static/terms.tsx
+++ b/src/pages/static/terms.tsx
@@ -3,7 +3,11 @@ import React from 'react'
 import RelatedTopics from '@/components/Elements/RelatedTopics/RelatedTopics'
 
 const Terms = () => (
-  <Container w="min(90%, 1200px)" maxW={{ base: '7xl', xl: '6xl', '2xl': '80%' }}   my={{ base: '10', lg: '16' }}>
+  <Container
+    w="min(90%, 1200px)"
+    maxW={{ base: '7xl', xl: '6xl', '2xl': '80%' }}
+    my={{ base: '10', lg: '16' }}
+  >
     <Heading my={8} as="h1" size="3xl" letterSpacing="wide">
       Terms of Service
     </Heading>

--- a/src/pages/static/terms.tsx
+++ b/src/pages/static/terms.tsx
@@ -186,7 +186,7 @@ const Terms = () => (
           </Link>
         </Text>
       </Flex>
-      <Box flex="1">
+      <Box>
         <RelatedTopics
           topics={[
             { name: 'Privacy Policy', url: '/static/privacy' },

--- a/src/pages/static/terms.tsx
+++ b/src/pages/static/terms.tsx
@@ -1,9 +1,9 @@
-import { Box, Heading, Text, Flex, Link } from '@chakra-ui/react'
+import { Box, Heading, Text, Flex, Link, Container } from '@chakra-ui/react'
 import React from 'react'
 import RelatedTopics from '@/components/Elements/RelatedTopics/RelatedTopics'
 
 const Terms = () => (
-  <Box w="min(90%, 1200px)" mx="auto" my={{ base: 10, lg: 16 }}>
+  <Container w="min(90%, 1200px)" maxW={{ base: '7xl', xl: '6xl', '2xl': '80%' }}   my={{ base: '10', lg: '16' }}>
     <Heading my={8} as="h1" size="3xl" letterSpacing="wide">
       Terms of Service
     </Heading>
@@ -191,7 +191,7 @@ const Terms = () => (
         />
       </Box>
     </Flex>
-  </Box>
+  </Container>
 )
 
 export default Terms


### PR DESCRIPTION
# Improvements on Activity cards/Policy pages

_ For activity cards, Fix "Edited/New" Badges to sync with the design on Figma and fix margins on the pages under policies in the footer section (guidelines, privacy policy, and terms of service pages). Margins are different from other pages like the. homepage, the activity page, etc..

## How should this be tested?
Design
<img width="750" alt="image" src="https://user-images.githubusercontent.com/70170061/170965894-2c3c8103-9465-4eaa-a081-9577c162fb6c.png">
Implementation
<img width="1145" alt="image" src="https://user-images.githubusercontent.com/70170061/170966219-bd1424e6-7ab0-475a-ba58-83945c708f5f.png">

 and for the policies
Before
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/70170061/170966891-9ba7d5c2-6912-4435-9ea4-4be65a12ccc2.png">

After
<img width="1434" alt="image" src="https://user-images.githubusercontent.com/70170061/170966770-7b5dffe7-4513-49f8-847b-a58015c66206.png">


## Notes or observations

_jot down something here_

## Linked issues

fixes https://github.com/EveripediaNetwork/issues/issues/368