### PR TITLE
Profile wikis loading fix not loading wikis after first 12

### DIFF
--- a/src/utils/useInfiniteData.ts
+++ b/src/utils/useInfiniteData.ts
@@ -42,33 +42,6 @@ export const useInfiniteData = <T>(opts: Opts) => {
     setTimeout(fetchNewWikis, FETCH_DELAY_TIME)
   }
 
-  // const fetcher = (noOffset?: boolean) => {
-  //   setTimeout(() => {
-  //     const fetchNewWikis = async () => {
-  //       const result = await store.dispatch(
-  //         opts.initiator.initiate({
-  //           ...opts.arg,
-  //           limit: ITEM_PER_PAGE,
-  //           offset: noOffset ? 0 : updatedOffset,
-  //         }),
-  //       )
-  //       if (result.data && result.data?.length > 0) {
-  //         const { data: resData } = result
-  //         setData(prevData => [...prevData, ...resData])
-  //         setOffset(updatedOffset)
-  //         if (resData.length < ITEM_PER_PAGE) {
-  //           setHasMore(false)
-  //           setLoading(false)
-  //         }
-  //       } else {
-  //         setHasMore(false)
-  //         setLoading(false)
-  //       }
-  //     }
-  //     fetchNewWikis()
-  //   }, FETCH_DELAY_TIME)
-  // }
-
   return {
     fetcher,
     hasMore,

--- a/src/utils/useInfiniteData.ts
+++ b/src/utils/useInfiniteData.ts
@@ -14,31 +14,32 @@ export const useInfiniteData = <T>(opts: Opts) => {
   const [data, setData] = useState<T[] | []>([])
   const [offset, setOffset] = useState<number>(0)
   const [loading, setLoading] = useState<boolean>(opts.defaultLoading || false)
-  const updatedOffset = offset + ITEM_PER_PAGE
 
   const fetcher = (noOffset?: boolean) => {
     if (loading) return
-    setLoading(true)
 
     const fetchNewWikis = async () => {
+      setOffset(p => p + ITEM_PER_PAGE)
+
       const result = await store.dispatch(
         opts.initiator.initiate({
           ...opts.arg,
           limit: ITEM_PER_PAGE,
-          offset: noOffset ? 0 : updatedOffset,
+          offset: noOffset ? 0 : offset,
         }),
       )
-      if (result.data && result.data?.length > 0) {
-        const { data: resData } = result
+      const { data: resData } = result
+
+      if (resData) {
         setData(prevData => [...prevData, ...resData])
-        setOffset(updatedOffset)
         if (resData.length < ITEM_PER_PAGE) setHasMore(false)
         else setHasMore(true)
       }
-      setHasMore(false)
+      if (resData.length === 0) setHasMore(false)
       setLoading(false)
     }
 
+    setLoading(true)
     setTimeout(fetchNewWikis, FETCH_DELAY_TIME)
   }
 


### PR DESCRIPTION
Fixes https://github.com/EveripediaNetwork/issues/issues/581

# How to test
compare edited wikis in 
- https://alpha.everipedia.org/account/srujangurram.eth
- https://monopedia-ui-git-profile-wikis-loading-fix-prediqt.vercel.app/account/srujangurram.eth

The first one only loads 12 wikis but the second fixed version loads all the edited wikis which are more than 12