### PR TITLE
Publish button shows up toast w reasons

### DIFF
--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -163,6 +163,36 @@ const CreateWikiContent = () => {
   const getWikiSlug = () => slugifyText(String(wiki.title))
 
   const isValidWiki = () => {
+
+    if (!wiki.title) {
+      toast({
+        title: `Add a Title at the top for this Wiki to continue `,
+        status: 'error',
+        duration: 3000,
+      })
+      return false
+    }
+
+    const words = getWordCount(wiki.content || '')
+
+    if (words < MINIMUM_WORDS) {
+      toast({
+        title: `Add a minimum of ${MINIMUM_WORDS} words in the content section to continue, you have written ${words}`,
+        status: 'error',
+        duration: 3000,
+      })
+      return false
+    }
+
+    if (!isVerifiedContentLinks(wiki.content)) {
+      toast({
+        title: 'Please remove all external links from the content',
+        status: 'error',
+        duration: 3000,
+      })
+      return false
+    }
+
     if (!wiki.images?.length) {
       toast({
         title: 'Add a main image on the right column to continue',
@@ -175,26 +205,6 @@ const CreateWikiContent = () => {
     if (wiki.categories.length === 0) {
       toast({
         title: 'Add one category to continue',
-        status: 'error',
-        duration: 3000,
-      })
-      return false
-    }
-
-    const words = getWordCount(wiki.content || '')
-
-    if (words < MINIMUM_WORDS) {
-      toast({
-        title: `Add a minimum of ${MINIMUM_WORDS} words to continue, you have written ${words}`,
-        status: 'error',
-        duration: 3000,
-      })
-      return false
-    }
-
-    if (!isVerifiedContentLinks(wiki.content)) {
-      toast({
-        title: 'Please remove all external links from the content',
         status: 'error',
         duration: 3000,
       })
@@ -457,18 +467,6 @@ const CreateWikiContent = () => {
 
   if (!mounted) return null
 
-  const handlePublishDisable = () => {
-    if (
-      +wiki.content.split(' ').length >= 150 &&
-      wiki.title &&
-      wiki.images &&
-      +wiki.categories.length >= 1
-    ) {
-      return true
-    }
-    return false
-  }
-
   return (
     <Box scrollBehavior="auto" maxW="1900px" mx="auto">
       <ReactCanvasConfetti {...confettiProps} />
@@ -606,7 +604,7 @@ const CreateWikiContent = () => {
             onClick={() => {
               saveOnIpfs()
             }}
-            disabled={!handlePublishDisable()}
+            
           >
             Publish
           </Button>

--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -163,7 +163,6 @@ const CreateWikiContent = () => {
   const getWikiSlug = () => slugifyText(String(wiki.title))
 
   const isValidWiki = () => {
-
     if (!wiki.title) {
       toast({
         title: `Add a Title at the top for this Wiki to continue `,
@@ -604,7 +603,6 @@ const CreateWikiContent = () => {
             onClick={() => {
               saveOnIpfs()
             }}
-            
           >
             Publish
           </Button>


### PR DESCRIPTION
# Publish button tooltip toast 

_To identify to editors and users what remains in order to publish their wiki i enabled  the publish button so on every click it says whats remains to do to complete the creating wiki process

## How should this be tested?

when creating a wiki and clicking the publish button
![image](https://user-images.githubusercontent.com/75235148/179579535-9242a882-611d-4499-8986-b18e232f0f15.png)


![image](https://user-images.githubusercontent.com/75235148/179579568-3a114fd6-9540-47c7-92d6-019bf4ecf9fd.png)


![image](https://user-images.githubusercontent.com/75235148/179579594-a9e17f17-aa86-459b-8796-047c89b0ff17.png)


![image](https://user-images.githubusercontent.com/75235148/179579600-214f389e-427d-48e0-aa5d-fa8e10aa6076.png)


## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/527
