### PR TITLE
implements serverless redirection

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -20,6 +20,7 @@ const config = {
   ensRPC: String(process.env.NEXT_PUBLIC_ENS_RPC),
   magicLinkApiKey: String(process.env.NEXT_PUBLIC_MAGIC_LINK_API_KEY),
   publicDomain: String(process.env.NEXT_PUBLIC_DOMAIN),
+  baseArchiveUrl: 'https://archive.everipedia.org',
 }
 
 export default config

--- a/src/data/UrlData.ts
+++ b/src/data/UrlData.ts
@@ -1,0 +1,3 @@
+export const URLS: { [key: string]: string } = {
+  'cardano-cryptocurrency': 'cardano-cryptocurrency',
+}

--- a/src/pages/wiki/[slug]/_middleware.ts
+++ b/src/pages/wiki/[slug]/_middleware.ts
@@ -1,0 +1,21 @@
+import { NextResponse, NextRequest } from 'next/server'
+import { URLS } from '@/data/UrlData'
+import appConfig from '@/config'
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+  if (pathname.includes('/lang_en')) {
+    const oldWikiName = pathname.replace('/wiki/lang_en/', '')
+    if (oldWikiName in URLS) {
+      return NextResponse.rewrite(
+        new URL(`/wiki/${URLS[oldWikiName]}`, request.url),
+      )
+    }
+    return NextResponse.redirect(`${appConfig.baseArchiveUrl}${pathname}`, 301)
+  }
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: '/wiki/lang_en/:path*',
+}


### PR DESCRIPTION
# implements serverless redirection for old wikis

_we need a way to redirect users to everipedia archive or to new one when someone visits path: /wiki/lang_en/cardano-cryptocurrency

we will have an array of forced paths like:

cardano-cryptocurrency -> cardano

if url matches that path it will redirect 301 to the new wiki in everipedia like /wiki/cardano
if url doest not match the forced path, it will redirect to archive.everipedia.org/wiki/lang_en/cardano-cryptocurrency (301)

its important the status to send for SEO purposes

fixes https://github.com/EveripediaNetwork/issues/issues/456