### PR TITLE
Wiki cards homogenize

### DIFF
--- a/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
+++ b/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
@@ -16,6 +16,7 @@ import DisplayAvatar from '@/components/Elements/Avatar/Avatar'
 import Link from 'next/link'
 import { useENSData } from '@/hooks/useENSData'
 import shortenAccount from '@/utils/shortenAccount'
+import { shortenText } from '@/utils/shortenText'
 
 const WikiPreviewCard = ({
   wiki,
@@ -37,10 +38,10 @@ const WikiPreviewCard = ({
       cursor="pointer"
     >
       <WikiImage h={200} imageURL={getWikiImageUrl(wiki)} layout="fill" />
-      <Stack spacing={3} p={4}>
+      <Stack spacing={3} p={4} >
         <LinkOverlay href={`/wiki/${id}`}>
           <Text fontSize="2xl" fontWeight="bold">
-            {title}
+            {shortenText(title, 65)}
           </Text>
         </LinkOverlay>
         <Box>

--- a/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
+++ b/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
@@ -7,7 +7,7 @@ import {
   Stack,
   Text,
   Flex,
-  Box
+  Box,
 } from '@chakra-ui/react'
 import { Wiki } from '@/types/Wiki'
 import { getReadableDate } from '@/utils/getFormattedDate'
@@ -40,19 +40,19 @@ const WikiPreviewCard = ({
       cursor="pointer"
     >
       <WikiImage h={200} imageURL={getWikiImageUrl(wiki)} layout="fill" />
-      
+
       <Stack spacing={3} p={4}>
         <LinkOverlay href={`/wiki/${id}`}>
-            <Text
-              fontSize="2xl"
-              fontWeight="bold"
-              noOfLines={1}
-              textOverflow="ellipsis"
-              overflow="hidden"
-              orientation="vertical"
-            >
-              {shortenText(title, 65)}
-            </Text>
+          <Text
+            fontSize="2xl"
+            fontWeight="bold"
+            noOfLines={1}
+            textOverflow="ellipsis"
+            overflow="hidden"
+            orientation="vertical"
+          >
+            {shortenText(title, 65)}
+          </Text>
         </LinkOverlay>
         <Flex h="95" direction="column">
           <Box flex="1">

--- a/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
+++ b/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 import {
-  Box,
+  Spacer,
   HStack,
   LinkBox,
   LinkOverlay,
   Stack,
   Text,
+  Flex,
+  Box
 } from '@chakra-ui/react'
 import { Wiki } from '@/types/Wiki'
 import { getReadableDate } from '@/utils/getFormattedDate'
@@ -38,29 +40,51 @@ const WikiPreviewCard = ({
       cursor="pointer"
     >
       <WikiImage h={200} imageURL={getWikiImageUrl(wiki)} layout="fill" />
+      
       <Stack spacing={3} p={4}>
-        <Box
-          h="181"
-          display="flex"
-          flexDirection="column"
-          justifyContent="space-between"
-          flexGrow="1"
-        >
-          <LinkOverlay href={`/wiki/${id}`}>
+        <LinkOverlay href={`/wiki/${id}`}>
             <Text
               fontSize="2xl"
               fontWeight="bold"
-              noOfLines={2}
+              noOfLines={1}
               textOverflow="ellipsis"
               overflow="hidden"
               orientation="vertical"
             >
               {shortenText(title, 65)}
             </Text>
-          </LinkOverlay>
+        </LinkOverlay>
+        <Flex h="95" direction="column">
+          <Box flex="1">
+            <Text fontSize="md" opacity={0.7}>
+              {getWikiSummary(wiki, WikiSummarySize.Small)}
+            </Text>
+          </Box>
+          <Spacer />
+          <Box>
+            <HStack flexWrap="wrap" mt={2} justify="space-between">
+              {showLatestEditor && (
+                <HStack fontSize="sm" py={2} color="brand.500">
+                  <DisplayAvatar address={wiki.user?.id} />
+                  <Link href={`/account/${wiki.user?.id}`}>
+                    {username || shortenAccount(wiki.user?.id || '')}
+                  </Link>
+                </HStack>
+              )}
+              <Text py={2} m="0px !important" color="gray.400" fontSize="sm">
+                Last Edited {updated && getReadableDate(updated)}
+              </Text>
+            </HStack>
+          </Box>
+        </Flex>
+        {/* <Flex
+          flexDirection="column"
+          
+        >
           <Text fontSize="md" opacity={0.7}>
             {getWikiSummary(wiki, WikiSummarySize.Small)}
           </Text>
+          <Spacer/>
           <HStack flexWrap="wrap" mt={2} justify="space-between">
             {showLatestEditor && (
               <HStack fontSize="sm" py={2} color="brand.500">
@@ -74,7 +98,7 @@ const WikiPreviewCard = ({
               Last Edited {updated && getReadableDate(updated)}
             </Text>
           </HStack>
-        </Box>
+        </Flex> */}
       </Stack>
     </LinkBox>
   )

--- a/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
+++ b/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
@@ -56,7 +56,10 @@ const WikiPreviewCard = ({
         </LinkOverlay>
         <Flex h="95" direction="column">
           <Box flex="1">
-            <Text fontSize="md" opacity={0.7}>
+            <Text fontSize="md" opacity={0.7} noOfLines={2}
+            textOverflow="ellipsis"
+            overflow="hidden"
+            orientation="vertical">
               {getWikiSummary(wiki, WikiSummarySize.Small)}
             </Text>
           </Box>

--- a/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
+++ b/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
@@ -39,12 +39,12 @@ const WikiPreviewCard = ({
     >
       <WikiImage h={200} imageURL={getWikiImageUrl(wiki)} layout="fill" />
       <Stack spacing={3} p={4} >
-        <LinkOverlay href={`/wiki/${id}`}>
-          <Text fontSize="2xl" fontWeight="bold">
-            {shortenText(title, 65)}
-          </Text>
-        </LinkOverlay>
-        <Box>
+        <Box h="181" display="flex" flexDirection="column" justifyContent="space-between" flexGrow="1">
+          <LinkOverlay href={`/wiki/${id}`}>
+            <Text fontSize="2xl" fontWeight="bold" noOfLines={2} textOverflow="ellipsis" overflow="hidden" orientation="vertical">
+              {shortenText(title, 65)}
+            </Text>
+          </LinkOverlay>
           <Text fontSize="md" opacity={0.7}>
             {getWikiSummary(wiki, WikiSummarySize.Small)}
           </Text>

--- a/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
+++ b/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
@@ -44,7 +44,7 @@ const WikiPreviewCard = ({
       <Stack spacing={3} p={4}>
         <LinkOverlay href={`/wiki/${id}`}>
           <Text
-            fontSize="2xl"
+            fontSize="xl"
             fontWeight="bold"
             noOfLines={1}
             textOverflow="ellipsis"

--- a/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
+++ b/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
@@ -56,10 +56,14 @@ const WikiPreviewCard = ({
         </LinkOverlay>
         <Flex h="95" direction="column">
           <Box flex="1">
-            <Text fontSize="md" opacity={0.7} noOfLines={2}
-            textOverflow="ellipsis"
-            overflow="hidden"
-            orientation="vertical">
+            <Text
+              fontSize="md"
+              opacity={0.7}
+              noOfLines={2}
+              textOverflow="ellipsis"
+              overflow="hidden"
+              orientation="vertical"
+            >
               {getWikiSummary(wiki, WikiSummarySize.Small)}
             </Text>
           </Box>

--- a/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
+++ b/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
@@ -38,10 +38,23 @@ const WikiPreviewCard = ({
       cursor="pointer"
     >
       <WikiImage h={200} imageURL={getWikiImageUrl(wiki)} layout="fill" />
-      <Stack spacing={3} p={4} >
-        <Box h="181" display="flex" flexDirection="column" justifyContent="space-between" flexGrow="1">
+      <Stack spacing={3} p={4}>
+        <Box
+          h="181"
+          display="flex"
+          flexDirection="column"
+          justifyContent="space-between"
+          flexGrow="1"
+        >
           <LinkOverlay href={`/wiki/${id}`}>
-            <Text fontSize="2xl" fontWeight="bold" noOfLines={2} textOverflow="ellipsis" overflow="hidden" orientation="vertical">
+            <Text
+              fontSize="2xl"
+              fontWeight="bold"
+              noOfLines={2}
+              textOverflow="ellipsis"
+              overflow="hidden"
+              orientation="vertical"
+            >
               {shortenText(title, 65)}
             </Text>
           </LinkOverlay>

--- a/src/utils/getFormattedDate.ts
+++ b/src/utils/getFormattedDate.ts
@@ -1,5 +1,5 @@
 import { formatDistance } from 'date-fns'
 
 export const getReadableDate = (dateToFormat: string) => {
-  return formatDistance(new Date(dateToFormat), new Date(), { addSuffix: true })
+  return formatDistance(new Date(dateToFormat), new Date(), { addSuffix: false })
 }

--- a/src/utils/getFormattedDate.ts
+++ b/src/utils/getFormattedDate.ts
@@ -1,5 +1,7 @@
 import { formatDistance } from 'date-fns'
 
 export const getReadableDate = (dateToFormat: string) => {
-  return formatDistance(new Date(dateToFormat), new Date(), { addSuffix: false })
+  return formatDistance(new Date(dateToFormat), new Date(), {
+    addSuffix: false,
+  })
 }

--- a/src/utils/getFormattedDate.ts
+++ b/src/utils/getFormattedDate.ts
@@ -1,7 +1,7 @@
-import { formatDistance } from 'date-fns'
+import { formatDistanceToNowStrict } from 'date-fns'
 
 export const getReadableDate = (dateToFormat: string) => {
-  return formatDistance(new Date(dateToFormat), new Date(), {
+  return formatDistanceToNowStrict(new Date(dateToFormat),  {
     addSuffix: false,
   })
 }

--- a/src/utils/getFormattedDate.ts
+++ b/src/utils/getFormattedDate.ts
@@ -1,7 +1,7 @@
 import { formatDistanceToNowStrict } from 'date-fns'
 
 export const getReadableDate = (dateToFormat: string) => {
-  return formatDistanceToNowStrict(new Date(dateToFormat),  {
+  return formatDistanceToNowStrict(new Date(dateToFormat), {
     addSuffix: false,
   })
 }


### PR DESCRIPTION
# wiki cards homogenize

_we need to also homogenize wiki cards for homepage / activity / wiki categories / user wikis

## How should this be tested?

Before
     Profile
  
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/70170061/171444294-13c10a52-2639-472e-b193-b94977ab6177.png">

    Category
    
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/70170061/171444496-493bce23-daaf-4ace-a1c6-d8d8b8c6d694.png">


After
Profile
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/70170061/171444795-f635f185-dbb0-4d38-808b-a88d7c63a251.png">

Category
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/70170061/171445342-b3be8a27-fc45-45b9-8553-30c6100e3bc4.png">


fixes https://github.com/EveripediaNetwork/issues/issues/356