### PR TITLE
Fixing Wiki Tag Styling Issue

### DIFF
--- a/src/components/Wiki/WikiPage/InsightComponents/WikiDetails.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/WikiDetails.tsx
@@ -19,7 +19,6 @@ import { BaseCategory, WikiPreview } from '@/types/Wiki'
 import Link from '@/components/Elements/Link/Link'
 import DisplayAvatar from '@/components/Elements/Avatar/Avatar'
 import { useENSData } from '@/hooks/useENSData'
-import NextLink from 'next/link'
 import config from '@/config'
 
 export const WikiDetails = ({
@@ -84,13 +83,13 @@ export const WikiDetails = ({
               <Td py={1}>
                 <HStack marginLeft={-2} flexWrap="wrap" justify="start">
                   {tags?.map((tag, i) => (
-                    <NextLink key={i} href={`/tags/${tag.id}`} passHref>
+                    <Link key={i} href={`/tags/${tag.id}`} passHref>
                       <Box py={1}>
                         <Tag key={i} whiteSpace="nowrap" as="a">
                           {tag.id}
                         </Tag>
                       </Box>
-                    </NextLink>
+                    </Link>
                   ))}
                 </HStack>
               </Td>


### PR DESCRIPTION
#Fixing Wiki Tag Styling Issue

_Styling the Tag links to behave like links (having underlines when hovered)

## How should this be tested?

1. Before
![Screenshot (205)](https://user-images.githubusercontent.com/75235148/171740621-6a8c1426-725d-4cec-9196-5c4c294f363e.png)


2. After

![Screenshot (207)](https://user-images.githubusercontent.com/75235148/171740960-8055ecb0-fd2f-4d2f-9b70-4da2b65e680a.png)






closes #00, closes #001, closes https://github.com/EveripediaNetwork/issues/issues/386
