### PR TITLE
Refactors and Fixes Wiki and Revision pages

### DIFF
--- a/src/components/Wiki/WikiPage/InsightComponents/RelatedMedia.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/RelatedMedia.tsx
@@ -5,7 +5,8 @@ import { Media } from '@/types/Wiki'
 import { constructMediaUrl } from '@/utils/mediaUtils'
 import WikiAccordion from '../../WikiAccordion'
 
-const RelatedMediaGrid = ({ media }: { media: Media[] }) => {
+const RelatedMediaGrid = ({ media }: { media?: Media[] }) => {
+  if (!media || media.length === 0) return null
   return (
     <VStack w="100%" spacing={4} borderRadius={2}>
       <WikiAccordion title="Media">

--- a/src/components/Wiki/WikiPage/WikiInsights.tsx
+++ b/src/components/Wiki/WikiPage/WikiInsights.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react'
-import { Flex, VStack } from '@chakra-ui/react'
+import { Box, Flex, VStack } from '@chakra-ui/react'
 import { CommonMetaIds, EditSpecificMetaIds, Wiki } from '@/types/Wiki'
 import { getWikiImageUrl } from '@/utils/getWikiImageUrl'
 import { TokenStats } from '@/services/token-stats'
 import { fetchTokenStats, getTokenFromURI } from '@/services/token-stats/utils'
-import ReactStickyBox from 'react-sticky-box'
+import { useStickyBox } from 'react-sticky-box'
 import { WikiDetails } from './InsightComponents/WikiDetails'
 import { RelatedWikis } from './InsightComponents/RelatedWikis'
 import ProfileStatistics from './InsightComponents/ProfileStatistics'
@@ -21,6 +21,7 @@ interface WikiInsightsProps {
 }
 
 const WikiInsights = ({ wiki, ipfs, dateTime }: WikiInsightsProps) => {
+  const stickyRef = useStickyBox({ offsetTop: 20, offsetBottom: 20 })
   const coingeckoLink = wiki.metadata.find(
     meta => meta.id === CommonMetaIds.COINGECKO_PROFILE,
   )?.value
@@ -52,7 +53,7 @@ const WikiInsights = ({ wiki, ipfs, dateTime }: WikiInsightsProps) => {
       p={4}
       pt={{ md: '24', base: '10' }}
     >
-      <ReactStickyBox offsetTop={100} offsetBottom={20}>
+      <Box as="aside" ref={stickyRef} w="100%">
         <VStack spacing={4}>
           <WikiDetails
             wikiTitle={wiki}
@@ -97,7 +98,7 @@ const WikiInsights = ({ wiki, ipfs, dateTime }: WikiInsightsProps) => {
             )}
           </Flex>
         </VStack>
-      </ReactStickyBox>
+      </Box>
     </VStack>
   )
 }

--- a/src/components/Wiki/WikiPage/WikiInsights.tsx
+++ b/src/components/Wiki/WikiPage/WikiInsights.tsx
@@ -50,7 +50,7 @@ const WikiInsights = ({ wiki, ipfs, dateTime }: WikiInsightsProps) => {
       minW="min(380px, 90vw)"
       borderLeftWidth={{ base: 0, md: '1px' }}
       mx={{ base: 'auto', md: 0 }}
-      p={4}
+      p={{ base: 0, md: 4 }}
       pt={{ md: '24', base: '10' }}
     >
       <Box as="aside" ref={stickyRef} w="100%">

--- a/src/components/Wiki/WikiPage/WikiInsights.tsx
+++ b/src/components/Wiki/WikiPage/WikiInsights.tsx
@@ -21,7 +21,7 @@ interface WikiInsightsProps {
 }
 
 const WikiInsights = ({ wiki, ipfs, dateTime }: WikiInsightsProps) => {
-  const stickyRef = useStickyBox({ offsetTop: 20, offsetBottom: 20 })
+  const stickyRef = useStickyBox({ offsetTop: 100, offsetBottom: 20 })
   const coingeckoLink = wiki.metadata.find(
     meta => meta.id === CommonMetaIds.COINGECKO_PROFILE,
   )?.value
@@ -46,9 +46,9 @@ const WikiInsights = ({ wiki, ipfs, dateTime }: WikiInsightsProps) => {
 
   return (
     <VStack
-      maxW="500px"
+      maxW="450px"
+      minW="min(380px, 90vw)"
       borderLeftWidth={{ base: 0, md: '1px' }}
-      w={{ base: '100%', md: '50%', lg: '40%', '2xl': '50%' }}
       mx={{ base: 'auto', md: 0 }}
       p={4}
       pt={{ md: '24', base: '10' }}

--- a/src/components/Wiki/WikiPage/WikiMainContent.tsx
+++ b/src/components/Wiki/WikiPage/WikiMainContent.tsx
@@ -45,8 +45,9 @@ const WikiMainContent = ({ wiki, editedTimestamp }: WikiMainContentProps) => {
 
   return (
     <Box
-      p={4}
-      w={{ base: '100%', lg: '50%', '2xl': '62%', md: '45%' }}
+      py={4}
+      px={{ base: 4, lg: 14 }}
+      maxW="900px"
       mx="auto"
       minH={{ base: 'unset', md: 'calc(100vh - 70px)' }}
       borderColor="borderColor"

--- a/src/components/Wiki/WikiPage/WikiMainContent.tsx
+++ b/src/components/Wiki/WikiPage/WikiMainContent.tsx
@@ -11,7 +11,6 @@ import { customLinkRenderer } from '@/utils/customLinkRender'
 interface WikiMainContentProps {
   wiki: Wiki | undefined
   editedTimestamp?: string
-  mobileView: boolean
 }
 const MarkdownRender = React.memo(
   ({ wikiContent }: { wikiContent?: string }) => {
@@ -41,11 +40,7 @@ const MarkdownRender = React.memo(
   },
 )
 
-const WikiMainContent = ({
-  wiki,
-  editedTimestamp,
-  mobileView,
-}: WikiMainContentProps) => {
+const WikiMainContent = ({ wiki, editedTimestamp }: WikiMainContentProps) => {
   const { colorMode } = useColorMode()
 
   return (
@@ -55,14 +50,14 @@ const WikiMainContent = ({
       mx="auto"
       minH={{ base: 'unset', md: 'calc(100vh - 70px)' }}
       borderColor="borderColor"
-      mb={mobileView ? '0rem' : '3rem'}
+      mb={{ base: '0rem', md: '3rem' }}
     >
       <Flex
         mt={22}
         flexDir={{ base: 'column', md: 'row' }}
         gap={2}
         align="center"
-        display={mobileView ? 'none' : 'block'}
+        display={{ base: 'none', md: 'block' }}
       >
         <Heading mb={8}>{wiki?.title}</Heading>
         {editedTimestamp && (

--- a/src/components/Wiki/WikiPage/WikiMainContent.tsx
+++ b/src/components/Wiki/WikiPage/WikiMainContent.tsx
@@ -51,7 +51,7 @@ const WikiMainContent = ({ wiki, editedTimestamp }: WikiMainContentProps) => {
       mx="auto"
       minH={{ base: 'unset', md: 'calc(100vh - 70px)' }}
       borderColor="borderColor"
-      mb={{ base: '0rem', md: '3rem' }}
+      mb={{ md: '3rem' }}
     >
       <Flex
         mt={22}

--- a/src/components/Wiki/WikiPage/WikiMainContent.tsx
+++ b/src/components/Wiki/WikiPage/WikiMainContent.tsx
@@ -1,6 +1,5 @@
 import { Wiki } from '@/types/Wiki'
-import { getReadableDate } from '@/utils/getFormattedDate'
-import { Box, Flex, Heading, Tag, useColorMode } from '@chakra-ui/react'
+import { Box, Heading, useColorMode } from '@chakra-ui/react'
 import React from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -10,7 +9,6 @@ import { customLinkRenderer } from '@/utils/customLinkRender'
 
 interface WikiMainContentProps {
   wiki: Wiki | undefined
-  editedTimestamp?: string
 }
 const MarkdownRender = React.memo(
   ({ wikiContent }: { wikiContent?: string }) => {
@@ -40,7 +38,7 @@ const MarkdownRender = React.memo(
   },
 )
 
-const WikiMainContent = ({ wiki, editedTimestamp }: WikiMainContentProps) => {
+const WikiMainContent = ({ wiki }: WikiMainContentProps) => {
   const { colorMode } = useColorMode()
 
   return (
@@ -53,20 +51,7 @@ const WikiMainContent = ({ wiki, editedTimestamp }: WikiMainContentProps) => {
       borderColor="borderColor"
       mb={{ md: '3rem' }}
     >
-      <Flex
-        mt={22}
-        flexDir={{ base: 'column', md: 'row' }}
-        gap={2}
-        align="center"
-        display={{ base: 'none', md: 'block' }}
-      >
-        <Heading mb={8}>{wiki?.title}</Heading>
-        {editedTimestamp && (
-          <Tag whiteSpace="nowrap">
-            Edited {getReadableDate(editedTimestamp)}
-          </Tag>
-        )}
-      </Flex>
+      <Heading my={8}>{wiki?.title}</Heading>
       <Box
         className={`markdown-body ${
           colorMode === 'dark' ? 'markdown-body-dark' : ''

--- a/src/components/Wiki/WikiPage/WikiMarkup.tsx
+++ b/src/components/Wiki/WikiPage/WikiMarkup.tsx
@@ -28,12 +28,11 @@ const MobileMeta = (wiki: {
   )?.value
 
   return (
-    <Flex
+    <chakra.div
       p={4}
       mx={{ base: 'auto', md: 0 }}
       w={{ base: '100%', md: '50%', lg: '40%', '2xl': '50%' }}
       display={{ base: 'block', lg: 'none' }}
-      flexDirection="row"
     >
       {!!twitterLink && <TwitterTimeline url={twitterLink} />}
       {categories?.length !== 0 && <RelatedWikis categories={categories} />}

--- a/src/components/Wiki/WikiPage/WikiMarkup.tsx
+++ b/src/components/Wiki/WikiPage/WikiMarkup.tsx
@@ -77,7 +77,7 @@ export const WikiMarkup = ({ wiki, isTocEmpty }: WikiLayoutProps) => {
                 {wiki?.title}
               </Heading>
             </Flex>
-            <Flex
+            <chakra.div
               display={{
                 base: 'block',
                 md: 'none',

--- a/src/components/Wiki/WikiPage/WikiMarkup.tsx
+++ b/src/components/Wiki/WikiPage/WikiMarkup.tsx
@@ -1,6 +1,6 @@
 import { BaseCategory, CommonMetaIds, Media, Wiki } from '@/types/Wiki'
 import { getWikiMetadataById } from '@/utils/getWikiFields'
-import { Box, Flex, Heading, HStack } from '@chakra-ui/react'
+import { Box, Flex, Heading, HStack, chakra } from '@chakra-ui/react'
 import React from 'react'
 import WikiNotFound from '../WIkiNotFound/WikiNotFound'
 import RelatedMediaGrid from './InsightComponents/RelatedMedia'
@@ -37,7 +37,7 @@ const MobileMeta = (wiki: {
       {!!twitterLink && <TwitterTimeline url={twitterLink} />}
       {categories?.length !== 0 && <RelatedWikis categories={categories} />}
       {media && media.length > 0 && <RelatedMediaGrid media={media} />}
-    </Flex>
+    </chakra.div>
   )
 }
 
@@ -88,7 +88,7 @@ export const WikiMarkup = ({ wiki, isTocEmpty }: WikiLayoutProps) => {
                 categories={wiki.categories}
                 media={wiki.media}
               />
-            </Flex>
+            </chakra.div>
             <WikiReferences
               references={JSON.parse(
                 getWikiMetadataById(wiki, CommonMetaIds.REFERENCES)?.value ||

--- a/src/components/Wiki/WikiPage/WikiMarkup.tsx
+++ b/src/components/Wiki/WikiPage/WikiMarkup.tsx
@@ -1,0 +1,109 @@
+import { BaseCategory, CommonMetaIds, Media, Wiki } from '@/types/Wiki'
+import { getWikiMetadataById } from '@/utils/getWikiFields'
+import { Box, Flex, Heading, HStack } from '@chakra-ui/react'
+import React from 'react'
+import WikiNotFound from '../WIkiNotFound/WikiNotFound'
+import RelatedMediaGrid from './InsightComponents/RelatedMedia'
+import { RelatedWikis } from './InsightComponents/RelatedWikis'
+import TwitterTimeline from './InsightComponents/TwitterTimeline'
+import WikiActionBar from './WikiActionBar'
+import WikiInsights from './WikiInsights'
+import WikiMainContent from './WikiMainContent'
+import WikiReferences from './WikiReferences'
+import WikiTableOfContents from './WikiTableOfContents'
+
+interface WikiLayoutProps {
+  wiki?: Wiki
+  isTocEmpty: boolean
+}
+
+const MobileMeta = (wiki: {
+  metadata: { id: string; value: string }[]
+  categories: BaseCategory[]
+  media?: Media[]
+}) => {
+  const { metadata, categories, media } = wiki
+  const twitterLink = metadata.find(
+    meta => meta.id === CommonMetaIds.TWITTER_PROFILE,
+  )?.value
+
+  return (
+    <Flex
+      p={4}
+      mx={{ base: 'auto', md: 0 }}
+      w={{ base: '100%', md: '50%', lg: '40%', '2xl': '50%' }}
+      display={{ base: 'block', lg: 'none' }}
+      flexDirection="row"
+    >
+      {!!twitterLink && <TwitterTimeline url={twitterLink} />}
+      {categories?.length !== 0 && <RelatedWikis categories={categories} />}
+      {media && media.length > 0 && <RelatedMediaGrid media={media} />}
+    </Flex>
+  )
+}
+
+export const WikiMarkup = ({ wiki, isTocEmpty }: WikiLayoutProps) => {
+  return (
+    <HStack align="stretch" justify="stretch">
+      <Flex
+        w="100%"
+        justify="space-between"
+        direction={{
+          base: 'column',
+          md: 'row',
+        }}
+      >
+        <WikiActionBar wiki={wiki} />
+        {wiki ? (
+          <Box w="100%">
+            <Flex
+              w="100%"
+              justify="space-between"
+              direction={{
+                base: 'column-reverse',
+                md: 'row',
+              }}
+            >
+              <WikiMainContent wiki={wiki} />
+              <WikiInsights wiki={wiki} />
+              <Heading
+                mt={8}
+                mb={-4}
+                display={{
+                  base: 'block',
+                  md: 'none',
+                }}
+                textAlign="center"
+                px={4}
+              >
+                {wiki?.title}
+              </Heading>
+            </Flex>
+            <RelatedMediaGrid media={wiki.media} />
+            <Flex
+              display={{
+                base: 'block',
+                md: 'none',
+              }}
+            >
+              <MobileMeta
+                metadata={wiki.metadata}
+                categories={wiki.categories}
+                media={wiki.media}
+              />
+            </Flex>
+            <WikiReferences
+              references={JSON.parse(
+                getWikiMetadataById(wiki, CommonMetaIds.REFERENCES)?.value ||
+                  '[]',
+              )}
+            />
+          </Box>
+        ) : (
+          <WikiNotFound />
+        )}
+      </Flex>
+      {!isTocEmpty && <WikiTableOfContents />}
+    </HStack>
+  )
+}

--- a/src/components/Wiki/WikiPage/WikiMarkup.tsx
+++ b/src/components/Wiki/WikiPage/WikiMarkup.tsx
@@ -79,7 +79,6 @@ export const WikiMarkup = ({ wiki, isTocEmpty }: WikiLayoutProps) => {
                 {wiki?.title}
               </Heading>
             </Flex>
-            <RelatedMediaGrid media={wiki.media} />
             <Flex
               display={{
                 base: 'block',

--- a/src/components/Wiki/WikiPage/WikiMarkup.tsx
+++ b/src/components/Wiki/WikiPage/WikiMarkup.tsx
@@ -69,7 +69,6 @@ export const WikiMarkup = ({ wiki, isTocEmpty }: WikiLayoutProps) => {
                 mt={8}
                 mb={-4}
                 display={{
-                  base: 'block',
                   md: 'none',
                 }}
                 textAlign="center"

--- a/src/pages/revision/[id].tsx
+++ b/src/pages/revision/[id].tsx
@@ -3,20 +3,7 @@ import { useRouter } from 'next/router'
 import { skipToken } from '@reduxjs/toolkit/query'
 import { store } from '@/store/store'
 import { GetServerSideProps } from 'next'
-import {
-  HStack,
-  Flex,
-  Spinner,
-  Text,
-  Button,
-  Box,
-  Heading,
-} from '@chakra-ui/react'
-import WikiActionBar from '@/components/Wiki/WikiPage/WikiActionBar'
-import WikiMainContent from '@/components/Wiki/WikiPage/WikiMainContent'
-import WikiInsights from '@/components/Wiki/WikiPage/WikiInsights'
-import WikiTableOfContents from '@/components/Wiki/WikiPage/WikiTableOfContents'
-import WikiNotFound from '@/components/Wiki/WIkiNotFound/WikiNotFound'
+import { Flex, Spinner, Text, Button, Box } from '@chakra-ui/react'
 import {
   getActivityById,
   getLatestIPFSByWiki,
@@ -25,41 +12,11 @@ import {
   getRunningOperationPromises,
 } from '@/services/activities'
 import Link from 'next/link'
-import WikiReferences from '@/components/Wiki/WikiPage/WikiReferences'
-import { getWikiMetadataById } from '@/utils/getWikiFields'
-import { BaseCategory, CommonMetaIds, Media } from '@/types/Wiki'
 import { useAppSelector } from '@/store/hook'
 import { WikiHeader } from '@/components/SEO/Wiki'
 import { getWikiSummary } from '@/utils/getWikiSummary'
 import { getWikiImageUrl } from '@/utils/getWikiImageUrl'
-import RelatedMediaGrid from '@/components/Wiki/WikiPage/InsightComponents/RelatedMedia'
-import { RelatedWikis } from '@/components/Wiki/WikiPage/InsightComponents/RelatedWikis'
-import TwitterTimeline from '@/components/Wiki/WikiPage/InsightComponents/TwitterTimeline'
-
-const MobileMeta = (wiki: {
-  metadata: { id: string; value: string }[]
-  categories: BaseCategory[]
-  media?: Media[]
-}) => {
-  const { metadata, categories, media } = wiki
-  const twitterLink = metadata.find(
-    meta => meta.id === CommonMetaIds.TWITTER_PROFILE,
-  )?.value
-
-  return (
-    <Flex
-      p={4}
-      mx={{ base: 'auto', md: 0 }}
-      w={{ base: '100%', md: '50%', lg: '40%', '2xl': '50%' }}
-      display={{ base: 'block', lg: 'none' }}
-      flexDirection="row"
-    >
-      {!!twitterLink && <TwitterTimeline url={twitterLink} />}
-      {categories?.length !== 0 && <RelatedWikis categories={categories} />}
-      {media && media.length > 0 && <RelatedMediaGrid media={media} />}
-    </Flex>
-  )
-}
+import { WikiMarkup } from '@/components/Wiki/WikiPage/WikiMarkup'
 
 const Revision = () => {
   const router = useRouter()
@@ -182,75 +139,7 @@ const Revision = () => {
                 </Link>
               </Flex>
             )}
-            <HStack m="0 !important" align="stretch" justify="stretch">
-              <Flex
-                w="100%"
-                justify="space-between"
-                direction={{ base: 'column', md: 'row' }}
-              >
-                <WikiActionBar wiki={wiki?.content[0]} />
-                {wiki ? (
-                  <Box w="full">
-                    <Flex
-                      display={{ lg: 'flex', base: 'none', md: 'flex' }}
-                      flexDirection={{
-                        base: 'column-reverse',
-                        lg: 'row',
-                        md: 'row',
-                      }}
-                    >
-                      <WikiMainContent
-                        wiki={wiki.content[0]}
-                        mobileView={false}
-                      />
-                      <WikiInsights
-                        dateTime={wiki.datetime}
-                        wiki={wiki.content[0]}
-                        ipfs={wiki.ipfs}
-                      />
-                    </Flex>
-                    <Flex
-                      display={{ lg: 'none', base: 'block', md: 'none' }}
-                      flexDirection={{
-                        base: 'column-reverse',
-                        lg: 'row',
-                      }}
-                    >
-                      <Heading mb={2} p={4}>
-                        {wiki.content[0]?.title}
-                      </Heading>
-                      <WikiInsights
-                        dateTime={wiki.datetime}
-                        wiki={wiki.content[0]}
-                        ipfs={wiki.ipfs}
-                      />
-                      <WikiMainContent wiki={wiki.content[0]} mobileView />
-                    </Flex>
-                    <Flex
-                      display={{ base: 'block', lg: 'none', md: 'none' }}
-                      flexDirection="column"
-                    >
-                      <MobileMeta
-                        metadata={wiki.content[0].metadata}
-                        categories={wiki.content[0].categories}
-                        media={wiki.content[0].media}
-                      />
-                    </Flex>
-                    <WikiReferences
-                      references={JSON.parse(
-                        getWikiMetadataById(
-                          wiki.content[0],
-                          CommonMetaIds.REFERENCES,
-                        )?.value || '[]',
-                      )}
-                    />
-                  </Box>
-                ) : (
-                  <WikiNotFound />
-                )}
-              </Flex>
-              {!isTocEmpty && <WikiTableOfContents isAlertAtTop={!isLatest} />}
-            </HStack>
+            <WikiMarkup wiki={wiki?.content[0]} isTocEmpty={isTocEmpty} />
           </Box>
         )}
       </main>

--- a/src/pages/wiki/[slug]/index.tsx
+++ b/src/pages/wiki/[slug]/index.tsx
@@ -122,52 +122,32 @@ const Wiki = () => {
             >
               <WikiActionBar wiki={wiki} />
               {wiki ? (
-                <Box>
+                <Box w="100%">
                   <Flex
                     w="100%"
                     justify="space-between"
-                    direction={{ base: 'column', md: 'row' }}
+                    direction={{ base: 'column-reverse', md: 'row' }}
                   >
-                    <Flex
-                      display={{ lg: 'flex', base: 'none', md: 'flex' }}
-                      flexDirection={{
-                        base: 'column-reverse',
-                        lg: 'row',
-                        md: 'row',
-                      }}
+                    <WikiMainContent wiki={wiki} />
+                    <WikiInsights wiki={wiki} />
+                    <Heading
+                      mt={8}
+                      mb={-4}
+                      display={{ base: 'block', md: 'none' }}
+                      textAlign="center"
+                      px={4}
                     >
-                      <WikiMainContent wiki={wiki} mobileView={false} />
-                      <WikiInsights wiki={wiki} />
-                    </Flex>
-                    <Flex
-                      display={{ lg: 'none', base: 'block', md: 'none' }}
-                      flexDirection={{
-                        base: 'column-reverse',
-                        lg: 'row',
-                        md: 'row',
-                      }}
-                    >
-                      <Heading mt={8} mb={-4} textAlign="center" px={4}>
-                        {wiki?.title}
-                      </Heading>
-                      <WikiInsights wiki={wiki} />
-                      <WikiMainContent wiki={wiki} mobileView />
-                    </Flex>
+                      {wiki?.title}
+                    </Heading>
                   </Flex>
-                  {wiki.media && wiki.media.length > 0 && (
-                    <RelatedMediaGrid media={wiki.media} />
-                  )}
-                  <Flex
-                    display={{ base: 'block', md: 'none' }}
-                    flexDirection="column"
-                  >
+                  <RelatedMediaGrid media={wiki.media} />
+                  <Flex display={{ base: 'block', md: 'none' }}>
                     <MobileMeta
                       metadata={wiki.metadata}
                       categories={wiki.categories}
                       media={wiki.media}
                     />
                   </Flex>
-
                   <WikiReferences
                     references={JSON.parse(
                       getWikiMetadataById(wiki, CommonMetaIds.REFERENCES)

--- a/src/pages/wiki/[slug]/index.tsx
+++ b/src/pages/wiki/[slug]/index.tsx
@@ -9,47 +9,12 @@ import {
 } from '@/services/wikis'
 import { store } from '@/store/store'
 import { GetServerSideProps } from 'next'
-import { HStack, Flex, Spinner, Box, Heading } from '@chakra-ui/react'
-import WikiActionBar from '@/components/Wiki/WikiPage/WikiActionBar'
-import WikiMainContent from '@/components/Wiki/WikiPage/WikiMainContent'
-import WikiInsights from '@/components/Wiki/WikiPage/WikiInsights'
-import WikiTableOfContents from '@/components/Wiki/WikiPage/WikiTableOfContents'
-import WikiNotFound from '@/components/Wiki/WIkiNotFound/WikiNotFound'
-import WikiReferences from '@/components/Wiki/WikiPage/WikiReferences'
-import { getWikiMetadataById } from '@/utils/getWikiFields'
-import { BaseCategory, CommonMetaIds, Media } from '@/types/Wiki'
+import { Box, Flex, Spinner } from '@chakra-ui/react'
 import { useAppSelector } from '@/store/hook'
 import { WikiHeader } from '@/components/SEO/Wiki'
 import { getWikiSummary } from '@/utils/getWikiSummary'
 import { getWikiImageUrl } from '@/utils/getWikiImageUrl'
-import RelatedMediaGrid from '@/components/Wiki/WikiPage/InsightComponents/RelatedMedia'
-import { RelatedWikis } from '@/components/Wiki/WikiPage/InsightComponents/RelatedWikis'
-import TwitterTimeline from '@/components/Wiki/WikiPage/InsightComponents/TwitterTimeline'
-
-const MobileMeta = (wiki: {
-  metadata: { id: string; value: string }[]
-  categories: BaseCategory[]
-  media?: Media[]
-}) => {
-  const { metadata, categories, media } = wiki
-  const twitterLink = metadata.find(
-    meta => meta.id === CommonMetaIds.TWITTER_PROFILE,
-  )?.value
-
-  return (
-    <Flex
-      p={4}
-      mx={{ base: 'auto', md: 0 }}
-      w={{ base: '100%', md: '50%', lg: '40%', '2xl': '50%' }}
-      display={{ base: 'block', lg: 'none' }}
-      flexDirection="row"
-    >
-      {!!twitterLink && <TwitterTimeline url={twitterLink} />}
-      {categories?.length !== 0 && <RelatedWikis categories={categories} />}
-      {media && media.length > 0 && <RelatedMediaGrid media={media} />}
-    </Flex>
-  )
-}
+import { WikiMarkup } from '@/components/Wiki/WikiPage/WikiMarkup'
 
 const Wiki = () => {
   const router = useRouter()
@@ -70,11 +35,6 @@ const Wiki = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isTocEmpty])
-
-  // here toc is not state variable since there seems to be some issue
-  // with in react-markdown that is causing infinite loop if toc is state variable
-  // (so using useEffect to update toc length for now)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
 
   const toc = useAppSelector(state => state.toc)
 
@@ -114,53 +74,9 @@ const Wiki = () => {
             <Spinner size="xl" />
           </Flex>
         ) : (
-          <HStack mt={-2} align="stretch" justify="stretch">
-            <Flex
-              w="100%"
-              justify="space-between"
-              direction={{ base: 'column', md: 'row' }}
-            >
-              <WikiActionBar wiki={wiki} />
-              {wiki ? (
-                <Box w="100%">
-                  <Flex
-                    w="100%"
-                    justify="space-between"
-                    direction={{ base: 'column-reverse', md: 'row' }}
-                  >
-                    <WikiMainContent wiki={wiki} />
-                    <WikiInsights wiki={wiki} />
-                    <Heading
-                      mt={8}
-                      mb={-4}
-                      display={{ base: 'block', md: 'none' }}
-                      textAlign="center"
-                      px={4}
-                    >
-                      {wiki?.title}
-                    </Heading>
-                  </Flex>
-                  <RelatedMediaGrid media={wiki.media} />
-                  <Flex display={{ base: 'block', md: 'none' }}>
-                    <MobileMeta
-                      metadata={wiki.metadata}
-                      categories={wiki.categories}
-                      media={wiki.media}
-                    />
-                  </Flex>
-                  <WikiReferences
-                    references={JSON.parse(
-                      getWikiMetadataById(wiki, CommonMetaIds.REFERENCES)
-                        ?.value || '[]',
-                    )}
-                  />
-                </Box>
-              ) : (
-                <WikiNotFound />
-              )}
-            </Flex>
-            {!isTocEmpty && <WikiTableOfContents />}
-          </HStack>
+          <Box mt={-2}>
+            <WikiMarkup wiki={wiki} isTocEmpty={isTocEmpty} />
+          </Box>
         )}
       </main>
     </>


### PR DESCRIPTION
Fixes https://github.com/EveripediaNetwork/issues/issues/431

# Changes
1. made wiki main content and insights bar to span all the way till actions bar which fixes content squeezing bug
2. refactored wiki page mobile view to make code dry
3. extracted wiki page structure to ```WikiMarkup``` component which is common to revision and wiki pages 
4. removed widths for wiki main content and insights bar and replaced it with paddings and min-max widths to make implementation simpler 