### PR TITLE
Fixed facebook link test

### DIFF
--- a/src/data/WikiLinks.ts
+++ b/src/data/WikiLinks.ts
@@ -88,7 +88,7 @@ export const LINK_OPTIONS = [
     type: LinkType.SOCIAL,
     label: 'Facebook',
     icon: FacebookIcon,
-    tests: [/https:\/\/(www.)?facebook.com\/\w+/],
+    tests: [/https:\/\/(www.)?((web|m).)?facebook.com\/\w+/],
   },
   {
     id: CommonMetaIds.COINGECKO_PROFILE,


### PR DESCRIPTION
Fixes https://github.com/EveripediaNetwork/issues/issues/629

# Changes
- adds support for web.facebook.com and m.facebook.com links