### PR TITLE
Fixed the categories wiki problem

### DIFF
--- a/src/components/Layout/Editor/Highlights/HighlightsModal/HighlightsModal.tsx
+++ b/src/components/Layout/Editor/Highlights/HighlightsModal/HighlightsModal.tsx
@@ -199,7 +199,7 @@ const HighlightsModal = ({
                 }
               >
                 {categoryOptions?.map(o => (
-                  <option key={o.title}>{o.title}</option>
+                  <option key={o.id}>{o.id}</option>
                 ))}
               </Select>
             </Flex>


### PR DESCRIPTION
#Fixed the categories wiki problem

_Solves the categories problem of a wiki not being in the category it was specified to be in

## How should this be tested?
wikis can be created under defi category and it would be seen under the defi category when decentralised finance is clicked on the homepage

1.before
![image](https://user-images.githubusercontent.com/75235148/172619927-1c84ae3e-055a-4470-b4d2-59182588043b.png)
![image](https://user-images.githubusercontent.com/75235148/172619978-9485f536-696e-4b26-b841-38c3fbcf53c0.png)

2. Now
![Screenshot (236)](https://user-images.githubusercontent.com/75235148/172619716-0665c202-1c70-4b99-a01e-1037717474f7.png)
![Screenshot (237)](https://user-images.githubusercontent.com/75235148/172619738-1267516d-ad6f-4404-abe3-21a95f94fa76.png)
![Screenshot (238)](https://user-images.githubusercontent.com/75235148/172619749-1f55911c-33a5-43f8-afc9-bb0bfc63249b.png)




closes https://github.com/EveripediaNetwork/issues/issues/406
