### PR TITLE
Fixed the dark twitter

### DIFF
--- a/src/components/Wiki/WikiPage/InsightComponents/TwitterTimeline.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/TwitterTimeline.tsx
@@ -31,7 +31,6 @@ const TwitterTimeline = ({ url }: { url: string }) => {
             <TwitterTimelineEmbed
               options={{ height: 400 }}
               theme={colorMode}
-              transparent
               sourceType="url"
               noScrollbar
               borderColor={colorMode === 'dark' ? '#4a5568' : '#ddd'}


### PR DESCRIPTION
# The dark mode for the twitter widget

_Now the twitter widget follows the dark mode perfectly

## How should this be tested?

1. Before

![image](https://user-images.githubusercontent.com/75235148/176207697-631a6952-9507-4006-80c8-d17d52f8ce86.png)



2. Now 
![Screenshot (276)](https://user-images.githubusercontent.com/75235148/176207574-64dfc40e-4669-4629-88df-8d81910ee4a3.png)





## Linked issues

 closes https://github.com/EveripediaNetwork/issues/issues/459
