### PR TITLE
Adding cateogory title in page title for SEO

### DIFF
--- a/src/pages/wiki/[slug]/index.tsx
+++ b/src/pages/wiki/[slug]/index.tsx
@@ -44,7 +44,7 @@ const Wiki = ({ wiki }: WikiProps) => {
     <>
       {wiki && (
         <WikiHeader
-          title={`${wiki.title} [${wiki?.categories[0]?.title}]`}
+          title={`${wiki.title} - ${wiki?.categories[0]?.title}`}
           description={getWikiSummary(wiki)}
           mainImage={getWikiImageUrl(wiki)}
         />

--- a/src/pages/wiki/[slug]/index.tsx
+++ b/src/pages/wiki/[slug]/index.tsx
@@ -40,12 +40,11 @@ const Wiki = ({ wiki }: WikiProps) => {
   useEffect(() => {
     setIsTocEmpty(toc.length === 0)
   }, [toc])
-
   return (
     <>
       {wiki && (
         <WikiHeader
-          title={wiki.title}
+          title={`${wiki.title} [${wiki?.categories[0]?.title}]`}
           description={getWikiSummary(wiki)}
           mainImage={getWikiImageUrl(wiki)}
         />


### PR DESCRIPTION
<img width="319" alt="Screenshot 2022-07-26 at 20 22 09" src="https://user-images.githubusercontent.com/30846348/181094844-7ff82d57-44e6-4cf4-b287-65dedef7abf2.png">
Before 

![image](https://user-images.githubusercontent.com/30846348/181101053-ac9ddb72-6b96-458f-881c-0fc27394353c.png)
After. 

## Linked issues

closes #542, closes #542, closes https://github.com/EveripediaNetwork/issues/issues/542
