### PR TITLE
Disable Publishing until completion

### DIFF
--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -453,6 +453,18 @@ const CreateWikiContent = () => {
 
   if (!mounted) return null
 
+  const handlePublishDisable = () => {
+    if (
+      +wiki.content.split(' ').length >= 150 &&
+      wiki.title &&
+      wiki.images &&
+      +wiki.categories.length >= 1
+    ) {
+      return true
+    }
+    return false
+  }
+
   return (
     <Box scrollBehavior="auto" maxW="1900px" mx="auto">
       <HStack
@@ -589,6 +601,7 @@ const CreateWikiContent = () => {
             onClick={() => {
               saveOnIpfs()
             }}
+            disabled={!handlePublishDisable()}
           >
             Publish
           </Button>


### PR DESCRIPTION
On this PR, the Publish button is only activated when the following conditions are met
- Content of wiki is more than 150words.
- A main image has been added.
- A title has been added.
- A category has been selected. 

Before: 
![image](https://user-images.githubusercontent.com/30846348/178159666-258ac9b0-0a30-469c-a2ea-694685adacde.png)

After
![image](https://user-images.githubusercontent.com/30846348/178159672-0c975dff-fa57-4349-881d-bf4446addfd7.png)


## Linked issues

closes #488, closes #488, closes https://github.com/EveripediaNetwork/issues/issues/488
