### PR TITLE
changed content override keyword which is interfearing with links

### DIFF
--- a/src/components/Layout/Editor/Editor.tsx
+++ b/src/components/Layout/Editor/Editor.tsx
@@ -78,8 +78,8 @@ const Editor = ({ onChange, markdown = '' }: EditorType) => {
 
   useEffect(() => {
     if (
-      markdown.substring(0, EditorContentOverride.KEYWORD.length) ===
-      EditorContentOverride.KEYWORD
+      markdown.substring(0, EditorContentOverride.length) ===
+      EditorContentOverride
     )
       updateEditorText(markdown.substring(26))
     else updateEditorText(markdown)
@@ -103,8 +103,8 @@ const Editor = ({ onChange, markdown = '' }: EditorType) => {
 
     if (markdown !== currentMd) {
       if (
-        markdown.substring(0, EditorContentOverride.KEYWORD.length) ===
-        EditorContentOverride.KEYWORD
+        markdown.substring(0, EditorContentOverride.length) ===
+        EditorContentOverride
       ) {
         onChange(markdown.substring(26), true)
       } else if (

--- a/src/editor-plugins/cite/frame/ReferenceCard.tsx
+++ b/src/editor-plugins/cite/frame/ReferenceCard.tsx
@@ -72,7 +72,7 @@ export const ReferenceCard = ({
     }
     store.dispatch({
       type: 'wiki/setContent',
-      payload: EditorContentOverride.KEYWORD + newContent,
+      payload: EditorContentOverride + newContent,
     })
 
     // =======================

--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -441,7 +441,7 @@ const CreateWikiContent = () => {
         payload: {
           ...initWikiData,
           content:
-            EditorContentOverride.KEYWORD +
+            EditorContentOverride +
             initWikiData.content.replace(/ {2}\n/gm, '\n'),
           metadata,
         },

--- a/src/types/Wiki.ts
+++ b/src/types/Wiki.ts
@@ -23,10 +23,7 @@ export interface Media {
   source: 'IPFS_IMG' | 'VIMEO' | 'YOUTUBE' | 'IPFS_VID'
 }
 
-export enum EditorContentOverride {
-  KEYWORD = '[OVERRIDE@EDITOR@MARKDOWN]',
-}
-
+export const EditorContentOverride = '%OVERRIDE@EDITOR@MARKDOWN%'
 export const CreateNewWikiSlug = '/*CREATE+NEW+WIKI*/'
 
 export enum CommonMetaIds {

--- a/src/utils/create-wiki.ts
+++ b/src/utils/create-wiki.ts
@@ -140,8 +140,7 @@ export const useCreateWikiEffects = (
           payload: {
             ...draft,
             content:
-              EditorContentOverride.KEYWORD +
-              draft.content.replace(/ {2}\n/gm, '\n'),
+              EditorContentOverride + draft.content.replace(/ {2}\n/gm, '\n'),
           },
         })
       } else {
@@ -149,7 +148,7 @@ export const useCreateWikiEffects = (
         dispatch({
           type: 'wiki/setInitialWikiState',
           payload: {
-            content: EditorContentOverride.KEYWORD + initialEditorValue,
+            content: EditorContentOverride + initialEditorValue,
           },
         })
       }


### PR DESCRIPTION
# Changes
- changed editor override keyword from ```[OVERRIDE@EDITOR@MARKDOWN]``` to ```%OVERRIDE@EDITOR@MARKDOWN%``` which is interfering with links if opening of wiki is in parenthesis

# Screenshots
### Before 
![image](https://user-images.githubusercontent.com/52039218/184532964-69f6c00c-04f4-4b80-b9a6-94f0b210a672.png)

### After
<img width="1401" alt="CleanShot 2022-08-14 at 16 04 00@2x" src="https://user-images.githubusercontent.com/52039218/184532983-b9bec10f-3d96-4555-bd5f-bc7cc24620b1.png">

