### PR TITLE
Removed icon, Text margins smaller and made sub-cat card links

### DIFF
--- a/src/components/Categories/CategoryCard.tsx
+++ b/src/components/Categories/CategoryCard.tsx
@@ -67,9 +67,9 @@ const CategoryCard = ({
 
         <Box p={8}>
           <LinkOverlay href={`/categories/${categoryId}`}>
-              <Heading textAlign="center" size="sm" my="10px">
-                {title}
-              </Heading>
+            <Heading textAlign="center" size="sm" my="10px">
+              {title}
+            </Heading>
           </LinkOverlay>
           <Text maxWidth="300px" fontSize="xs" textAlign="center" opacity="0.6">
             {brief.length > CATEGORY_DESCRIPTION_WORD_LIMIT

--- a/src/components/Categories/CategoryCard.tsx
+++ b/src/components/Categories/CategoryCard.tsx
@@ -11,7 +11,6 @@ import {
 import { getBootStrapIcon } from '@/utils/getBootStrapIcon'
 import { CATEGORY_DESCRIPTION_WORD_LIMIT } from '@/data/Constants'
 import { Image } from '../Elements/Image/Image'
-import { Link } from '../Elements'
 
 interface CategoryCardProps {
   imageCard: string
@@ -67,13 +66,11 @@ const CategoryCard = ({
         </Box>
 
         <Box p={8}>
-          <Link href={`/categories/${categoryId}`} passHref>
-            <LinkOverlay>
+          <LinkOverlay href={`/categories/${categoryId}`}>
               <Heading textAlign="center" size="sm" my="10px">
                 {title}
               </Heading>
-            </LinkOverlay>
-          </Link>
+          </LinkOverlay>
           <Text maxWidth="300px" fontSize="xs" textAlign="center" opacity="0.6">
             {brief.length > CATEGORY_DESCRIPTION_WORD_LIMIT
               ? brief.slice(0, CATEGORY_DESCRIPTION_WORD_LIMIT).concat('...')

--- a/src/pages/categories/[category].tsx
+++ b/src/pages/categories/[category].tsx
@@ -101,12 +101,12 @@ const CategoryPage = ({ categoryData, wikis }: CategoryPageProps) => {
           mx="auto"
           px={5}
         >
-          <Text my={5} mx={14}>
+          <Text my={8} mx={14}>
             {categoryData?.description || ''}
           </Text>
         </Flex>
         <Divider />
-        <Box mt={16}>
+        <Box mt={10}>
           <Heading fontSize={25} textAlign="center">
             {t('wikiInCategory')}
           </Heading>
@@ -116,7 +116,7 @@ const CategoryPage = ({ categoryData, wikis }: CategoryPageProps) => {
                 columns={{ base: 1, sm: 2, lg: 3 }}
                 width="min(90%, 1300px)"
                 mx="auto"
-                my={12}
+                my={10}
                 gap={8}
               >
                 {wikisInCategory.map((wiki, i) => (

--- a/src/pages/categories/[category].tsx
+++ b/src/pages/categories/[category].tsx
@@ -6,7 +6,6 @@ import {
   Box,
   Heading,
   SimpleGrid,
-  Icon,
   Flex,
   Text,
   Button,
@@ -36,7 +35,6 @@ type CategoryPageProps = NextPage & {
 }
 
 const CategoryPage = ({ categoryData, wikis }: CategoryPageProps) => {
-  const categoryIcon = getBootStrapIcon(categoryData.icon)
   const router = useRouter()
   const category = router.query.category as string
   const {
@@ -96,27 +94,15 @@ const CategoryPage = ({ categoryData, wikis }: CategoryPageProps) => {
         >
           {categoryData?.title}
         </Heading>
-        <Flex mx="auto" justifyContent="center" mt={5}>
-          <Icon
-            as={categoryIcon}
-            borderRadius="100px"
-            overflow="hidden"
-            borderWidth="5px"
-            bgColor={`hsl(${Math.floor(Math.random() * 360)}, 70%, 80%)`}
-            color="#0000002f"
-            width={{ base: 14, lg: 15 }}
-            height={{ base: 14, lg: 15 }}
-            padding={1}
-          />
-        </Flex>
         <Flex
           textAlign="center"
           justifyContent="center"
           fontWeight="400"
+          maxW={{ base: "70%", md: "60%", lg: "40%" }}
           mx="auto"
           px={5}
         >
-          <Text mt={3} mb={3}>
+          <Text my={5} mx={14}>
             {categoryData?.description || ''}
           </Text>
         </Flex>

--- a/src/pages/categories/[category].tsx
+++ b/src/pages/categories/[category].tsx
@@ -20,7 +20,6 @@ import {
 } from '@/services/categories'
 import { store } from '@/store/store'
 import { Category } from '@/types/CategoryDataTypes'
-import { getBootStrapIcon } from '@/utils/getBootStrapIcon'
 import WikiPreviewCard from '@/components/Wiki/WikiPreviewCard/WikiPreviewCard'
 import { getWikisByCategory } from '@/services/wikis'
 import { Wiki } from '@/types/Wiki'
@@ -98,7 +97,7 @@ const CategoryPage = ({ categoryData, wikis }: CategoryPageProps) => {
           textAlign="center"
           justifyContent="center"
           fontWeight="400"
-          maxW={{ base: "70%", md: "60%", lg: "40%" }}
+          maxW={{ base: '70%', md: '60%', lg: '40%' }}
           mx="auto"
           px={5}
         >

--- a/src/pages/categories/[category].tsx
+++ b/src/pages/categories/[category].tsx
@@ -97,7 +97,7 @@ const CategoryPage = ({ categoryData, wikis }: CategoryPageProps) => {
           textAlign="center"
           justifyContent="center"
           fontWeight="400"
-          maxW={{ base: '70%', md: '60%', lg: '40%' }}
+          maxW="70%"
           mx="auto"
           px={5}
         >

--- a/src/pages/categories/index.tsx
+++ b/src/pages/categories/index.tsx
@@ -48,9 +48,10 @@ const Categories: NextPage = () => {
           justifyContent="center"
           fontWeight="400"
           mx="auto"
+          maxW={{ base: "70%", md: "60%", lg: "40%" }}
           px={6}
         >
-          <Text mt={3} mb={7}>
+          <Text mt={3} mb={7} mx={14}>
             {CATEGORY_HEADER}
           </Text>
         </Flex>

--- a/src/pages/categories/index.tsx
+++ b/src/pages/categories/index.tsx
@@ -48,7 +48,7 @@ const Categories: NextPage = () => {
           justifyContent="center"
           fontWeight="400"
           mx="auto"
-          maxW={{ base: "70%", md: "60%", lg: "40%" }}
+          maxW={{ base: '70%', md: '60%', lg: '40%' }}
           px={6}
         >
           <Text mt={3} mb={7} mx={14}>

--- a/src/pages/categories/index.tsx
+++ b/src/pages/categories/index.tsx
@@ -38,7 +38,6 @@ const Categories: NextPage = () => {
           maxW="80%"
           mx="auto"
           textAlign="center"
-          mt={8}
           p={10}
         >
           {`${t('wikiCategory')}`}
@@ -51,7 +50,7 @@ const Categories: NextPage = () => {
           maxW={{ base: '70%', lg: '60%' }}
           px={5}
         >
-          <Text mt={3} mb={7} mx={14}>
+          <Text mb={7} mx={14}>
             {CATEGORY_HEADER}
           </Text>
         </Flex>

--- a/src/pages/categories/index.tsx
+++ b/src/pages/categories/index.tsx
@@ -48,8 +48,8 @@ const Categories: NextPage = () => {
           justifyContent="center"
           fontWeight="400"
           mx="auto"
-          maxW={{ base: '70%', md: '60%', lg: '40%' }}
-          px={6}
+          maxW={{ base: '70%', lg: '60%' }}
+          px={5}
         >
           <Text mt={3} mb={7} mx={14}>
             {CATEGORY_HEADER}


### PR DESCRIPTION
# Removed Cetgory page icon, Reduced Text margins and made sub-category card to link to pages

This Pr fixes the text margins , Category icons removed & linked sub-category cards

## How should this be tested?
By checking the Category page and sub-category pages, the text margins are smaller and the icons are removed as well as the sub-category cards are now linked to their respective pages.

 How they now look compared to before 
![image](https://user-images.githubusercontent.com/75235148/180609639-6e50a7bf-f25a-4d89-be0f-e0013618547b.png)

![image](https://user-images.githubusercontent.com/75235148/180609645-20bf17c5-5ccc-480e-817a-34bc534f0efa.png)

![image](https://user-images.githubusercontent.com/75235148/180609647-628778b1-4b25-4798-b625-4bc44a4977b3.png)


## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/551
