### PR TITLE
Fixing multi-select on Search Dropdown

### DIFF
--- a/src/components/Layout/Navbar/NavSearch/index.tsx
+++ b/src/components/Layout/Navbar/NavSearch/index.tsx
@@ -132,7 +132,7 @@ export const NavSearch = (props: NavSearchProps) => {
           article.images && article.images[0].id
         }`
         const value = fillType(article, SEARCH_TYPES.ARTICLE)
-        //This negates the bug that is casued by two wikis with the same title.
+        // This negates the bug that is casued by two wikis with the same title.
         value.title = `${article.title}${article.id}`
         return (
           <AutoCompleteItem

--- a/src/components/Layout/Navbar/NavSearch/index.tsx
+++ b/src/components/Layout/Navbar/NavSearch/index.tsx
@@ -133,7 +133,7 @@ export const NavSearch = (props: NavSearchProps) => {
         const value = fillType(article, SEARCH_TYPES.ARTICLE)
         return (
           <AutoCompleteItem
-            key={article.id}
+            key={`${article.id}${article.updated}`}
             value={value}
             getValue={art => art.title}
             label={article.title}
@@ -145,7 +145,7 @@ export const NavSearch = (props: NavSearchProps) => {
                 {article.title}
               </chakra.span>
               <Text noOfLines={1} maxW="full" fontSize="xs">
-                {article.content}
+                {article.content.replace(/[^a-zA-Z0-9 ]/g, '')}
               </Text>
             </Flex>
             <Flex gap="1" ml="auto">

--- a/src/components/Layout/Navbar/NavSearch/index.tsx
+++ b/src/components/Layout/Navbar/NavSearch/index.tsx
@@ -13,6 +13,7 @@ import {
   useEventListener,
 } from '@chakra-ui/react'
 import { Search2Icon } from '@chakra-ui/icons'
+import { getWikiSummary, WikiSummarySize } from '@/utils/getWikiSummary'
 import {
   AutoComplete,
   AutoCompleteGroup,
@@ -145,7 +146,7 @@ export const NavSearch = (props: NavSearchProps) => {
                 {article.title}
               </chakra.span>
               <Text noOfLines={1} maxW="full" fontSize="xs">
-                {article.content.replace(/[^a-zA-Z0-9 ]/g, '')}
+                {getWikiSummary(article, WikiSummarySize.Small)}
               </Text>
             </Flex>
             <Flex gap="1" ml="auto">

--- a/src/components/Layout/Navbar/NavSearch/index.tsx
+++ b/src/components/Layout/Navbar/NavSearch/index.tsx
@@ -132,9 +132,11 @@ export const NavSearch = (props: NavSearchProps) => {
           article.images && article.images[0].id
         }`
         const value = fillType(article, SEARCH_TYPES.ARTICLE)
+        //This negates the bug that is casued by two wikis with the same title.
+        value.title = `${article.title}${article.id}`
         return (
           <AutoCompleteItem
-            key={`${article.id}${article.updated}`}
+            key={article.id}
             value={value}
             getValue={art => art.title}
             label={article.title}

--- a/src/services/search/queries.ts
+++ b/src/services/search/queries.ts
@@ -6,6 +6,7 @@ export const GET_WIKIS_BY_TITLE = gql`
       id
       title
       content
+      summary
       updated
       tags {
         id


### PR DESCRIPTION
The issue was the IDs of the items were identical and we were using this as the Key for the items. 
To fix this, we now have the the Key to be a combination of ID and the Unique UpdateTimes. 

The markdown symbols have also been replaced using Regex. 

<img width="819" alt="image" src="https://user-images.githubusercontent.com/30846348/180765944-b9556cc7-63ed-4b15-b5a7-ed80d7267b9b.png">
Before.  

<img width="877" alt="image" src="https://user-images.githubusercontent.com/30846348/180765964-2df211d6-72e3-4086-872d-529316d3e012.png">
After. 

## Linked issues

closes #555, closes #555, closes https://github.com/EveripediaNetwork/issues/issues/555
