### PR TITLE
Share profile btn workning

### DIFF
--- a/src/components/Profile/UserDetails.tsx
+++ b/src/components/Profile/UserDetails.tsx
@@ -8,6 +8,8 @@ import {
   Tooltip,
   TooltipProps,
   Skeleton,
+  useClipboard,
+  useToast,
 } from '@chakra-ui/react'
 import { useProfileContext } from '@/components/Profile/utils'
 import { useRouter } from 'next/router'
@@ -32,6 +34,12 @@ export const UserDetails = ({ hide }: UserDetailsProps) => {
   const { headerIsSticky } = useProfileContext()
   const [, ensUserName, loading] = useENSData(address)
   const isSticky = headerIsSticky && hide
+  const customLink = `${window.origin}/account/${profileData?.username || address || ensUserName }`
+
+  const clipboard = useClipboard(customLink || '')
+
+  const toast = useToast()
+
 
   const tooltipProps: Partial<TooltipProps> = {
     placement: 'top',
@@ -114,6 +122,14 @@ export const UserDetails = ({ hide }: UserDetailsProps) => {
                 icon={<RiShareFill size={isSticky ? '15' : '20'} />}
                 rounded="xl"
                 _hover={{ shadow: 'xl' }}
+                onClick={() => {
+                  clipboard.onCopy()
+                  toast({
+                    title: 'Profile Link Copied to Clipboard!',
+                    status: 'success',
+                    duration: 1000,
+                  })
+                }}
                 {...(isSticky && { boxSize: 8, rounded: '4' })}
               />
             </Tooltip>


### PR DESCRIPTION
# Share button in the profile page

_This PR makes the share button in the profile page copy the account url of the user 

## How should this be tested?

1. By connecting your account to the Everipedia dapp and going to profile 

2. Click on the share btn on the profile page


## Linked issue
closes https://github.com/EveripediaNetwork/issues/issues/487
