### PR TITLE
fixed the braines bg

### DIFF
--- a/src/components/Landing/CategoriesList.tsx
+++ b/src/components/Landing/CategoriesList.tsx
@@ -31,6 +31,7 @@ const CategoriesList = () => {
         fontWeight="semibold"
         fontSize="2xl"
         mb={0}
+        px={{ base: 6, lg: 20 }}
       >
         {`${t('browseCategory')}`}
       </Text>
@@ -41,6 +42,8 @@ const CategoriesList = () => {
         columns={[1, 2, 3]}
         spacingX={6}
         spacingY={12}
+        py={{ base: 6, lg: 0 }}
+        px={{ base: 6, lg: 0 }}
       >
         {categories.map(category => (
           <LinkBox

--- a/src/components/Landing/Hero.tsx
+++ b/src/components/Landing/Hero.tsx
@@ -107,6 +107,7 @@ export const Hero = ({ wiki }: HeroProps) => {
       justify="center"
       w={{ base: 'full', lg: '90vw', xl: 'min(90%, 1150px)' }}
       mx="auto"
+      px={{ base: 3, lg: 10 }}
     >
       <VStack
         alignItems={{ base: 'center', lg: 'start' }}

--- a/src/components/Landing/NotableDrops.tsx
+++ b/src/components/Landing/NotableDrops.tsx
@@ -128,7 +128,12 @@ export const NotableDrops = ({ drops = [] }: NotableDropsProps) => {
       direction="column"
       mt={{ base: '10', lg: '20' }}
       gap={10}
+      px={{ base: 6, lg: 20 }}
       align="center"
+      _dark={{
+        bgImage: '/images/homepage-bg-dark.png',
+      }}
+      bgImage="/images/homepage-bg-white.png"
     >
       <Text align="center" fontWeight="bold" fontSize="2xl">
         {`${t('trendingWIkis')}`}

--- a/src/components/Layout/Navbar/NavSearch/index.tsx
+++ b/src/components/Layout/Navbar/NavSearch/index.tsx
@@ -46,8 +46,6 @@ const ItemPaths = {
 
 const ARTICLES_LIMIT = 5
 const CATEGORIES_LIMIT = 2
-const ACTION_KEY_DEFAULT = ['Ctrl', 'Control']
-const ACTION_KEY_APPLE = ['⌘', 'Command']
 
 export const NavSearch = (props: NavSearchProps) => {
   const { inputGroupProps, inputProps, listProps } = props

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,13 +21,8 @@ export const Index: NextPage = () => {
       direction="column"
       mx="auto"
       w="full"
-      px={{ base: 6, lg: 20 }}
       py={{ base: 6, lg: 20 }}
       gap={10}
-      _dark={{
-        bgImage: '/images/homepage-bg-dark.png',
-      }}
-      bgImage="/images/homepage-bg-white.png"
     >
       <Hero wiki={wiki} />
       <NotableDrops drops={data} />


### PR DESCRIPTION
# Braines background in the right place

_this fixes and removes the branies bg from the whole page to only the trandeing section page

## How should this be tested?

1. Before
![Screenshot 2022-06-20 214131](https://user-images.githubusercontent.com/75235148/174675528-b3d786b4-5363-43de-ad41-4bbe0951bcca.png)


2.Now

![Screenshot 2022-06-20 214500](https://user-images.githubusercontent.com/75235148/174675578-576bd47a-5e18-46c4-ac2d-fa51217f30e0.png)



## Linked issues
 closes https://github.com/EveripediaNetwork/issues/issues/434
