### PR TITLE
Fix external links to have target _blank

### DIFF
--- a/src/components/Elements/LinkOverlay/LinkOverlay.tsx
+++ b/src/components/Elements/LinkOverlay/LinkOverlay.tsx
@@ -15,12 +15,7 @@ const LinkOverlay = ({ href, children, ...props }: ChakraLinkAndNextProps) => {
     }
   }
   return (
-    <NextLink
-      href={href}
-      prefetch={!(href.includes('create-wiki') || href.includes('about'))}
-      passHref
-      {...linkProps}
-    >
+    <NextLink href={href} passHref {...linkProps}>
       <ChakraLinkOverlay {...props}>{children}</ChakraLinkOverlay>
     </NextLink>
   )

--- a/src/components/Wiki/WikiPage/WikiReferences.tsx
+++ b/src/components/Wiki/WikiPage/WikiReferences.tsx
@@ -72,7 +72,7 @@ const WikiReferences = ({ references }: WikiReferencesProps) => {
                   <LinkOverlay
                     fontWeight="500"
                     rel="nofollow"
-                    target="_blank"
+                    isExternal
                     p="0 !important"
                     href={ref.url}
                   >

--- a/src/components/Wiki/WikiPage/WikiReferences.tsx
+++ b/src/components/Wiki/WikiPage/WikiReferences.tsx
@@ -72,6 +72,7 @@ const WikiReferences = ({ references }: WikiReferencesProps) => {
                   <LinkOverlay
                     fontWeight="500"
                     rel="nofollow"
+                    target="_blank"
                     p="0 !important"
                     href={ref.url}
                   >


### PR DESCRIPTION
# Changes
- fixes prefetch true warning coming from link overviews
- adds target _blank to etherscan icon in user profile page
- makes reference external links (citations) to open in new tab

# Links
- https://monopedia-ui-git-fix-external-links-prediqt.vercel.app/account/srujangurram.eth
- https://monopedia-ui-git-fix-external-links-prediqt.vercel.app/wiki/sushiswap