### PR TITLE
Fixes twitter timeline overflow

### DIFF
--- a/src/components/Wiki/WikiPage/InsightComponents/TwitterTimeline.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/TwitterTimeline.tsx
@@ -18,14 +18,14 @@ const TwitterTimeline = ({ url }: { url: string }) => {
     <VStack w="100%" spacing={4} borderRadius={2} mb="5">
       <WikiAccordion title="Twitter Timeline">
         <Box
-          className="wikiTwitterTimelineWidget"
           h="400px"
-          bgColor="white"
+          bgColor="dimColor"
           _dark={{
             bgColor: 'dimColor',
           }}
-          borderRadius={4}
+          borderRadius={12}
           position="relative"
+          overflowY="scroll"
         >
           {snapOpen && (
             <TwitterTimelineEmbed
@@ -34,7 +34,7 @@ const TwitterTimeline = ({ url }: { url: string }) => {
               sourceType="url"
               noScrollbar
               borderColor={colorMode === 'dark' ? '#4a5568' : '#ddd'}
-              url={`//${url}`}
+              url={url}
             />
           )}
         </Box>

--- a/src/components/Wiki/WikiPage/InsightComponents/TwitterTimeline.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/TwitterTimeline.tsx
@@ -19,7 +19,7 @@ const TwitterTimeline = ({ url }: { url: string }) => {
       <WikiAccordion title="Twitter Timeline">
         <Box
           h="400px"
-          bgColor="dimColor"
+          bgColor="white"
           _dark={{
             bgColor: 'dimColor',
           }}


### PR DESCRIPTION
# Changes
- fixes twitter timeline overflow

# screenshots
## Before
![CleanShot 2022-08-21 at 17 52 01@2x](https://user-images.githubusercontent.com/52039218/185790677-97fa3f16-d559-497c-acec-4c27963b7f4f.png)

## After
![CleanShot 2022-08-21 at 17 49 41@2x](https://user-images.githubusercontent.com/52039218/185790610-5196b30e-c757-412e-9b48-33c8494553bc.png)

