### PR TITLE
Updating Profile when navigating accounts. 

### DIFF
--- a/src/pages/account/[profile].tsx
+++ b/src/pages/account/[profile].tsx
@@ -8,7 +8,7 @@ import config from '@/config'
 import { getUserAddressFromUsername, getUserProfile } from '@/services/profile'
 import { store } from '@/store/store'
 import { ProfileData } from '@/types/ProfileType'
-import { Flex } from '@chakra-ui/react'
+import { Box, Flex } from '@chakra-ui/react'
 import { BaseProvider, StaticJsonRpcProvider } from '@ethersproject/providers'
 import { GetServerSideProps } from 'next'
 import { useRouter } from 'next/router'
@@ -25,7 +25,7 @@ const Profile = ({ profileData }: ProfileProps) => {
   const profileContext = useProfile()
 
   return (
-    <>
+    <Box key={address}>
       <UserProfileHeader
         username={profileData?.username || address}
         bio={profileData?.bio}
@@ -49,7 +49,7 @@ const Profile = ({ profileData }: ProfileProps) => {
           <Collections />
         </Flex>
       </ProfileProvider>
-    </>
+    </Box>
   )
 }
 


### PR DESCRIPTION
This PR fixes the issue where profile data does not change even after navigating to a different account. 

How to test. ([link](https://monopedia-ui-git-585-routing-error-of-pages-prediqt.vercel.app/))
-Go to any random user  account, then using the profile dropdown go to your account and notice how the data on the profile page adjusts and changes as you navigate. 

## Linked issues

closes #585, closes #585, closes https://github.com/EveripediaNetwork/issues/issues/585
