### PR TITLE
ensures default wiki category is set

### DIFF
--- a/src/components/Layout/Editor/Highlights/HighlightsModal/HighlightsModal.tsx
+++ b/src/components/Layout/Editor/Highlights/HighlightsModal/HighlightsModal.tsx
@@ -206,7 +206,7 @@ const HighlightsModal = ({
                     })
                   }
                 }}
-                value={currentWiki.categories[0]?.title}
+                defaultValue={currentWiki.categories[0]?.id}
                 placeholder={
                   currentWiki.categories.length > 0
                     ? undefined


### PR DESCRIPTION
# Ensure the default wiki category is set on the wiki edit page


Fixes https://github.com/EveripediaNetwork/issues/issues/482