### PR TITLE
Disable Buttons on undefined wikis. 

### DIFF
--- a/src/components/Wiki/WikiPage/WikiActionBar.tsx
+++ b/src/components/Wiki/WikiPage/WikiActionBar.tsx
@@ -62,17 +62,26 @@ const WikiActionBar = ({ wiki }: WikiActionBarProps) => {
       >
         {actionBarItems.map((item, index) => (
           <VStack
-            cursor={item.isDisabled ? 'not-allowed' : 'pointer'}
+            cursor={
+              item.isDisabled || wiki === undefined ? 'not-allowed' : 'pointer'
+            }
             color={
               // eslint-disable-next-line no-nested-ternary
               item.isActive
                 ? 'brand.600'
-                : item.isDisabled
+                : // eslint-disable-next-line no-nested-ternary
+                item.isDisabled
+                ? 'wikiActionBtnDisabled'
+                : wiki === undefined
                 ? 'wikiActionBtnDisabled'
                 : 'unset'
             }
             key={index}
-            onClick={!item.isDisabled ? item.handleClick : undefined}
+            onClick={
+              !item.isDisabled && wiki !== undefined
+                ? item.handleClick
+                : undefined
+            }
           >
             <Icon fontSize={{ base: '16px', sm: '20px' }} as={item.icon} />
             <Text fontSize={{ base: '12px', sm: '14px' }}>{item.label}</Text>


### PR DESCRIPTION
This PR disable buttons on undefined/invalid wikis. Previously the Edit and History button were having active colors and were clickable- now they no longer clickable and have the default disabled colors. 

![image](https://user-images.githubusercontent.com/30846348/174048545-a9650d89-027a-40bb-8d2f-ea5a6f63d8f8.png)
 Now 

![image](https://user-images.githubusercontent.com/30846348/174048098-78e6464c-e1ff-4eb1-9e09-552c0466c392.png)
Before

closes #424, closes #424, closes https://github.com/EveripediaNetwork/issues/issues/424
