### PR TITLE
Stylings on the home page and wiki

### DIFF
--- a/src/components/Landing/HeroCard.tsx
+++ b/src/components/Landing/HeroCard.tsx
@@ -21,6 +21,7 @@ export const HeroCard = ({ wiki }: { wiki: Wiki | undefined }) => {
         alignSelf="center"
         direction="column"
         bgColor="red"
+        _dark={{ bgColor: 'gray.700', color: 'white' }}
         shadow="lg"
         rounded="lg"
         bg="white"

--- a/src/components/Wiki/WikiPage/InsightComponents/ProfileSummary.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/ProfileSummary.tsx
@@ -12,7 +12,7 @@ import {
 import { CommonMetaIds, Wiki } from '@/types/Wiki'
 import { LINK_OPTIONS } from '@/components/Layout/Editor/Highlights/HighlightsModal/HighlightsModal'
 import { FiExternalLink } from 'react-icons/fi'
-import {shortenText} from '@/utils/shortenText'
+import { shortenText } from '@/utils/shortenText'
 
 type ProfileSummaryProps = {
   wiki: Wiki

--- a/src/components/Wiki/WikiPage/InsightComponents/ProfileSummary.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/ProfileSummary.tsx
@@ -118,7 +118,7 @@ const OfficialSite = ({
                     <Link
                       rel="nofollow"
                       target="_blank"
-                      href={parseLink((social.value).trim())}
+                      href={parseLink(social.value.trim())}
                       color="brand.500"
                     >
                       <Text>{shortenText(social.value, 20)}</Text>

--- a/src/components/Wiki/WikiPage/InsightComponents/ProfileSummary.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/ProfileSummary.tsx
@@ -12,6 +12,7 @@ import {
 import { CommonMetaIds, Wiki } from '@/types/Wiki'
 import { LINK_OPTIONS } from '@/components/Layout/Editor/Highlights/HighlightsModal/HighlightsModal'
 import { FiExternalLink } from 'react-icons/fi'
+import {shortenText} from '@/utils/shortenText'
 
 type ProfileSummaryProps = {
   wiki: Wiki
@@ -117,10 +118,10 @@ const OfficialSite = ({
                     <Link
                       rel="nofollow"
                       target="_blank"
-                      href={parseLink(social.value)}
+                      href={parseLink((social.value).trim())}
                       color="brand.500"
                     >
-                      <Text>{social.value}</Text>
+                      <Text>{shortenText(social.value, 20)}</Text>
                     </Link>
                   )
                 })}


### PR DESCRIPTION
# Stylings on the home page and wiki

_This PR solves two issues 
a) the home page wiki bg color
b) the profile summary link styling : here I trimmed the link because some have whitespace in front which doesn't parse the link well....also I shortened the Text to show a length that's okay for links 

## How should this be tested?
 Visiting the homepage

Checking a wiki with a profile official site link

1. 
![Screenshot_20220722-172121_Chrome](https://user-images.githubusercontent.com/75235148/180482572-fa5e2ba1-043d-4b4f-9d7c-b1ada9f1d311.jpg)
![Screenshot_20220722-172247_Chrome](https://user-images.githubusercontent.com/75235148/180482578-d1284c1b-da14-4324-8359-58388d82990c.jpg)



2. Now
![Screenshot (328)](https://user-images.githubusercontent.com/75235148/180481851-297abcb2-b817-49ca-9d2a-8a08f31229ac.png)
![Screenshot (326)](https://user-images.githubusercontent.com/75235148/180481865-c5cf76e3-987a-4bb3-a348-d3a435da1106.png)



## Linked issues

 closes https://github.com/EveripediaNetwork/issues/issues/541
And 
closes https://github.com/EveripediaNetwork/issues/issues/553
