### PR TITLE
uses user address if ens name does not exist

### DIFF
--- a/src/components/Profile/LoadingProfile.tsx
+++ b/src/components/Profile/LoadingProfile.tsx
@@ -78,9 +78,6 @@ export const LoadingProfile = (props: LoadingProfileProps) => {
               <chakra.span fontWeight="medium">userName</chakra.span>
             </Skeleton>
           </Flex>
-          <Skeleton>
-            <chakra.span color="gray.500">Joined November 2020</chakra.span>
-          </Skeleton>
         </Flex>
       )}
     </>

--- a/src/components/Profile/UserDetails.tsx
+++ b/src/components/Profile/UserDetails.tsx
@@ -48,10 +48,10 @@ export const UserDetails = (props: UserDetailsProps) => {
   return (
     <>
       <NextSeo
-        title={`${username || 'Unnamed'} Profile Page - Everipedia`}
+        title={`${username || address} Profile Page - Everipedia`}
         openGraph={{
-          title: `${username || 'Unnamed'} Profile Page - Everipedia`,
-          description: `${username || 'Unnamed'} profile page`,
+          title: `${username || address} Profile Page - Everipedia`,
+          description: `${username || address} profile page`,
         }}
       />
       <Flex align="center" justify="space-between" w="full" px="6" gap={3}>
@@ -125,11 +125,6 @@ export const UserDetails = (props: UserDetailsProps) => {
         </chakra.span>
       </Flex>
 
-      {!isSticky && (
-        <Flex gap="3" direction="column" px="6" w="full" align="center">
-          <chakra.span color="gray.500">Joined November 2020</chakra.span>
-        </Flex>
-      )}
     </>
   )
 }

--- a/src/components/Profile/UserDetails.tsx
+++ b/src/components/Profile/UserDetails.tsx
@@ -124,7 +124,6 @@ export const UserDetails = (props: UserDetailsProps) => {
           </ButtonGroup>
         </chakra.span>
       </Flex>
-
     </>
   )
 }

--- a/src/components/Profile/UserDetails.tsx
+++ b/src/components/Profile/UserDetails.tsx
@@ -19,6 +19,7 @@ import { useENSData } from '@/hooks/useENSData'
 import { NextSeo } from 'next-seo'
 import { useAccount } from 'wagmi'
 import { useTranslation } from 'react-i18next'
+import shortenAccount from '@/utils/shortenAccount'
 
 export type UserDetailsProps = { hide?: boolean }
 
@@ -92,7 +93,7 @@ export const UserDetails = (props: UserDetailsProps) => {
               fontWeight="semibold"
               letterSpacing="tighter"
             >
-              {username || 'Unnamed'}
+              {username || shortenAccount(address)}
             </chakra.span>
           </Skeleton>
         </Flex>


### PR DESCRIPTION
# Use user wallet address if ens name does not exist

_switch from user unnamed to their address ( or ens address if the user has ). 99% of users will be unnamed so it's better to show there their address.
Before 
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/70170061/176547482-f6d63bd4-9193-48f2-b8e5-a6c847b48f57.png">

After
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/70170061/176547330-92f7d274-de9a-4d45-a59c-f7be66e8d232.png">

fixes https://github.com/EveripediaNetwork/issues/issues/469