### PR TITLE
Show commit message in revision page

### DIFF
--- a/src/components/Wiki/WikiAccordion/AccordionWidget.tsx
+++ b/src/components/Wiki/WikiAccordion/AccordionWidget.tsx
@@ -21,10 +21,12 @@ import {
   RiShareBoxLine,
 } from 'react-icons/ri'
 import shortenAccount from '@/utils/shortenAccount'
+import DisplayAvatar from '@/components/Elements/Avatar/Avatar'
+import { useENSData } from '@/hooks/useENSData'
 
 const AccordionWidget = ({ type, title, titleTag, content }: WikiInsights) => {
   const { hasCopied, onCopy } = useClipboard(content as string)
-
+  const [, username] = useENSData((type === 'address' && typeof content === 'string') ?  content : '')
   const contentTemplate = () => {
     if (type === 'url') {
       const contentURL = content as string
@@ -56,6 +58,16 @@ const AccordionWidget = ({ type, title, titleTag, content }: WikiInsights) => {
             variant="link"
           />
         </HStack>
+      )
+    }
+    if (type === 'account' && typeof content === 'string') {
+      return (
+        <HStack>
+        <DisplayAvatar size="16" address={content} />
+        <Link fontSize="xs" href={`/account/${content}`} color="brand.500">
+          {username || shortenAccount(content || '')}
+        </Link>
+      </HStack>
       )
     }
     if (type === 'explorers' && content instanceof Array) {
@@ -96,7 +108,7 @@ const AccordionWidget = ({ type, title, titleTag, content }: WikiInsights) => {
         </Stat>
       )
     }
-    return <Text>{content.toString()}</Text>
+    return <Text fontSize="xs">{content.toString()}</Text>
   }
   return (
     <HStack

--- a/src/components/Wiki/WikiAccordion/AccordionWidget.tsx
+++ b/src/components/Wiki/WikiAccordion/AccordionWidget.tsx
@@ -26,7 +26,9 @@ import { useENSData } from '@/hooks/useENSData'
 
 const AccordionWidget = ({ type, title, titleTag, content }: WikiInsights) => {
   const { hasCopied, onCopy } = useClipboard(content as string)
-  const [, username] = useENSData((type === 'address' && typeof content === 'string') ?  content : '')
+  const [, username] = useENSData(
+    type === 'address' && typeof content === 'string' ? content : '',
+  )
   const contentTemplate = () => {
     if (type === 'url') {
       const contentURL = content as string
@@ -63,11 +65,11 @@ const AccordionWidget = ({ type, title, titleTag, content }: WikiInsights) => {
     if (type === 'account' && typeof content === 'string') {
       return (
         <HStack>
-        <DisplayAvatar size="16" address={content} />
-        <Link fontSize="xs" href={`/account/${content}`} color="brand.500">
-          {username || shortenAccount(content || '')}
-        </Link>
-      </HStack>
+          <DisplayAvatar size="16" address={content} />
+          <Link fontSize="xs" href={`/account/${content}`} color="brand.500">
+            {username || shortenAccount(content || '')}
+          </Link>
+        </HStack>
       )
     }
     if (type === 'explorers' && content instanceof Array) {

--- a/src/components/Wiki/WikiPage/InsightComponents/WikiCommiMessage.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/WikiCommiMessage.tsx
@@ -1,14 +1,19 @@
 import React from 'react'
 import WikiAccordion from '@/components/Wiki/WikiAccordion'
 import AccordionWidget from '@/components/Wiki/WikiAccordion/AccordionWidget'
-import {
-  Text,
-  VStack,
-} from '@chakra-ui/react'
+import { Text, VStack } from '@chakra-ui/react'
 import { User } from '@/types/Wiki'
 
-const WikiCommitMessage = ({user, lastUpdated, commitMessage}: {user: User,  lastUpdated: string | undefined, commitMessage: string}) => {
-  const lastEdited  = lastUpdated
+const WikiCommitMessage = ({
+  user,
+  lastUpdated,
+  commitMessage,
+}: {
+  user: User
+  lastUpdated: string | undefined
+  commitMessage: string
+}) => {
+  const lastEdited = lastUpdated
     ? new Date(lastUpdated).toLocaleDateString('en-US', {
         year: 'numeric',
         month: 'long',
@@ -24,21 +29,22 @@ const WikiCommitMessage = ({user, lastUpdated, commitMessage}: {user: User,  las
         gap={2}
         title="Commit Message"
       >
-          <AccordionWidget title="Edited by:" type="account" content={user.id} />
-          <AccordionWidget title="Edited in:" type="text" content={lastEdited} />
-          <VStack 
-            bgColor="wikiCardItemBg"
-            borderRadius={4}
-            align="left"
-            p={4}
-            spacing={2}>
-              <Text fontSize="sm" color="linkColor">
-                Reason for edit:
-              </Text>
-              <Text fontSize="xs" color="linkColor">
-                {commitMessage}
-              </Text>
-          </VStack>
+        <AccordionWidget title="Edited by:" type="account" content={user.id} />
+        <AccordionWidget title="Edited in:" type="text" content={lastEdited} />
+        <VStack
+          bgColor="wikiCardItemBg"
+          borderRadius={4}
+          align="left"
+          p={4}
+          spacing={2}
+        >
+          <Text fontSize="sm" color="linkColor">
+            Reason for edit:
+          </Text>
+          <Text fontSize="xs" color="linkColor">
+            {commitMessage}
+          </Text>
+        </VStack>
       </WikiAccordion>
     </VStack>
   )

--- a/src/components/Wiki/WikiPage/InsightComponents/WikiCommiMessage.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/WikiCommiMessage.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import WikiAccordion from '@/components/Wiki/WikiAccordion'
+import AccordionWidget from '@/components/Wiki/WikiAccordion/AccordionWidget'
+import {
+  Text,
+  VStack,
+} from '@chakra-ui/react'
+import { User } from '@/types/Wiki'
+
+const WikiCommitMessage = ({user, lastUpdated, commitMessage}: {user: User,  lastUpdated: string | undefined, commitMessage: string}) => {
+  const lastEdited  = lastUpdated
+    ? new Date(lastUpdated).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : '-'
+  return (
+    <VStack w="100%" spacing={4} borderRadius={2}>
+      <WikiAccordion
+        display="flex"
+        withNoDarkBg
+        flexDir="column"
+        gap={2}
+        title="Commit Message"
+      >
+          <AccordionWidget title="Edited by:" type="account" content={user.id} />
+          <AccordionWidget title="Edited in:" type="text" content={lastEdited} />
+          <VStack 
+            bgColor="wikiCardItemBg"
+            borderRadius={4}
+            align="left"
+            p={4}
+            spacing={2}>
+              <Text fontSize="sm" color="linkColor">
+                Reason for edit:
+              </Text>
+              <Text fontSize="xs" color="linkColor">
+                {commitMessage}
+              </Text>
+          </VStack>
+      </WikiAccordion>
+    </VStack>
+  )
+}
+
+export default WikiCommitMessage

--- a/src/components/Wiki/WikiPage/WikiInsights.tsx
+++ b/src/components/Wiki/WikiPage/WikiInsights.tsx
@@ -28,7 +28,7 @@ const WikiInsights = ({ wiki, ipfs }: WikiInsightsProps) => {
   )?.value
 
   const commitMessage = wiki.metadata.find(
-    meta => meta.id === CommonMetaIds.COMMIT_MESSAGE
+    meta => meta.id === CommonMetaIds.COMMIT_MESSAGE,
   )?.value
 
   const [tokenStats, setTokenStats] = useState<TokenStats>()
@@ -73,7 +73,13 @@ const WikiInsights = ({ wiki, ipfs }: WikiInsightsProps) => {
           )}
         </>
       )}
-      {!!commitMessage && <WikiCommitMessage commitMessage={commitMessage} user={wiki.user} lastUpdated={wiki.updated} />}
+      {!!commitMessage && (
+        <WikiCommitMessage
+          commitMessage={commitMessage}
+          user={wiki.user}
+          lastUpdated={wiki.updated}
+        />
+      )}
       {!!twitterLink && <TwitterTimeline url={twitterLink} />}
       {wiki.categories.length !== 0 && (
         <RelatedWikis categories={wiki.categories} />

--- a/src/components/Wiki/WikiPage/WikiInsights.tsx
+++ b/src/components/Wiki/WikiPage/WikiInsights.tsx
@@ -11,6 +11,7 @@ import ProfileSummary from './InsightComponents/ProfileSummary'
 import TwitterTimeline from './InsightComponents/TwitterTimeline'
 import RelatedMediaGrid from './InsightComponents/RelatedMedia'
 import CurrencyConverter from './InsightComponents/CurrencyConverter'
+import WikiCommitMessage from './InsightComponents/WikiCommiMessage'
 
 interface WikiInsightsProps {
   wiki: Wiki
@@ -24,6 +25,10 @@ const WikiInsights = ({ wiki, ipfs }: WikiInsightsProps) => {
 
   const twitterLink = wiki.metadata.find(
     meta => meta.id === CommonMetaIds.TWITTER_PROFILE,
+  )?.value
+
+  const commitMessage = wiki.metadata.find(
+    meta => meta.id === CommonMetaIds.COMMIT_MESSAGE
   )?.value
 
   const [tokenStats, setTokenStats] = useState<TokenStats>()
@@ -68,6 +73,7 @@ const WikiInsights = ({ wiki, ipfs }: WikiInsightsProps) => {
           )}
         </>
       )}
+      {!!commitMessage && <WikiCommitMessage commitMessage={commitMessage} user={wiki.user} lastUpdated={wiki.updated} />}
       {!!twitterLink && <TwitterTimeline url={twitterLink} />}
       {wiki.categories.length !== 0 && (
         <RelatedWikis categories={wiki.categories} />

--- a/src/types/Wiki.ts
+++ b/src/types/Wiki.ts
@@ -34,7 +34,7 @@ export enum CommonMetaIds {
   LINKEDIN_PROFILE = 'linkedin_profile',
   YOUTUBE_PROFILE = 'youtube_profile',
   COINGECKO_PROFILE = 'coingecko_profile',
-  COMMIT_MESSAGE = 'commit-message'
+  COMMIT_MESSAGE = 'commit-message',
 }
 
 export enum EditSpecificMetaIds {

--- a/src/types/Wiki.ts
+++ b/src/types/Wiki.ts
@@ -34,6 +34,7 @@ export enum CommonMetaIds {
   LINKEDIN_PROFILE = 'linkedin_profile',
   YOUTUBE_PROFILE = 'youtube_profile',
   COINGECKO_PROFILE = 'coingecko_profile',
+  COMMIT_MESSAGE = 'commit-message'
 }
 
 export enum EditSpecificMetaIds {

--- a/src/types/WikiInsightsDataType.ts
+++ b/src/types/WikiInsightsDataType.ts
@@ -10,7 +10,7 @@ export type WikiInsights =
       }
     }
   | {
-      type: 'url' | 'address' | 'text'| 'account'
+      type: 'url' | 'address' | 'text' | 'account'
       title: string
       titleTag?: string
       content: string

--- a/src/types/WikiInsightsDataType.ts
+++ b/src/types/WikiInsightsDataType.ts
@@ -10,7 +10,7 @@ export type WikiInsights =
       }
     }
   | {
-      type: 'url' | 'address' | 'text'
+      type: 'url' | 'address' | 'text'| 'account'
       title: string
       titleTag?: string
       content: string


### PR DESCRIPTION
# Show commit message on revision page

_if the user added a commit message prob. it would be something meaningful to show in the revision page

## How should this be tested?

1. Edit a wiki
2. Add a commit message
3. Go to the wiki page to view the commit message

<img width="429" alt="image" src="https://user-images.githubusercontent.com/70170061/171788373-aec10592-9e0e-4ba2-870b-9990dfc99e5c.png">

## Linked issues

fixes https://github.com/EveripediaNetwork/issues/issues/315