### PR TITLE
Strip html on Copy/Paste

### DIFF
--- a/src/components/Layout/Editor/Editor.tsx
+++ b/src/components/Layout/Editor/Editor.tsx
@@ -101,7 +101,10 @@ const Editor = ({ onChange, markdown = '' }: EditorType) => {
     const currentMd = editorRef.current
       ?.getInstance()
       .getMarkdown()
-      .toString() as string
+      .toString()
+      .replace(/<[^>]+>/gm, '')
+      .replace(/\\/g,'')
+
     if (markdown !== currentMd) {
       if (
         markdown.substring(0, EditorContentOverride.KEYWORD.length) ===
@@ -113,7 +116,7 @@ const Editor = ({ onChange, markdown = '' }: EditorType) => {
         currentMd !== 'Write\nPreview\n\nMarkdown\nWYSIWYG'
       ) {
         onChange(currentMd)
-      } else if (currentMd.trim() === '') {
+      } else if (currentMd?.trim() === '') {
         onChange(' ')
       }
     }

--- a/src/components/Layout/Editor/Editor.tsx
+++ b/src/components/Layout/Editor/Editor.tsx
@@ -98,12 +98,7 @@ const Editor = ({ onChange, markdown = '' }: EditorType) => {
 
   // when there is a change in the editor, update the markdown
   const handleOnEditorChange = useCallback(() => {
-    const currentMd = editorRef.current
-      ?.getInstance()
-      .getMarkdown()
-      .toString()
-      .replace(/<[^>]+>/gm, '')
-      .replace(/\\/g, '')
+    const currentMd = editorRef.current?.getInstance().getMarkdown().toString()
 
     if (markdown !== currentMd) {
       if (

--- a/src/components/Layout/Editor/Editor.tsx
+++ b/src/components/Layout/Editor/Editor.tsx
@@ -103,7 +103,7 @@ const Editor = ({ onChange, markdown = '' }: EditorType) => {
       .getMarkdown()
       .toString()
       .replace(/<[^>]+>/gm, '')
-      .replace(/\\/g,'')
+      .replace(/\\/g, '')
 
     if (markdown !== currentMd) {
       if (

--- a/src/components/Layout/Navbar/NavSearch/index.tsx
+++ b/src/components/Layout/Navbar/NavSearch/index.tsx
@@ -69,10 +69,7 @@ export const NavSearch = (props: NavSearchProps) => {
   useEventListener('keydown', event => {
     const isMac = /(Mac|iPhone|iPod|iPad)/i.test(navigator?.userAgent)
     const hotkey = isMac ? 'metaKey' : 'ctrlKey'
-    if (
-      (event.key.toLowerCase() === 'k' && event[hotkey]) ||
-      event.key === '/'
-    ) {
+    if (event.key.toLowerCase() === 'k' && event[hotkey]) {
       event.preventDefault()
       inputRef.current?.focus()
     }

--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -338,6 +338,7 @@ const CreateWikiContent = () => {
   ) => {
     const newVal = val
       ?.replace(/[<]br[^>]*[>]/, '\n')
+      ?.replace(/[<][/]br[^>]*[>]/, '\n')
       .replace(/<[^>]+>/gm, '')
       .replace(/\\/g, '')
 

--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -336,17 +336,22 @@ const CreateWikiContent = () => {
     val: string | undefined,
     isInitSet?: boolean,
   ) => {
+    const newVal = val
+      ?.replace(/[<]br[^>]*[>]/, '\n')
+      .replace(/<[^>]+>/gm, '')
+      .replace(/\\/g, '')
+
     if (isInitSet)
       dispatch({
         type: 'wiki/setInitialWikiState',
         payload: {
-          content: val || ' ',
+          content: newVal || ' ',
         },
       })
     else
       dispatch({
         type: 'wiki/setContent',
-        payload: val || ' ',
+        payload: newVal || ' ',
       })
   }
 


### PR DESCRIPTION
1. Previously when you paste a hypertext it comes with the opening and closing elements which could be buggy especially with `anchor` tags. This PR address that by stripping away the tags. 
2. `<br/>`, `<br></br>` and `<br>` are now replaced with a line break when pasted into the Editor. 
3. Also focusing on search bar using the `/` has been disabled as it doesn't allow users to type `/` inside of the Editor. Now Search bar can be focused by clicking on `CMD + K` 

Before: 
![image](https://user-images.githubusercontent.com/30846348/176288527-e0910a01-3a7d-4f17-bdd2-3f5536326077.png)
 
After:  
![image](https://user-images.githubusercontent.com/30846348/176288604-c818b476-7e1a-457e-a688-2440001221ce.png)



## Linked issues

fixes https://github.com/EveripediaNetwork/issues/issues/393
fixes https://github.com/EveripediaNetwork/issues/issues/463