### PR TITLE
Media upload improvement

### DIFF
--- a/src/components/Elements/Dropzone/Dropzone.tsx
+++ b/src/components/Elements/Dropzone/Dropzone.tsx
@@ -93,7 +93,7 @@ const Dropzone = ({ dropZoneActions }: DropzoneType) => {
           justifyContent="center"
           alignItems="center"
           maxH="345px"
-          minH={!showFetchedImage ? "165px": "300px"}
+          minH={!showFetchedImage ? '165px' : '300px'}
           _hover={{
             boxShadow: 'md',
             borderColor: 'brand.400',
@@ -104,7 +104,7 @@ const Dropzone = ({ dropZoneActions }: DropzoneType) => {
           {isDragActive ? (
             <Text textAlign="center">Drop the files here ...</Text>
           ) : (
-            <Box px="8" mb={!showFetchedImage ? "10": "1"}>
+            <Box px="8" mb={!showFetchedImage ? '10' : '1'}>
               <Text textAlign="center" opacity="0.5">
                 Drag and drop a <b>{textType}</b>, or click to select.
               </Text>

--- a/src/components/Elements/Dropzone/Dropzone.tsx
+++ b/src/components/Elements/Dropzone/Dropzone.tsx
@@ -93,7 +93,7 @@ const Dropzone = ({ dropZoneActions }: DropzoneType) => {
           justifyContent="center"
           alignItems="center"
           maxH="345px"
-          minH="300px"
+          minH={!showFetchedImage ? "165px": "300px"}
           _hover={{
             boxShadow: 'md',
             borderColor: 'brand.400',
@@ -104,7 +104,7 @@ const Dropzone = ({ dropZoneActions }: DropzoneType) => {
           {isDragActive ? (
             <Text textAlign="center">Drop the files here ...</Text>
           ) : (
-            <Box px="8">
+            <Box px="8" mb={!showFetchedImage ? "10": "1"}>
               <Text textAlign="center" opacity="0.5">
                 Drag and drop a <b>{textType}</b>, or click to select.
               </Text>

--- a/src/components/Elements/Dropzone/Dropzone.tsx
+++ b/src/components/Elements/Dropzone/Dropzone.tsx
@@ -16,6 +16,7 @@ type DropzoneType = {
     isToResetImage?: boolean
     initialImage?: string | undefined
     showFetchedImage: boolean
+    textType: string
   }
 }
 
@@ -29,6 +30,7 @@ const Dropzone = ({ dropZoneActions }: DropzoneType) => {
     deleteImage,
     initialImage,
     showFetchedImage,
+    textType,
   } = dropZoneActions
 
   const onDrop = useCallback(
@@ -104,7 +106,7 @@ const Dropzone = ({ dropZoneActions }: DropzoneType) => {
           ) : (
             <Box px="8">
               <Text textAlign="center" opacity="0.5">
-                Drag and drop a <b>main image</b>, or click to select.
+                Drag and drop a <b>{textType}</b>, or click to select.
               </Text>
               <Text textAlign="center" opacity="0.5" fontWeight="bold">
                 (10mb max)

--- a/src/components/Elements/Dropzone/Dropzone.tsx
+++ b/src/components/Elements/Dropzone/Dropzone.tsx
@@ -6,16 +6,16 @@ import { useAccount } from 'wagmi'
 import buffer from 'buffer'
 
 import config from '@/config'
-import { useTranslation } from 'react-i18next'
 import { Image } from '../Image/Image'
 
 type DropzoneType = {
   dropZoneActions: {
-    setHideImageInput: (hide: boolean) => void
+    setHideImageInput?: (hide: boolean) => void
     setImage: (name: string, f: ArrayBuffer) => void
-    deleteImage: () => void
-    isToResetImage: boolean
-    initialImage: string | undefined
+    deleteImage?: () => void
+    isToResetImage?: boolean
+    initialImage?: string | undefined
+    showFetchedImage: boolean
   }
 }
 
@@ -28,6 +28,7 @@ const Dropzone = ({ dropZoneActions }: DropzoneType) => {
     setImage,
     deleteImage,
     initialImage,
+    showFetchedImage,
   } = dropZoneActions
 
   const onDrop = useCallback(
@@ -44,7 +45,9 @@ const Dropzone = ({ dropZoneActions }: DropzoneType) => {
 
         reader.readAsArrayBuffer(f)
       })
-      setHideImageInput(true)
+      if (setHideImageInput) {
+        setHideImageInput(true)
+      }
     },
     [setPaths, setHideImageInput, setImage],
   )
@@ -58,23 +61,26 @@ const Dropzone = ({ dropZoneActions }: DropzoneType) => {
   useEffect(() => {
     if (initialImage) {
       const path = `${config.pinataBaseUrl}${initialImage}`
-      setHideImageInput(true)
+      if (setHideImageInput) {
+        setHideImageInput(true)
+      }
       setPaths([path])
     }
   }, [initialImage, setHideImageInput])
 
   useEffect(() => {
     if (isToResetImage) {
-      deleteImage()
-      setHideImageInput(false)
+      if (deleteImage && setHideImageInput) {
+        deleteImage()
+        setHideImageInput(false)
+      }
       setPaths([])
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isToResetImage, setHideImageInput])
-  const { t } = useTranslation()
   return (
     <Box>
-      {paths.length === 0 ? (
+      {paths.length === 0 || !showFetchedImage ? (
         <Box
           display="flex"
           padding="10px"
@@ -96,43 +102,54 @@ const Dropzone = ({ dropZoneActions }: DropzoneType) => {
           {isDragActive ? (
             <Text textAlign="center">Drop the files here ...</Text>
           ) : (
-            <Text textAlign="center" opacity="0.5" maxW="xs">
-              {`${t('dragMainImgLabel')}`}
-            </Text>
+            <Box px="8">
+              <Text textAlign="center" opacity="0.5">
+                Drag and drop a <b>main image</b>, or click to select.
+              </Text>
+              <Text textAlign="center" opacity="0.5" fontWeight="bold">
+                (10mb max)
+              </Text>
+            </Box>
           )}
         </Box>
       ) : (
-        <Flex direction="column" w="full" h="full" justify="center">
-          {paths.map(path => (
-            <Image
-              mx="auto"
-              priority
-              h="255px"
-              w="full"
-              borderRadius={4}
-              overflow="hidden"
-              key={path}
-              src={path}
-              alt="highlight"
-            />
-          ))}
-          <Button
-            w="25%"
-            fontWeight="bold"
-            fontSize="20px"
-            m="auto"
-            mt="5px"
-            shadow="md"
-            bg="red.400"
-            onClick={() => {
-              setPaths([])
-              setHideImageInput(false)
-              deleteImage()
-            }}
-          >
-            <RiCloseLine />
-          </Button>
-        </Flex>
+        <>
+          {showFetchedImage && (
+            <Flex direction="column" w="full" h="full" justify="center">
+              {paths.map(path => (
+                <Image
+                  mx="auto"
+                  priority
+                  h="255px"
+                  w="full"
+                  borderRadius={4}
+                  overflow="hidden"
+                  key={path}
+                  src={path}
+                  alt="highlight"
+                />
+              ))}
+              <Button
+                w="25%"
+                fontWeight="bold"
+                fontSize="20px"
+                m="auto"
+                mt="5px"
+                shadow="md"
+                bg="red.400"
+                onClick={() => {
+                  setPaths([])
+                  if (setHideImageInput && deleteImage) {
+                    setHideImageInput(false)
+                    deleteImage()
+                  }
+                }}
+              >
+                <RiCloseLine />
+              </Button>
+            </Flex>
+          )}
+        </>
       )}
     </Box>
   )

--- a/src/components/Elements/ImageInput/ImageInput.tsx
+++ b/src/components/Elements/ImageInput/ImageInput.tsx
@@ -45,7 +45,7 @@ const ImageInput = ({
       }
       const data = await response.arrayBuffer()
       setImage(event.target.value, new buffer.Buffer(data as Buffer))
-      if(!showFetchedImage){
+      if (!showFetchedImage) {
         setImageSrc('')
       }
       toast({

--- a/src/components/Elements/ImageInput/ImageInput.tsx
+++ b/src/components/Elements/ImageInput/ImageInput.tsx
@@ -23,6 +23,7 @@ const ImageInput = ({
     event: ChangeEvent<HTMLInputElement>,
   ) => {
     setImageSrc(event.target.value)
+
     if (setHideDropzone) {
       setHideDropzone(true)
     }
@@ -44,6 +45,9 @@ const ImageInput = ({
       }
       const data = await response.arrayBuffer()
       setImage(event.target.value, new buffer.Buffer(data as Buffer))
+      if(!showFetchedImage){
+        setImageSrc('')
+      }
       toast({
         title: 'Image successfully Fetched',
         status: 'success',
@@ -101,6 +105,7 @@ const ImageInput = ({
         <Input
           w="90%"
           textAlign="center"
+          value={imgSrc}
           onChange={handleOnImageInputChanges}
           placeholder={`${t('pasteMainImgLabel')}`}
         />

--- a/src/components/Elements/ImageInput/ImageInput.tsx
+++ b/src/components/Elements/ImageInput/ImageInput.tsx
@@ -4,15 +4,17 @@ import buffer from 'buffer'
 import { useTranslation } from 'react-i18next'
 
 type ImageInputType = {
-  setHideDropzone: (hide: boolean) => void
+  setHideDropzone?: (hide: boolean) => void
   setImage: (name: string, f: ArrayBuffer) => void
-  deleteImage: () => void
+  deleteImage?: () => void
+  showFetchedImage: boolean
 }
 
 const ImageInput = ({
   setHideDropzone,
   setImage,
   deleteImage,
+  showFetchedImage,
 }: ImageInputType) => {
   const [imgSrc, setImageSrc] = useState<string>()
   const toast = useToast()
@@ -21,7 +23,9 @@ const ImageInput = ({
     event: ChangeEvent<HTMLInputElement>,
   ) => {
     setImageSrc(event.target.value)
-    setHideDropzone(true)
+    if (setHideDropzone) {
+      setHideDropzone(true)
+    }
     try {
       const response = await fetch(
         `https://images.weserv.nl/?url=${event.target.value}`,
@@ -30,8 +34,15 @@ const ImageInput = ({
           headers: {},
         },
       )
+      if (response.status !== 200) {
+        toast({
+          title: 'Image could not be fetched. Ensure you have the right link',
+          status: 'error',
+          duration: 2000,
+        })
+        return
+      }
       const data = await response.arrayBuffer()
-
       setImage(event.target.value, new buffer.Buffer(data as Buffer))
       toast({
         title: 'Image successfully Fetched',
@@ -45,18 +56,17 @@ const ImageInput = ({
         duration: 2000,
       })
     }
-    return null
   }
   const { t } = useTranslation()
   return (
     <Flex
-      mt={imgSrc ? 0 : -20}
+      mt={imgSrc && showFetchedImage ? 0 : -20}
       mb={5}
       direction="column"
       justifyContent="center"
       alignItems="center"
     >
-      {imgSrc ? (
+      {imgSrc && showFetchedImage ? (
         <Flex
           direction="column"
           justifyContent="center"
@@ -78,8 +88,10 @@ const ImageInput = ({
             bg="red.400"
             onClick={() => {
               setImageSrc(undefined)
-              setHideDropzone(false)
-              deleteImage()
+              if (deleteImage && setHideDropzone) {
+                setHideDropzone(false)
+                deleteImage()
+              }
             }}
           >
             Clear

--- a/src/components/Layout/Editor/Highlights/Highlights.tsx
+++ b/src/components/Layout/Editor/Highlights/Highlights.tsx
@@ -56,6 +56,7 @@ const Highlights = ({ initialImage, isToResetImage }: HightLightsType) => {
     isToResetImage,
     deleteImage: handleDeleteImage,
     initialImage,
+    showFetchedImage: true,
   }
   const { t } = useTranslation()
   return (
@@ -75,6 +76,7 @@ const Highlights = ({ initialImage, isToResetImage }: HightLightsType) => {
           setImage={handleSetImage}
           setHideDropzone={setHideDropzone}
           deleteImage={handleDeleteImage}
+          showFetchedImage
         />
       )}
       <VStack align="start" spacing={2}>

--- a/src/components/Layout/Editor/Highlights/Highlights.tsx
+++ b/src/components/Layout/Editor/Highlights/Highlights.tsx
@@ -57,6 +57,7 @@ const Highlights = ({ initialImage, isToResetImage }: HightLightsType) => {
     deleteImage: handleDeleteImage,
     initialImage,
     showFetchedImage: true,
+    textType: 'main image',
   }
   const { t } = useTranslation()
   return (

--- a/src/components/Layout/Editor/Highlights/MediaModal/MediaModal.tsx
+++ b/src/components/Layout/Editor/Highlights/MediaModal/MediaModal.tsx
@@ -120,7 +120,7 @@ const MediaModal = ({
         <Divider />
         <ModalBody>
           <Box mt="3">
-            <Text fontWeight="bold">Local Files</Text>
+            <Text fontWeight="bold">Uploads</Text>
             {wiki.media !== undefined && wiki.media?.length > 0 && (
               <Box
                 my={4}

--- a/src/components/Layout/Editor/Highlights/MediaModal/MediaModal.tsx
+++ b/src/components/Layout/Editor/Highlights/MediaModal/MediaModal.tsx
@@ -156,11 +156,11 @@ const MediaModal = ({
                         )}
                       </Box>
                       <VStack>
-                        <Flex w="full" gap={16}>
+                        <Flex w="full" >
                           {media.name && (
                             <Box flex="1">
                               <Text fontSize="sm">
-                                {shortenText(media.name, 8)}
+                                {shortenText(media.name, 15)}
                               </Text>
                             </Box>
                           )}

--- a/src/components/Layout/Editor/Highlights/MediaModal/MediaModal.tsx
+++ b/src/components/Layout/Editor/Highlights/MediaModal/MediaModal.tsx
@@ -61,9 +61,10 @@ const MediaModal = ({
   }
 
   const handleSetImage = (name: string, value: ArrayBuffer) => {
-    if(wiki.media !== undefined && wiki.media?.length >= 8){
+    if (wiki.media !== undefined && wiki.media?.length >= 8) {
       toast({
-        title: 'You cannot upload more than 8 media. You can delete some existing media to create more spaces',
+        title:
+          'You cannot upload more than 8 media. You can delete some existing media to create more spaces',
         status: 'error',
         duration: 3000,
       })
@@ -135,7 +136,6 @@ const MediaModal = ({
                   columns={{ base: 1, md: 2 }}
                   spacingY={6}
                   spacingX={12}
-                  
                 >
                   {wiki.media.map(media => (
                     <Flex key={media.id} gap={4} color="linkColor">
@@ -155,7 +155,7 @@ const MediaModal = ({
                           <RiImageLine size="40" />
                         )}
                       </Box>
-                      <VStack >
+                      <VStack>
                         <Flex w="full" gap={16}>
                           {media.name && (
                             <Box flex="1">

--- a/src/components/Layout/Editor/Highlights/MediaModal/MediaModal.tsx
+++ b/src/components/Layout/Editor/Highlights/MediaModal/MediaModal.tsx
@@ -156,7 +156,7 @@ const MediaModal = ({
                         )}
                       </Box>
                       <VStack>
-                        <Flex w="full" >
+                        <Flex w="full">
                           {media.name && (
                             <Box flex="1">
                               <Text fontSize="sm">

--- a/src/components/Layout/Editor/Highlights/MediaModal/MediaModal.tsx
+++ b/src/components/Layout/Editor/Highlights/MediaModal/MediaModal.tsx
@@ -128,7 +128,7 @@ const MediaModal = ({
                 justifyContent={{ base: 'center', md: 'left' }}
                 maxH="162px"
                 border="1px solid #CBD5E0"
-                p={6}
+                p={5}
                 borderRadius={8}
                 overflow="auto"
               >

--- a/src/components/Layout/Editor/Highlights/MediaModal/MediaModal.tsx
+++ b/src/components/Layout/Editor/Highlights/MediaModal/MediaModal.tsx
@@ -61,6 +61,14 @@ const MediaModal = ({
   }
 
   const handleSetImage = (name: string, value: ArrayBuffer) => {
+    if(wiki.media !== undefined && wiki.media?.length >= 8){
+      toast({
+        title: 'You cannot upload more than 8 media. You can delete some existing media to create more spaces',
+        status: 'error',
+        duration: 3000,
+      })
+      return
+    }
     const id = `${uuidv4()}_${MEDIA_POST_DEFAULT_ID}`
     const fileSize = value.byteLength / 1024 ** 2
     if (fileSize > 10) {
@@ -117,11 +125,17 @@ const MediaModal = ({
                 my={4}
                 display="flex"
                 justifyContent={{ base: 'center', md: 'left' }}
+                maxH="162px"
+                border="1px solid #CBD5E0"
+                p={6}
+                borderRadius={8}
+                overflow="auto"
               >
                 <SimpleGrid
                   columns={{ base: 1, md: 2 }}
-                  spacing={6}
+                  spacingY={6}
                   spacingX={12}
+                  
                 >
                   {wiki.media.map(media => (
                     <Flex key={media.id} gap={4} color="linkColor">
@@ -131,21 +145,24 @@ const MediaModal = ({
                             cursor="pointer"
                             flexShrink={0}
                             imageURL={constructMediaUrl(media)}
-                            h={{ base: '50px', lg: '60px' }}
-                            w={{ base: '50px', lg: '60px' }}
+                            h={{ base: '30px', lg: '40px' }}
+                            w={{ base: '30px', lg: '40px' }}
                             borderRadius="lg"
                             overflow="hidden"
+                            mt="1"
                           />
                         ) : (
-                          <RiImageLine size="50" />
+                          <RiImageLine size="40" />
                         )}
                       </Box>
-                      <VStack>
+                      <VStack >
                         <Flex w="full" gap={16}>
                           {media.name && (
-                            <Text fontSize="sm">
-                              {shortenText(media.name, 8)}
-                            </Text>
+                            <Box flex="1">
+                              <Text fontSize="sm">
+                                {shortenText(media.name, 8)}
+                              </Text>
+                            </Box>
                           )}
                           <Box mt={1}>
                             <RiCloseLine
@@ -159,7 +176,7 @@ const MediaModal = ({
                         <Box w="full">
                           <Progress
                             value={checkMediaDefaultId(media.id) ? 50 : 100}
-                            h="5px"
+                            h="3px"
                             colorScheme="green"
                             size="sm"
                           />

--- a/src/components/Layout/Editor/Highlights/MediaModal/MediaModal.tsx
+++ b/src/components/Layout/Editor/Highlights/MediaModal/MediaModal.tsx
@@ -86,6 +86,7 @@ const MediaModal = ({
   const dropZoneActions = {
     setImage: handleSetImage,
     showFetchedImage: false,
+    textType: 'image or video',
   }
 
   return isOpen ? (


### PR DESCRIPTION
# Media upload improvement

_Redesign the media upload modal following the new design on the Figma page.

## How should this be tested?

1. go to the create wiki page
2. click on the new image or video button
3. You should have two options (Drag and drop & upload a link)  through which you can upload your media

Before
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/70170061/172375868-ae8948c7-d556-49e4-9190-c3d3f84670ea.png">

After
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/70170061/172375965-d6902eea-6354-42d9-b4ca-c253b9e48151.png">


fixes https://github.com/EveripediaNetwork/issues/issues/390
