### PR TITLE
Stop overflow in create wiki highlight bar. 

### DIFF
--- a/src/components/Layout/Editor/Highlights/Highlights.tsx
+++ b/src/components/Layout/Editor/Highlights/Highlights.tsx
@@ -77,7 +77,7 @@ const Highlights = ({ initialImage, isToResetImage }: HightLightsType) => {
       borderColor="borderColor"
       borderRadius="7px"
       padding="15px"
-      h="75vh"
+      h="auto"
     >
       <SummaryInput />
       {!hideDropzone && <Dropzone dropZoneActions={dropZoneActions} />}


### PR DESCRIPTION
The overflow was caused by us using a `vh` for the height of the bar: 

![image](https://user-images.githubusercontent.com/30846348/175280595-44e57f7a-20b2-48fd-8e94-c61b6e4fabcf.png)
Before 

![image](https://user-images.githubusercontent.com/30846348/175280755-5908db76-5442-4cb7-b5e8-1e79cd9b5b59.png)
After

## Linked issues

closes #441, closes #441, closes https://github.com/EveripediaNetwork/issues/issues/441
