### PR TITLE
profile wikis showing

### DIFF
--- a/src/components/Profile/UserWikis/UserCreatedWikis.tsx
+++ b/src/components/Profile/UserWikis/UserCreatedWikis.tsx
@@ -22,7 +22,6 @@ const UserCreatedWikis = () => {
   } = useInfiniteData<Activity>({
     initiator: getUserCreatedWikis,
     arg: { id: address },
-    defaultLoading: true,
   })
 
   useEffect(() => {

--- a/src/components/Profile/UserWikis/UserEditedWikis.tsx
+++ b/src/components/Profile/UserWikis/UserEditedWikis.tsx
@@ -23,7 +23,6 @@ const UserEditedWikis = () => {
   } = useInfiniteData<Activity>({
     initiator: getUserEditedWikis,
     arg: { id: address },
-    defaultLoading: true,
   })
 
   useEffect(() => {


### PR DESCRIPTION
# Profile wikis now fully showing

_All wikis in the wikis and edit tab on the profile are now fully showing

## How should this be tested?
Going to your profile or the profile of a writer/editor and view the wikis created

1. Like this
![Screenshot (334)](https://user-images.githubusercontent.com/75235148/181711751-980916c3-2624-427e-a351-0c252d5e2812.png)

![Screenshot (336)](https://user-images.githubusercontent.com/75235148/181711789-df9e8d9b-b709-46db-9336-bdb8b60ccc9c.png)

![Screenshot (337)](https://user-images.githubusercontent.com/75235148/181711811-df3356c2-885f-4ebf-8e51-5bd348daab41.png)

![Screenshot (338)](https://user-images.githubusercontent.com/75235148/181711833-dba04ead-7b13-4250-89a7-440f022fc6e2.png)

![Screenshot (339)](https://user-images.githubusercontent.com/75235148/181711843-06e6107e-acb0-45e8-b080-8e7ed26b2353.png)




## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/581
