### PR TITLE
Switch network mobile

### DIFF
--- a/src/components/Layout/Navbar/Navbar.tsx
+++ b/src/components/Layout/Navbar/Navbar.tsx
@@ -75,8 +75,6 @@ const Navbar = () => {
 
   const handleChainChanged = useCallback(
     (chainDetails: string) => {
-      console.log(`${isConnected} here it is`)
-
       if (chainDetails !== chainId && isConnected) {
         setOpenSwitch(true)
       }

--- a/src/components/Layout/Navbar/Navbar.tsx
+++ b/src/components/Layout/Navbar/Navbar.tsx
@@ -11,10 +11,9 @@ import {
 } from '@chakra-ui/react'
 import { CloseIcon, HamburgerIcon } from '@chakra-ui/icons'
 import { RiWallet2Line } from 'react-icons/ri'
-import { useAccount } from 'wagmi'
+import { useAccount, useConnect } from 'wagmi'
 import { useDispatch } from 'react-redux'
 import config from '@/config'
-
 import detectEthereumProvider from '@metamask/detect-provider'
 import Link from '@/components/Elements/Link/Link'
 import { Logo } from '@/components/Elements/'
@@ -54,6 +53,7 @@ const Navbar = () => {
     useState<ProviderDataType | null>(null)
 
   const { data: accountData } = useAccount()
+  const {isConnected} = useConnect()
 
   const dispatch = useDispatch()
 
@@ -75,11 +75,13 @@ const Navbar = () => {
 
   const handleChainChanged = useCallback(
     (chainDetails: string) => {
-      if (chainDetails !== chainId) {
+      console.log(isConnected +" here it is")
+
+      if (chainDetails !== chainId && isConnected) {
         setOpenSwitch(true)
       }
     },
-    [chainId],
+    [chainId, isConnected],
   )
 
   useEffect(() => {
@@ -104,10 +106,11 @@ const Navbar = () => {
       setDetectedProvider(provider as ProviderDataType)
       if (provider) getConnectedChain(provider)
     }
-
+    
     if (!detectedProvider) {
       getDetectedProvider()
     } else {
+      getConnectedChain(detectedProvider)
       detectedProvider.on('chainChanged', handleChainChanged)
     }
 
@@ -116,7 +119,7 @@ const Navbar = () => {
         detectedProvider.removeListener('chainChanged', handleChainChanged)
       }
     }
-  }, [detectedProvider, handleChainChanged, dispatch])
+  }, [detectedProvider, handleChainChanged, dispatch, isConnected])
 
   const handleSwitchNetwork = async () => {
     try {

--- a/src/components/Layout/Navbar/Navbar.tsx
+++ b/src/components/Layout/Navbar/Navbar.tsx
@@ -53,7 +53,7 @@ const Navbar = () => {
     useState<ProviderDataType | null>(null)
 
   const { data: accountData } = useAccount()
-  const {isConnected} = useConnect()
+  const { isConnected } = useConnect()
 
   const dispatch = useDispatch()
 
@@ -75,7 +75,7 @@ const Navbar = () => {
 
   const handleChainChanged = useCallback(
     (chainDetails: string) => {
-      console.log(isConnected +" here it is")
+      console.log(`${isConnected} here it is`)
 
       if (chainDetails !== chainId && isConnected) {
         setOpenSwitch(true)
@@ -106,7 +106,7 @@ const Navbar = () => {
       setDetectedProvider(provider as ProviderDataType)
       if (provider) getConnectedChain(provider)
     }
-    
+
     if (!detectedProvider) {
       getDetectedProvider()
     } else {


### PR DESCRIPTION
# Rework Switch network modal

_Switch network modal should come up when the user is logged in and not connected to the right chain id.

## How should this be tested?

1. logout and switch your Metamask network to something else. The switch network modal shouldn't come up because you are not logged in.
2. log in to your account ensuring you are on the wrong network. the switch network modal should come up because you are logged in but on the wrong network. By clicking on the switch network, you will be prompted to switch your network

## Linked issues

fixes https://github.com/EveripediaNetwork/issues/issues/452