### PR TITLE
Extended user profiles

### DIFF
--- a/src/components/Elements/Avatar/Avatar.tsx
+++ b/src/components/Elements/Avatar/Avatar.tsx
@@ -40,7 +40,8 @@ const DisplayAvatar = ({
   if (profileData?.avatar) {
     content = (
       <Avatar
-        boxSize={size}
+        boxSize={`${size}px`}
+        mt="2px"
         src={`${config.pinataBaseUrl}${profileData.avatar}`}
         {...rest}
       />

--- a/src/components/Profile/UserDetails.tsx
+++ b/src/components/Profile/UserDetails.tsx
@@ -16,7 +16,6 @@ import { useRouter } from 'next/router'
 import DisplayAvatar from '@/components/Elements/Avatar/Avatar'
 import { LoadingProfile } from '@/components/Profile/LoadingProfile'
 import { useENSData } from '@/hooks/useENSData'
-import { NextSeo } from 'next-seo'
 import { useAccount } from 'wagmi'
 import { useTranslation } from 'react-i18next'
 import shortenAccount from '@/utils/shortenAccount'
@@ -50,13 +49,6 @@ export const UserDetails = ({ hide }: UserDetailsProps) => {
   if (loading) return <LoadingProfile hide={hide} />
   return (
     <>
-      <NextSeo
-        title={`${ensUserName || address} Profile Page - Everipedia`}
-        openGraph={{
-          title: `${ensUserName || address} Profile Page - Everipedia`,
-          description: `${ensUserName || address} profile page`,
-        }}
-      />
       <Flex
         flexDir={{ base: isSticky ? 'row' : 'column', lg: 'row' }}
         align="center"

--- a/src/components/Profile/UserDetails.tsx
+++ b/src/components/Profile/UserDetails.tsx
@@ -8,6 +8,8 @@ import {
   Tooltip,
   TooltipProps,
   Skeleton,
+  Text,
+  VStack,
 } from '@chakra-ui/react'
 import { useProfileContext } from '@/components/Profile/utils'
 import { useRouter } from 'next/router'
@@ -20,6 +22,7 @@ import { useTranslation } from 'react-i18next'
 import shortenAccount from '@/utils/shortenAccount'
 import { useUserProfileData } from '@/services/profile/utils'
 import { RiSettings5Fill, RiShareFill } from 'react-icons/ri'
+import UserSocialLinks from './UserSocialLinks'
 
 export type UserDetailsProps = { hide?: boolean }
 
@@ -95,13 +98,23 @@ export const UserDetails = ({ hide }: UserDetailsProps) => {
           </Box>
 
           <Skeleton isLoaded={!loading}>
-            <chakra.span
-              fontSize={isSticky ? 'lg' : '3xl'}
-              fontWeight="semibold"
-              letterSpacing="tighter"
-            >
-              {profileData?.username || ensUserName || shortenAccount(address)}
-            </chakra.span>
+            <VStack>
+              <chakra.span
+                fontSize={isSticky ? 'lg' : '3xl'}
+                fontWeight="semibold"
+                letterSpacing="tighter"
+              >
+                {profileData?.username ||
+                  ensUserName ||
+                  shortenAccount(address)}
+              </chakra.span>
+              {profileData && !isSticky && (
+                <VStack spacing={4}>
+                  <Text textAlign="center">{profileData.bio}</Text>
+                  <UserSocialLinks links={profileData?.links[0]} />
+                </VStack>
+              )}
+            </VStack>
           </Skeleton>
         </Flex>
         <chakra.span display="flex" flex="1">

--- a/src/components/Profile/UserDetails.tsx
+++ b/src/components/Profile/UserDetails.tsx
@@ -102,7 +102,9 @@ export const UserDetails = ({ hide }: UserDetailsProps) => {
               </chakra.span>
               {profileData && !isSticky && (
                 <VStack spacing={4}>
-                  <Text textAlign="center">{profileData.bio}</Text>
+                  <Text maxW="min(400px, 80vw)" textAlign="center">
+                    {profileData.bio}
+                  </Text>
                   <UserSocialLinks links={profileData?.links[0]} />
                 </VStack>
               )}

--- a/src/components/Profile/UserInfo.tsx
+++ b/src/components/Profile/UserInfo.tsx
@@ -19,7 +19,7 @@ const UserInfo = () => {
         top="70px"
         bg="white"
         _dark={{ bg: 'gray.800' }}
-        zIndex={headerIsSticky ? 1300 : -1}
+        zIndex={headerIsSticky ? 'sticky' : -1}
         borderTopWidth={headerIsSticky ? '1px' : '0px'}
         shadow="md"
         opacity={headerIsSticky ? 1 : 0}

--- a/src/components/Profile/UserSocialLinks.tsx
+++ b/src/components/Profile/UserSocialLinks.tsx
@@ -1,0 +1,35 @@
+import { UserSocialLinksData as dt } from '@/data/UserSocialLinksData'
+import { ProfileLinks } from '@/types/ProfileType'
+import { HStack, Icon, Link, Tooltip } from '@chakra-ui/react'
+import React from 'react'
+
+interface ProfileLinksProps {
+  links: ProfileLinks
+}
+const UserSocialLinks = ({ links }: ProfileLinksProps) => {
+  const socials = Object.keys(links) as Array<keyof ProfileLinks>
+  return (
+    <HStack justify="center" spacing={4}>
+      {socials.map(key => {
+        return (
+          <Link position="relative" href={dt[key].urlPrefix(links[key] || '')}>
+            <Tooltip hasArrow label={dt[key].label}>
+              <span>
+                <Icon
+                  aria-label={dt[key].label}
+                  as={dt[key].icon}
+                  boxSize="25px"
+                  _hover={{
+                    opacity: 0.7,
+                  }}
+                />
+              </span>
+            </Tooltip>
+          </Link>
+        )
+      })}
+    </HStack>
+  )
+}
+
+export default UserSocialLinks

--- a/src/components/Profile/UserWikis/UserCreatedWikis.tsx
+++ b/src/components/Profile/UserWikis/UserCreatedWikis.tsx
@@ -42,7 +42,7 @@ const UserCreatedWikis = () => {
   })
 
   return (
-    <Box py="10" px={{ base: 10, lg: 0 }}>
+    <Box py="10" px={{ base: 6, lg: 0 }}>
       {wikis.length < 1 && !hasMore && (
         <Center>
           <EmptyState />

--- a/src/components/Profile/UserWikis/UserEditedWikis.tsx
+++ b/src/components/Profile/UserWikis/UserEditedWikis.tsx
@@ -43,7 +43,7 @@ const UserEditedWikis = () => {
   })
 
   return (
-    <Box py="10" px={{ base: 10, lg: 0 }}>
+    <Box py="10" px={{ base: 6, lg: 0 }}>
       {wikis.length < 1 && !hasMore && (
         <Center>
           <EmptyState />

--- a/src/components/SEO/UserProfile.tsx
+++ b/src/components/SEO/UserProfile.tsx
@@ -1,0 +1,56 @@
+import config from '@/config'
+import { UserSocialLinksData as dt } from '@/data/UserSocialLinksData'
+import { ProfileLinks } from '@/types/ProfileType'
+import { NextSeo, SocialProfileJsonLd } from 'next-seo'
+import React from 'react'
+
+interface UserProfileHeaderProps {
+  username: string
+  bio?: string | null
+  avatarIPFS?: string | null
+  links?: ProfileLinks
+}
+
+export const UserProfileHeader = ({
+  username,
+  bio,
+  avatarIPFS,
+  links,
+}: UserProfileHeaderProps) => {
+  let socials = [] as Array<keyof ProfileLinks>
+
+  if (links) socials = Object.keys(links) as Array<keyof ProfileLinks>
+  return (
+    <>
+      <SocialProfileJsonLd
+        type="Person"
+        name={username}
+        url={`https://everipedia.org/account/${username}`}
+        sameAs={
+          socials.map(key =>
+            dt[key].urlPrefix((links && links[key]) || ''),
+          ) as Array<string>
+        }
+      />
+      <NextSeo
+        openGraph={{
+          title: `${username} · Everipedia`,
+          description: bio || 'check out this user on Everipedia',
+          url: `https://everipedia.org/account/${username}`,
+          type: 'profile',
+          profile: {
+            username,
+          },
+          images: [
+            {
+              url: `${config.pinataBaseUrl}${avatarIPFS}`,
+              width: 650,
+              height: 650,
+              alt: 'Profile Photo',
+            },
+          ],
+        }}
+      />
+    </>
+  )
+}

--- a/src/components/Settings/ProfileSettings.tsx
+++ b/src/components/Settings/ProfileSettings.tsx
@@ -111,8 +111,8 @@ const ProfileSettings = ({ settingsData }: ProfileSettingsProps) => {
     return ''
   }
   const validateBio = (bio: string): string => {
-    if (bio.length > 140) {
-      return 'Bio must be 140 characters or less'
+    if (bio.length > 85) {
+      return 'Bio must be 85 characters or less'
     }
     return ''
   }

--- a/src/components/Settings/ProfileSettings.tsx
+++ b/src/components/Settings/ProfileSettings.tsx
@@ -257,7 +257,7 @@ const ProfileSettings = ({ settingsData }: ProfileSettingsProps) => {
           {/* PROFILE: LINKS */}
           <FormControl>
             <FormLabel htmlFor="links">Links</FormLabel>
-            <Box borderWidth="1px" borderRadius="md">
+            <Box overflow="hidden" borderWidth="1px" borderRadius="md">
               {/* LINKS: Twitter */}
               <InputGroup>
                 <InputLeftElement pointerEvents="none">
@@ -294,8 +294,16 @@ const ProfileSettings = ({ settingsData }: ProfileSettingsProps) => {
                   _focus={{ borderBottomColor: 'inherit' }}
                   value={website}
                   onChange={e => setWebsite(e.target.value)}
+                  type="url"
                   variant="flushed"
-                  placeholder="yoursite.io"
+                  _invalid={{
+                    bgColor: '#FF000022',
+                  }}
+                  isInvalid={
+                    website.length !== 0 &&
+                    !/^(http|https):\/\/[^ "]+$/.test(website)
+                  }
+                  placeholder="https://yoursite.io"
                 />
               </InputGroup>
             </Box>

--- a/src/components/Settings/ProfileSettings.tsx
+++ b/src/components/Settings/ProfileSettings.tsx
@@ -354,7 +354,7 @@ const ProfileSettings = ({ settingsData }: ProfileSettingsProps) => {
       </Flex>
       <Button
         isLoading={isLoading}
-        disabled={isAvatarLoading || isBannerLoading}
+        disabled={isLoading || isAvatarLoading || isBannerLoading}
         loadingText="Submitting"
         type="submit"
         _disabled={{

--- a/src/data/UserSocialLinksData.ts
+++ b/src/data/UserSocialLinksData.ts
@@ -4,16 +4,16 @@ export const UserSocialLinksData = {
   twitter: {
     label: 'Twitter',
     icon: RiTwitterLine,
-    urlPrefix: (username: string) => `https://twitter.com/${username}`,
+    urlPrefix: (username?: string) => `https://twitter.com/${username}`,
   },
   website: {
     label: 'Website',
     icon: RiLink,
-    urlPrefix: (website: string) => website,
+    urlPrefix: (website?: string) => website,
   },
   instagram: {
     label: 'Instagram',
     icon: RiInstagramLine,
-    urlPrefix: (username: string) => `https://instagram.com/${username}`,
+    urlPrefix: (username?: string) => `https://instagram.com/${username}`,
   },
 }

--- a/src/data/UserSocialLinksData.ts
+++ b/src/data/UserSocialLinksData.ts
@@ -1,0 +1,19 @@
+import { RiInstagramLine, RiLink, RiTwitterLine } from 'react-icons/ri'
+
+export const UserSocialLinksData = {
+  twitter: {
+    label: 'Twitter',
+    icon: RiTwitterLine,
+    urlPrefix: (username: string) => `https://twitter.com/${username}`,
+  },
+  website: {
+    label: 'Website',
+    icon: RiLink,
+    urlPrefix: (website: string) => website,
+  },
+  instagram: {
+    label: 'Instagram',
+    icon: RiInstagramLine,
+    urlPrefix: (username: string) => `https://instagram.com/${username}`,
+  },
+}

--- a/src/pages/account/[profile].tsx
+++ b/src/pages/account/[profile].tsx
@@ -3,6 +3,7 @@ import { Collections } from '@/components/Profile/Collections'
 import { useProfile } from '@/components/Profile/useProfile'
 import UserInfo from '@/components/Profile/UserInfo'
 import { ProfileProvider } from '@/components/Profile/utils'
+import { UserProfileHeader } from '@/components/SEO/UserProfile'
 import config from '@/config'
 import { useUserProfileData } from '@/services/profile/utils'
 import { validateAddress } from '@/utils/validateAddress'
@@ -49,31 +50,39 @@ const Profile: PageWithoutFooter = () => {
   const profileContext = useProfile()
 
   return (
-    <ProfileProvider value={profileContext}>
-      <Flex mt={-2} direction="column" align="center" pos="relative">
-        <Image
-          width="full"
-          height="56"
-          objectFit="cover"
-          bgColor="profileBannerBg"
-          backgroundImage="/images/homepage-bg-white.png"
-          _dark={{
-            backgroundImage: '/images/homepage-bg-dark.png',
-          }}
-          src={`${config.pinataBaseUrl}${profileData?.banner}`}
-        />
-        {!loading ? (
-          <>
-            <UserInfo />
-            <Collections />
-          </>
-        ) : (
-          <Box mt="20">
-            <Spinner size="xl" />
-          </Box>
-        )}
-      </Flex>
-    </ProfileProvider>
+    <>
+      <UserProfileHeader
+        username={profileData?.username || address}
+        bio={profileData?.bio}
+        avatarIPFS={profileData?.avatar}
+        links={profileData?.links[0]}
+      />
+      <ProfileProvider value={profileContext}>
+        <Flex mt={-2} direction="column" align="center" pos="relative">
+          <Image
+            width="full"
+            height="56"
+            objectFit="cover"
+            bgColor="profileBannerBg"
+            backgroundImage="/images/homepage-bg-white.png"
+            _dark={{
+              backgroundImage: '/images/homepage-bg-dark.png',
+            }}
+            src={`${config.pinataBaseUrl}${profileData?.banner}`}
+          />
+          {!loading ? (
+            <>
+              <UserInfo />
+              <Collections />
+            </>
+          ) : (
+            <Box mt="20">
+              <Spinner size="xl" />
+            </Box>
+          )}
+        </Flex>
+      </ProfileProvider>
+    </>
   )
 }
 Profile.noFooter = true

--- a/src/pages/account/[profile]/_middleware.ts
+++ b/src/pages/account/[profile]/_middleware.ts
@@ -1,0 +1,28 @@
+import { NextResponse, NextRequest } from 'next/server'
+import appConfig from '@/config'
+import { BaseProvider, StaticJsonRpcProvider } from '@ethersproject/providers'
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+  const userIdentifier = pathname.replace('/account/', '')
+  const ethAddressReg = /^0x[a-fA-F0-9]{40}$/
+  const isWalletAddress = ethAddressReg.test(userIdentifier)
+
+  if (!isWalletAddress) {
+    // TODO: check if userIdentifier is from user profile and redirect to profile page
+
+    // check if userIdentifier is eth address
+    if (userIdentifier.endsWith('.eth')) {
+      const provider: BaseProvider = new StaticJsonRpcProvider(appConfig.ensRPC)
+      const resolvedAddress = (await provider.resolveName(
+        userIdentifier,
+      )) as string
+      if (resolvedAddress) {
+        return NextResponse.redirect(
+          `${appConfig.publicDomain}/account/${resolvedAddress}`,
+        )
+      }
+    }
+  }
+  return NextResponse.next()
+}

--- a/src/pages/account/[profile]/index.tsx
+++ b/src/pages/account/[profile]/index.tsx
@@ -6,12 +6,10 @@ import { ProfileProvider } from '@/components/Profile/utils'
 import { UserProfileHeader } from '@/components/SEO/UserProfile'
 import config from '@/config'
 import { useUserProfileData } from '@/services/profile/utils'
-import { validateAddress } from '@/utils/validateAddress'
 import { Flex, Spinner, Box } from '@chakra-ui/react'
-import { BaseProvider, StaticJsonRpcProvider } from '@ethersproject/providers'
 import { NextPage } from 'next'
 import { useRouter } from 'next/router'
-import React, { useState, useEffect } from 'react'
+import React, { useEffect } from 'react'
 
 export type PageWithoutFooter = NextPage & {
   noFooter?: boolean
@@ -19,33 +17,14 @@ export type PageWithoutFooter = NextPage & {
 
 const Profile: PageWithoutFooter = () => {
   const router = useRouter()
-  const provider: BaseProvider = new StaticJsonRpcProvider(config.ensRPC)
   const address = router.query.profile as string
-  const [loading, setLoading] = useState<boolean>(true)
-  const { profileData, setAccount } = useUserProfileData(address)
+  const { profileData, setAccount, loading } = useUserProfileData(address)
 
   useEffect(() => {
     if (address) {
       setAccount(address)
-      if (!validateAddress(address)) {
-        const lookUpAddress = async () => {
-          const resolvedAddress = (await provider.resolveName(
-            address,
-          )) as string
-          if (resolvedAddress) {
-            router.push(`/account/${resolvedAddress}`)
-          } else {
-            return router.push(`/404`)
-          }
-          return null
-        }
-        lookUpAddress()
-      } else {
-        setLoading(false)
-      }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [address])
+  }, [address, setAccount])
 
   const profileContext = useProfile()
 

--- a/src/types/Wiki.ts
+++ b/src/types/Wiki.ts
@@ -160,6 +160,6 @@ export const whiteListedDomains = [
   'youtu.be',
   'vimeo.com',
   'alpha.everipedia.org/wiki',
-  'beta.everipedia.org/wiki',  
+  'beta.everipedia.org/wiki',
   'ipfs.everipedia.org/ipfs',
 ]

--- a/src/utils/getDeadline.ts
+++ b/src/utils/getDeadline.ts
@@ -1,4 +1,4 @@
 export const getDeadline = () => {
   const deadline = new Date()
-  return (Math.floor(deadline.getTime() / 1000.0) + 2 * 60 * 60)
+  return Math.floor(deadline.getTime() / 1000.0) + 2 * 60 * 60
 }


### PR DESCRIPTION
Closes https://github.com/EveripediaNetwork/issues/issues/495

# Tasks
- [x] Display social links and user bio in user profile page below their username
- [ ] Make use of username instead of address/ens when user has one set in their profile
- [x] Integrate Next SEO on user profile page
- [x] reimplement ens to user account javascript redirect logic to do 302 server side redirect
- [ ] route ```/avatar/{username}``` to ```/avatar/{user_address}```
- [x] make save button in settings disable when loading
- [x] fix sticky header in user profile page overlapping profile sub menu from navbar
- [x] fix avatar sizes not transmitting on userset avatar
- [x] validate website url input in settings