### PR TITLE
fixed editor unordered list having list type none

### DIFF
--- a/src/pages/static/assets/global.css
+++ b/src/pages/static/assets/global.css
@@ -124,6 +124,9 @@ html {
 :where(.toastui-editor-contents h4) {
   font-size: 16px;
 }
+.toastui-editor-contents ul {
+  list-style-type: disc !important;
+}
 .toastui-editor-contents li {
   list-style-type: unset !important;
 }


### PR DESCRIPTION
Fixes unordered lists are not showing discs at start