### PR TITLE
fixed wiki cards in category page getting duplicated

### DIFF
--- a/src/utils/useInfiniteData.ts
+++ b/src/utils/useInfiniteData.ts
@@ -17,30 +17,32 @@ export const useInfiniteData = <T>(opts: Opts) => {
   const updatedOffset = offset + ITEM_PER_PAGE
 
   const fetcher = (noOffset?: boolean) => {
-    setTimeout(() => {
-      const fetchNewWikis = async () => {
-        const result = await store.dispatch(
-          opts.initiator.initiate({
-            ...opts.arg,
-            limit: ITEM_PER_PAGE,
-            offset: noOffset ? 0 : updatedOffset,
-          }),
-        )
-        if (result.data && result.data?.length > 0) {
-          const { data: resData } = result
-          setData(prevData => [...prevData, ...resData])
-          setOffset(updatedOffset)
-          if (resData.length < ITEM_PER_PAGE) {
-            setHasMore(false)
-            setLoading(false)
-          }
-        } else {
+    if (loading) return
+    setLoading(true)
+
+    const fetchNewWikis = async () => {
+      const result = await store.dispatch(
+        opts.initiator.initiate({
+          ...opts.arg,
+          limit: ITEM_PER_PAGE,
+          offset: noOffset ? 0 : updatedOffset,
+        }),
+      )
+      if (result.data && result.data?.length > 0) {
+        const { data: resData } = result
+        setData(prevData => [...prevData, ...resData])
+        setOffset(updatedOffset)
+        if (resData.length < ITEM_PER_PAGE) {
           setHasMore(false)
-          setLoading(false)
+        } else {
+          setHasMore(true)
         }
       }
-      fetchNewWikis()
-    }, FETCH_DELAY_TIME)
+
+      setLoading(false)
+    }
+
+    setTimeout(fetchNewWikis, FETCH_DELAY_TIME)
   }
 
   return {


### PR DESCRIPTION
Fixes https://github.com/EveripediaNetwork/issues/issues/612

# Changes
- made useInfiniteData hook to not fetch data if the previous is still loading

# How to test
Scroll up and down rapidly multiple times till many wikis gets loaded. observe for duplicate wikis for both links
- **Unfixed version** : https://alpha.everipedia.org/categories/nfts
-  **Fixed version** : https://monopedia-ui-git-fix-category-wikis-duplicates-prediqt.vercel.app/categories/nfts
