### PR TITLE
Category title vs text

### DIFF
--- a/src/components/Layout/Editor/Highlights/HighlightsModal/HighlightsModal.tsx
+++ b/src/components/Layout/Editor/Highlights/HighlightsModal/HighlightsModal.tsx
@@ -241,7 +241,7 @@ const HighlightsModal = ({
                 }
               >
                 {categoryOptions?.map(o => (
-                  <option key={o.id}>{o.id}</option>
+                  <option key={o.id}>{o.title}</option>
                 ))}
               </Select>
             </Flex>

--- a/src/components/Wiki/WikiPage/InsightComponents/WikiDetails.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/WikiDetails.tsx
@@ -73,7 +73,7 @@ export const WikiDetails = ({
                       href={`/categories/${category.id}`}
                       color="brand.500"
                     >
-                      {category.id}
+                      {category.title}
                     </Link>
                   ))}
                 </HStack>


### PR DESCRIPTION
# Changing only the text of the category Shown in wikis widget and Create wiki 

_Categories shown in the wiki widget or create wiki options do not fully say the name of the category like in (people  [People In Crypto ] , defi  [Decentralised Finance] )

## How should this be tested?

1. Before
 
![image](https://user-images.githubusercontent.com/75235148/179994246-6d558e38-eeff-4dd9-8e04-e6c799188248.png)

![image](https://user-images.githubusercontent.com/75235148/179994508-c5a30979-7d65-4345-88ff-1f31e459d9da.png)


2. Now
![image](https://user-images.githubusercontent.com/75235148/179993711-be15ae4e-d6bf-4a80-a29c-273163ddbbf7.png)

![Screenshot 2022-07-20 140735](https://user-images.githubusercontent.com/75235148/179991905-f542bcab-39a1-4667-9bbc-71aa3e1d5dc8.png)


## Linked issues
closes https://github.com/EveripediaNetwork/issues/issues/535
