### PR TITLE
Compact Highlights modal and Uniform Wiki image Aspect ratio

### DIFF
--- a/src/components/Elements/Dropzone/Dropzone.tsx
+++ b/src/components/Elements/Dropzone/Dropzone.tsx
@@ -1,5 +1,12 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { Box, Button, Flex, Text, useToast } from '@chakra-ui/react'
+import {
+  AspectRatio,
+  Box,
+  Button,
+  Flex,
+  Text,
+  useToast,
+} from '@chakra-ui/react'
 import { useDropzone } from 'react-dropzone'
 import { RiCloseLine } from 'react-icons/ri'
 import { useAccount } from 'wagmi'
@@ -108,62 +115,83 @@ const Dropzone = ({ dropZoneActions }: DropzoneType) => {
   return (
     <Box>
       {paths.length === 0 || !showFetchedImage ? (
-        <Box
-          display="flex"
-          padding="10px"
-          border="1px"
-          borderColor="borderColor"
-          borderStyle="dashed"
-          borderRadius="5px"
-          justifyContent="center"
-          alignItems="center"
-          maxH="345px"
-          minH={!showFetchedImage ? '165px' : '30vh'}
-          _hover={{
-            boxShadow: 'md',
-            borderColor: 'brand.400',
-          }}
-          {...getRootProps()}
-        >
-          <input disabled={!accountData?.address} {...getInputProps()} />
-          {isDragActive ? (
-            <Text textAlign="center">Drop the files here ...</Text>
-          ) : (
-            <Box px="8" mb={!showFetchedImage ? '10' : '1'}>
-              <Text textAlign="center" opacity="0.5">
-                Drag and drop a <b>{textType}</b>, or click to select.
-              </Text>
-              <Text textAlign="center" opacity="0.5" fontWeight="bold">
-                (10mb max)
-              </Text>
-            </Box>
-          )}
-        </Box>
+        <AspectRatio ratio={4 / 3}>
+          <Box
+            display="flex"
+            padding="10px"
+            border="1px"
+            borderColor="borderColor"
+            borderStyle="dashed"
+            borderRadius="5px"
+            justifyContent="center"
+            alignItems="center"
+            h="full"
+            _hover={{
+              boxShadow: 'md',
+              borderColor: 'brand.400',
+            }}
+            {...getRootProps()}
+          >
+            <input disabled={!accountData?.address} {...getInputProps()} />
+            {isDragActive ? (
+              <Text textAlign="center">Drop the files here ...</Text>
+            ) : (
+              <Box px="8" mb={!showFetchedImage ? '10' : '1'}>
+                <Text textAlign="center" opacity="0.5">
+                  Drag and drop a <b>{textType}</b>, or click to select.
+                </Text>
+                <Text textAlign="center" opacity="0.5" fontWeight="bold">
+                  (10mb max)
+                </Text>
+              </Box>
+            )}
+          </Box>
+        </AspectRatio>
       ) : (
         <>
           {showFetchedImage && (
-            <Flex direction="column" w="full" h="full" justify="center">
+            <Flex
+              pos="relative"
+              direction="column"
+              w="full"
+              h="full"
+              justify="center"
+            >
               {paths.map(path => (
-                <Image
-                  mx="auto"
-                  priority
-                  h="255px"
-                  w="full"
-                  borderRadius={4}
-                  overflow="hidden"
-                  key={path}
-                  src={path}
-                  alt="highlight"
-                />
+                <AspectRatio ratio={4 / 3}>
+                  <Image
+                    mx="auto"
+                    priority
+                    h="full"
+                    w="full"
+                    borderRadius={4}
+                    overflow="hidden"
+                    key={path}
+                    src={path}
+                    alt="highlight"
+                  />
+                </AspectRatio>
               ))}
               <Button
-                w="25%"
                 fontWeight="bold"
+                pos="absolute"
+                top="0"
+                right="0"
+                transform="translate(50%, -50%)"
+                borderRadius="full"
                 fontSize="20px"
-                m="auto"
-                mt="5px"
-                shadow="md"
+                p={0}
+                size="xs"
+                boxSize={7}
+                borderWidth="3px"
+                borderColor="chakra-body-bg"
                 bg="red.400"
+                sx={{
+                  '&:hover, &:focus, &:active': {
+                    bg: 'red.500',
+                    color: 'white',
+                  },
+                }}
                 onClick={() => {
                   setPaths([])
                   if (setHideImageInput && deleteImage) {

--- a/src/components/Elements/Dropzone/Dropzone.tsx
+++ b/src/components/Elements/Dropzone/Dropzone.tsx
@@ -1,19 +1,12 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import {
-  AspectRatio,
-  Box,
-  Button,
-  Flex,
-  Text,
-  useToast,
-} from '@chakra-ui/react'
+import { AspectRatio, Box, Text, useToast } from '@chakra-ui/react'
 import { useDropzone } from 'react-dropzone'
-import { RiCloseLine } from 'react-icons/ri'
 import { useAccount } from 'wagmi'
 
 import config from '@/config'
 import { getDraftFromLocalStorage } from '@/store/slices/wiki.slice'
 import { useDispatch } from 'react-redux'
+import { EditorMainImageWrapper } from '../Image/EditorMainImageWrapper'
 import { Image } from '../Image/Image'
 
 type DropzoneType = {
@@ -150,59 +143,26 @@ const Dropzone = ({ dropZoneActions }: DropzoneType) => {
       ) : (
         <>
           {showFetchedImage && (
-            <Flex
-              pos="relative"
-              direction="column"
-              w="full"
-              h="full"
-              justify="center"
+            <EditorMainImageWrapper
+              removeImage={() => {
+                setPaths([])
+                if (setHideImageInput && deleteImage) {
+                  setHideImageInput(false)
+                  deleteImage()
+                }
+              }}
             >
-              {paths.map(path => (
-                <AspectRatio ratio={4 / 3}>
-                  <Image
-                    mx="auto"
-                    priority
-                    h="full"
-                    w="full"
-                    borderRadius={4}
-                    overflow="hidden"
-                    key={path}
-                    src={path}
-                    alt="highlight"
-                  />
-                </AspectRatio>
-              ))}
-              <Button
-                fontWeight="bold"
-                pos="absolute"
-                top="0"
-                right="0"
-                transform="translate(50%, -50%)"
-                borderRadius="full"
-                fontSize="20px"
-                p={0}
-                size="xs"
-                boxSize={7}
-                borderWidth="3px"
-                borderColor="chakra-body-bg"
-                bg="red.400"
-                sx={{
-                  '&:hover, &:focus, &:active': {
-                    bg: 'red.500',
-                    color: 'white',
-                  },
-                }}
-                onClick={() => {
-                  setPaths([])
-                  if (setHideImageInput && deleteImage) {
-                    setHideImageInput(false)
-                    deleteImage()
-                  }
-                }}
-              >
-                <RiCloseLine />
-              </Button>
-            </Flex>
+              <Image
+                objectFit="cover"
+                h="255px"
+                w="full"
+                borderRadius={4}
+                priority
+                overflow="hidden"
+                src={paths[0]}
+                alt="Input"
+              />
+            </EditorMainImageWrapper>
           )}
         </>
       )}

--- a/src/components/Elements/Image/EditorMainImageWrapper.tsx
+++ b/src/components/Elements/Image/EditorMainImageWrapper.tsx
@@ -1,0 +1,42 @@
+import { AspectRatio, Button, Flex } from '@chakra-ui/react'
+import React from 'react'
+import { RiCloseLine } from 'react-icons/ri'
+
+interface EditorMainImageProps {
+  removeImage: () => void
+  children?: React.ReactNode
+}
+export const EditorMainImageWrapper = ({
+  removeImage,
+  children,
+}: EditorMainImageProps) => {
+  return (
+    <Flex pos="relative" direction="column" w="full" h="full" justify="center">
+      <AspectRatio ratio={4 / 3}>{children}</AspectRatio>
+      <Button
+        fontWeight="bold"
+        pos="absolute"
+        top="0"
+        right="0"
+        transform="translate(50%, -50%)"
+        borderRadius="full"
+        fontSize="20px"
+        p={0}
+        size="xs"
+        boxSize={7}
+        borderWidth="3px"
+        borderColor="chakra-body-bg"
+        bg="red.400"
+        sx={{
+          '&:hover, &:focus, &:active': {
+            bg: 'red.500',
+            color: 'white',
+          },
+        }}
+        onClick={removeImage}
+      >
+        <RiCloseLine />
+      </Button>
+    </Flex>
+  )
+}

--- a/src/components/Elements/ImageInput/ImageInput.tsx
+++ b/src/components/Elements/ImageInput/ImageInput.tsx
@@ -1,6 +1,7 @@
-import React, { ChangeEvent, useState } from 'react'
-import { Button, Flex, Input, Image, useToast } from '@chakra-ui/react'
+import React, { ChangeEvent, useCallback, useState } from 'react'
+import { Flex, Image, Input, useToast } from '@chakra-ui/react'
 import { useTranslation } from 'react-i18next'
+import { EditorMainImageWrapper } from '../Image/EditorMainImageWrapper'
 
 type ImageInputType = {
   setHideDropzone?: (hide: boolean) => void
@@ -17,15 +18,33 @@ const ImageInput = ({
 }: ImageInputType) => {
   const [imgSrc, setImageSrc] = useState<string>()
   const toast = useToast()
+  const { t } = useTranslation()
+
+  const removeImage = useCallback(() => {
+    setImageSrc(undefined)
+    if (deleteImage && setHideDropzone) {
+      setHideDropzone(false)
+      deleteImage()
+    }
+  }, [deleteImage, setHideDropzone])
 
   const handleOnImageInputChanges = async (
     event: ChangeEvent<HTMLInputElement>,
   ) => {
+    if (!event.target.value.match(/^(http|https):\/\//)) {
+      setImageSrc(undefined)
+      toast({
+        title: 'Paste a valid image URL',
+        status: 'error',
+        duration: 3000,
+      })
+      return
+    }
     setImageSrc(event.target.value)
-
     if (setHideDropzone) {
       setHideDropzone(true)
     }
+
     try {
       const response = await fetch(
         `https://images.weserv.nl/?url=${event.target.value}`,
@@ -35,6 +54,7 @@ const ImageInput = ({
         },
       )
       if (response.status !== 200) {
+        removeImage()
         toast({
           title: 'Image could not be fetched. Ensure you have the right link',
           status: 'error',
@@ -53,6 +73,7 @@ const ImageInput = ({
         duration: 2000,
       })
     } catch (error) {
+      removeImage()
       toast({
         title: 'Image could not be fetched. Ensure you have the right link',
         status: 'error',
@@ -60,22 +81,17 @@ const ImageInput = ({
       })
     }
   }
-  const { t } = useTranslation()
+
   return (
     <Flex
       mt={imgSrc && showFetchedImage ? 0 : -20}
-      mb={7}
+      mb={imgSrc && showFetchedImage ? 0 : 7}
       direction="column"
       justifyContent="center"
       alignItems="center"
     >
       {imgSrc && showFetchedImage ? (
-        <Flex
-          direction="column"
-          justifyContent="center"
-          alignItems="center"
-          gap={5}
-        >
+        <EditorMainImageWrapper removeImage={removeImage}>
           <Image
             objectFit="cover"
             h="255px"
@@ -85,26 +101,12 @@ const ImageInput = ({
             src={imgSrc}
             alt="Input"
           />
-          <Button
-            w="25%"
-            shadow="md"
-            bg="red.400"
-            onClick={() => {
-              setImageSrc(undefined)
-              if (deleteImage && setHideDropzone) {
-                setHideDropzone(false)
-                deleteImage()
-              }
-            }}
-          >
-            Clear
-          </Button>
-        </Flex>
+        </EditorMainImageWrapper>
       ) : (
         <Input
           w="90%"
           textAlign="center"
-          value={imgSrc}
+          value=""
           onChange={handleOnImageInputChanges}
           placeholder={`${t('pasteMainImgLabel')}`}
         />

--- a/src/components/Elements/ImageInput/ImageInput.tsx
+++ b/src/components/Elements/ImageInput/ImageInput.tsx
@@ -64,7 +64,7 @@ const ImageInput = ({
   return (
     <Flex
       mt={imgSrc && showFetchedImage ? 0 : -20}
-      mb={5}
+      mb={7}
       direction="column"
       justifyContent="center"
       alignItems="center"

--- a/src/components/Elements/ImageInput/ImageInput.tsx
+++ b/src/components/Elements/ImageInput/ImageInput.tsx
@@ -98,6 +98,7 @@ const ImageInput = ({
             w="full"
             borderRadius={4}
             overflow="hidden"
+            bgColor="dimColor"
             src={imgSrc}
             alt="Input"
           />

--- a/src/components/Layout/Editor/Highlights/Highlights.tsx
+++ b/src/components/Layout/Editor/Highlights/Highlights.tsx
@@ -3,22 +3,13 @@ import {
   Flex,
   Text,
   useDisclosure,
-  Badge,
   Button,
-  Table,
-  Tbody,
-  Td,
-  Tr,
   Box,
   HStack,
 } from '@chakra-ui/react'
-import { RiFolder3Line, RiSurveyLine, RiFilmLine } from 'react-icons/ri'
+import { RiFilmLine } from 'react-icons/ri'
 
 import { ImageInput, Dropzone } from '@/components/Elements'
-import { useAppSelector } from '@/store/hook'
-import { getWikiMetadataById } from '@/utils/getWikiFields'
-import { BaseCategory, Wiki, CommonMetaIds } from '@/types/Wiki'
-import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
 import { saveImage } from '@/utils/create-wiki'
 import HighlightsModal from './HighlightsModal/HighlightsModal'
@@ -38,7 +29,6 @@ const Highlights = ({ initialImage, isToResetImage }: HightLightsType) => {
     onOpen: mediaOpen,
     onClose: mediaClose,
   } = useDisclosure()
-  const currentWiki = useAppSelector(state => state.wiki)
   const [hideDropzone, setHideDropzone] = useState(false)
   const [hideImageInput, setHideImageInput] = useState(false)
 
@@ -67,7 +57,6 @@ const Highlights = ({ initialImage, isToResetImage }: HightLightsType) => {
     showFetchedImage: true,
     textType: 'main image',
   }
-  const { t } = useTranslation()
   return (
     <Flex
       direction="column"
@@ -89,14 +78,7 @@ const Highlights = ({ initialImage, isToResetImage }: HightLightsType) => {
           showFetchedImage
         />
       )}
-      <HStack
-        // flexDirection={{ base: 'row', '2xl': 'column' }}
-        borderWidth="1px"
-        justify="space-between"
-        // alignItems={{ base: 'center', '2xl': 'unset' }}
-        gap={2}
-        p={2}
-      >
+      <HStack borderWidth="1px" justify="space-between" gap={2} p={2}>
         <Flex ml={2} gap={2} color="linkColor">
           <Box mt={1}>
             <RiFilmLine size="16" />
@@ -108,48 +90,14 @@ const Highlights = ({ initialImage, isToResetImage }: HightLightsType) => {
         </Button>
       </HStack>
       <Flex direction="column" justifyContent="center" alignItems="center">
-        <Table size="sm" variant="simple" mb={2}>
-          <Tbody borderWidth="1px" overflow="hidden">
-            <Tr>
-              <Td color="linkColor" display="flex" gap={2}>
-                <RiFolder3Line /> <Text>{`${t('pageTypeLabel')}`}</Text>
-              </Td>
-              <Td>
-                {
-                  getWikiMetadataById(
-                    currentWiki as Wiki,
-                    CommonMetaIds.PAGE_TYPE,
-                  )?.value
-                }
-              </Td>
-            </Tr>
-            <Tr>
-              <Td color="linkColor" display="flex" gap={2}>
-                <RiSurveyLine /> <Text>{`${t('categoryTypeLabel')}`}</Text>
-              </Td>
-              <Td borderColor="inherit">
-                {currentWiki.categories?.map((c: BaseCategory, i) => (
-                  <Badge variant="outline" m={0} key={i}>
-                    {c.title}
-                  </Badge>
-                ))}
-              </Td>
-            </Tr>
-          </Tbody>
-        </Table>
         <Flex
           w="full"
           direction="row"
           justifyContent="center"
           alignItems="center"
         >
-          <Button
-            size="sm"
-            variant="outline"
-            color="linkColor"
-            onClick={onOpen}
-          >
-            Edit
+          <Button w="full" variant="outline" color="linkColor" onClick={onOpen}>
+            Edit Wiki Details
           </Button>
         </Flex>
       </Flex>

--- a/src/components/Layout/Editor/Highlights/Highlights.tsx
+++ b/src/components/Layout/Editor/Highlights/Highlights.tsx
@@ -10,7 +10,7 @@ import {
   Td,
   Tr,
   Box,
-  VStack,
+  HStack,
 } from '@chakra-ui/react'
 import { RiFolder3Line, RiSurveyLine, RiFilmLine } from 'react-icons/ri'
 
@@ -71,7 +71,7 @@ const Highlights = ({ initialImage, isToResetImage }: HightLightsType) => {
   return (
     <Flex
       direction="column"
-      gap={5}
+      gap={{ base: 3, '2xl': 5 }}
       w={{ base: 'full', xl: '400px' }}
       border="1px"
       borderColor="borderColor"
@@ -89,17 +89,24 @@ const Highlights = ({ initialImage, isToResetImage }: HightLightsType) => {
           showFetchedImage
         />
       )}
-      <VStack align="start" spacing={2}>
-        <Flex gap={2} color="linkColor">
+      <HStack
+        // flexDirection={{ base: 'row', '2xl': 'column' }}
+        borderWidth="1px"
+        justify="space-between"
+        // alignItems={{ base: 'center', '2xl': 'unset' }}
+        gap={2}
+        p={2}
+      >
+        <Flex ml={2} gap={2} color="linkColor">
           <Box mt={1}>
             <RiFilmLine size="16" />
           </Box>
           <Text>Media</Text>
         </Flex>
-        <Button onClick={mediaOpen} mt="2" size="sm">
-          <Text fontSize="sm">Add new image or video</Text>
+        <Button maxW="190px" onClick={mediaOpen} px={3} size="sm">
+          <Text fontSize="sm">Add images/videos</Text>
         </Button>
-      </VStack>
+      </HStack>
       <Flex direction="column" justifyContent="center" alignItems="center">
         <Table size="sm" variant="simple" mb={2}>
           <Tbody borderWidth="1px" overflow="hidden">
@@ -136,7 +143,12 @@ const Highlights = ({ initialImage, isToResetImage }: HightLightsType) => {
           justifyContent="center"
           alignItems="center"
         >
-          <Button variant="outline" color="linkColor" onClick={onOpen}>
+          <Button
+            size="sm"
+            variant="outline"
+            color="linkColor"
+            onClick={onOpen}
+          >
             Edit
           </Button>
         </Flex>

--- a/src/components/Layout/Editor/Highlights/Highlights.tsx
+++ b/src/components/Layout/Editor/Highlights/Highlights.tsx
@@ -60,7 +60,7 @@ const Highlights = ({ initialImage, isToResetImage }: HightLightsType) => {
   return (
     <Flex
       direction="column"
-      gap={{ base: 3, '2xl': 5 }}
+      gap={4}
       w={{ base: 'full', xl: '400px' }}
       border="1px"
       borderColor="borderColor"

--- a/src/components/Wiki/WikiPage/InsightComponents/WikiDetails.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/WikiDetails.tsx
@@ -10,6 +10,7 @@ import {
   Tr,
   VStack,
   Box,
+  AspectRatio,
 } from '@chakra-ui/react'
 import shortenAccount from '@/utils/shortenAccount'
 import { SiIpfs } from 'react-icons/si'
@@ -55,7 +56,9 @@ export const WikiDetails = ({
       >
         {title}
       </Heading>
-      <WikiImage bgColor="dimColor" imageURL={imgSrc} w="100%" h="320px" />
+      <AspectRatio w="100%" ratio={4 / 3}>
+        <WikiImage bgColor="dimColor" imageURL={imgSrc} />
+      </AspectRatio>
       <Table size="sm" variant="simple">
         <Tbody>
           {categories.length !== 0 && (

--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -610,7 +610,7 @@ const CreateWikiContent = () => {
         gap={8}
         px={{ base: 4, xl: 8 }}
       >
-        <Box h="full" w="full">
+        <Box h="full" w="full" position="sticky" top="90px">
           <Skeleton isLoaded={!isLoadingWiki} w="full" h="75vh">
             <Editor markdown={wiki.content} onChange={handleOnEditorChanges} />
           </Skeleton>

--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -610,7 +610,7 @@ const CreateWikiContent = () => {
         gap={8}
         px={{ base: 4, xl: 8 }}
       >
-        <Box h="full" w="full" position="sticky" top="90px">
+        <Box h="full" w="full" position={{ xl: 'sticky' }} top="90px">
           <Skeleton isLoaded={!isLoadingWiki} w="full" h="75vh">
             <Editor markdown={wiki.content} onChange={handleOnEditorChanges} />
           </Skeleton>

--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -463,7 +463,7 @@ const CreateWikiContent = () => {
   if (!mounted) return null
 
   return (
-    <Box scrollBehavior="auto" maxW="1900px" mx="auto" mb={8}>
+    <Box scrollBehavior="auto" maxW="1900px" mx="auto">
       <HStack
         boxShadow="sm"
         borderRadius={4}
@@ -607,7 +607,7 @@ const CreateWikiContent = () => {
         flexDirection={{ base: 'column', xl: 'row' }}
         justify="center"
         align="stretch"
-        gap={8}
+        gap={4}
         px={{ base: 4, xl: 8 }}
       >
         <Box h="full" w="full" position={{ xl: 'sticky' }} top="90px">


### PR DESCRIPTION
Closes https://github.com/EveripediaNetwork/issues/issues/464

# Changes
- Redesigned Highlights modal to be more compact to avoid scroll
- Refactored code for Editor Main Image 
- Made Editor Main image and Wiki main image to share same aspect ratio

# Links
- https://monopedia-ui-git-editor-sticky-prediqt.vercel.app/create-wiki?slug=sushiswap
- https://monopedia-ui-git-editor-sticky-prediqt.vercel.app/create-wiki
- https://monopedia-ui-git-editor-sticky-prediqt.vercel.app/wiki/sushiswap

# Screenshots

![screely-1656492992290](https://user-images.githubusercontent.com/52039218/176396154-e3dff63c-ac52-4a0b-bb6e-133b65ce5e60.png)
![screely-1656492946330](https://user-images.githubusercontent.com/52039218/176396200-f6b5ee44-6270-4125-a04a-01a8f64156bd.png)

