### PR TITLE
centered wiki bg picture

### DIFF
--- a/src/components/Landing/HeroCard.tsx
+++ b/src/components/Landing/HeroCard.tsx
@@ -30,6 +30,7 @@ export const HeroCard = ({ wiki }: { wiki: Wiki | undefined }) => {
         _hover={{ shadow: '2xl' }}
         maxW={{ base: 'min(90vw, 400px)', md: '96', lg: '418' }}
         w="full"
+        overflow='clip'
       >
         <WikiImage
           cursor="pointer"
@@ -39,6 +40,7 @@ export const HeroCard = ({ wiki }: { wiki: Wiki | undefined }) => {
           imgW="450"
           borderRadius="none"
           roundedTop="lg"
+          ml='-5'
         />
         <Flex
           direction="column"

--- a/src/components/Landing/HeroCard.tsx
+++ b/src/components/Landing/HeroCard.tsx
@@ -30,7 +30,7 @@ export const HeroCard = ({ wiki }: { wiki: Wiki | undefined }) => {
         _hover={{ shadow: '2xl' }}
         maxW={{ base: 'min(90vw, 400px)', md: '96', lg: '418' }}
         w="full"
-        overflow='clip'
+        overflow="clip"
       >
         <WikiImage
           cursor="pointer"
@@ -40,7 +40,7 @@ export const HeroCard = ({ wiki }: { wiki: Wiki | undefined }) => {
           imgW="450"
           borderRadius="none"
           roundedTop="lg"
-          ml='-5'
+          ml="-5"
         />
         <Flex
           direction="column"


### PR DESCRIPTION
# Positioned the homepage wiki picture in center

_The frax finance picture in the home page is not evenly centered
## How should this be tested?

![image](https://user-images.githubusercontent.com/75235148/181838658-7a5a6bca-0f44-4461-89a5-1d6e42ce59ff.png)




## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/593
