### PR TITLE
Restore the page from the edit history

### DIFF
--- a/src/components/Wiki/History/HistoryCard.tsx
+++ b/src/components/Wiki/History/HistoryCard.tsx
@@ -6,6 +6,7 @@ import {
   Icon,
   Link,
   LinkBox,
+  Stack,
   Tag,
   Text,
   Tooltip,
@@ -22,6 +23,7 @@ import { User } from '@/types/Wiki'
 import { getUsername } from '@/utils/getUsername'
 import LinkOverlay from '@/components/Elements/LinkOverlay/LinkOverlay'
 import { LinkButton } from '@/components/Elements'
+import { RiHistoryLine } from 'react-icons/ri'
 
 interface HistoryCardArrowProps {
   isRightAligned?: boolean
@@ -70,6 +72,7 @@ const HistoryCardArrow = ({
 }
 
 interface HistoryCardProps {
+  isUserLoggedIn: boolean
   activityId: string
   isRightAligned?: boolean
   isFullWidth?: boolean
@@ -84,6 +87,7 @@ interface HistoryCardProps {
 }
 
 export const HistoryCard = ({
+  isUserLoggedIn,
   activityId,
   isRightAligned,
   isFullWidth,
@@ -180,7 +184,6 @@ export const HistoryCard = ({
           </Text>
         </Box>
       )}
-
       {/* What Changed tags */}
       {blocksChanged !== '' && (
         <Flex flexWrap="wrap" mt={2} justify="start" gap={2}>
@@ -208,10 +211,6 @@ export const HistoryCard = ({
         </Flex>
       )}
 
-      <LinkButton mt={2} size="sm" href={`/create-wiki?revision=${activityId}`}>
-        Edit
-      </LinkButton>
-
       {/* Transaction address and restore button */}
       <HStack
         borderTopWidth={1}
@@ -221,34 +220,53 @@ export const HistoryCard = ({
         mt={3}
         justify="space-between"
       >
-        <HStack>
-          <Text fontSize="sm" color="text.500">
-            IPFS:
-          </Text>
-          <Link
-            href={`${config.pinataBaseUrl}${IPFS}`}
-            color="brand.500"
-            ml={2}
-            isExternal
-            fontSize="sm"
+        <Stack
+          direction={isUserLoggedIn ? 'column' : 'row'}
+          justifyContent="space-between"
+          w="full"
+        >
+          <HStack>
+            <Text fontSize="sm" color="text.500">
+              {isUserLoggedIn ? 'TX Address:' : 'TX:'}
+            </Text>
+            <Link
+              href={`${config.blockExplorerUrl}/tx/${transactionAddress}`}
+              color="brand.500"
+              ml={2}
+              isExternal
+              fontSize="sm"
+            >
+              {shortenAccount(transactionAddress)}
+            </Link>
+          </HStack>
+          <HStack>
+            <Text fontSize="sm" color="text.500">
+              {isUserLoggedIn ? 'IPFS Hash:' : 'IPFS:'}
+            </Text>
+            <Link
+              href={`${config.pinataBaseUrl}${IPFS}`}
+              color="brand.500"
+              ml={2}
+              isExternal
+              fontSize="sm"
+            >
+              {shortenAccount(IPFS)}
+            </Link>
+          </HStack>
+        </Stack>
+        {isUserLoggedIn && (
+          <LinkButton
+            leftIcon={<RiHistoryLine />}
+            mt={4}
+            size="sm"
+            variant="outline"
+            px={6}
+            color="linkColor"
+            href={`/create-wiki?revision=${activityId}`}
           >
-            {shortenAccount(IPFS)}
-          </Link>
-        </HStack>
-        <HStack>
-          <Text fontSize="sm" color="text.500">
-            TX:
-          </Text>
-          <Link
-            href={`${config.blockExplorerUrl}/tx/${transactionAddress}`}
-            color="brand.500"
-            ml={2}
-            isExternal
-            fontSize="sm"
-          >
-            {shortenAccount(transactionAddress)}
-          </Link>
-        </HStack>
+            Restore
+          </LinkButton>
+        )}
       </HStack>
     </LinkBox>
   )

--- a/src/components/Wiki/History/HistoryCard.tsx
+++ b/src/components/Wiki/History/HistoryCard.tsx
@@ -215,10 +215,11 @@ export const HistoryCard = ({
       <HStack
         borderTopWidth={1}
         m={-4}
-        p={2}
         px={4}
-        mt={3}
+        py={isUserLoggedIn ? 4 : 2}
+        mt={4}
         justify="space-between"
+        align="end"
       >
         <Stack
           direction={isUserLoggedIn ? 'column' : 'row'}

--- a/src/components/Wiki/History/HistoryCard.tsx
+++ b/src/components/Wiki/History/HistoryCard.tsx
@@ -21,6 +21,7 @@ import config from '@/config'
 import { User } from '@/types/Wiki'
 import { getUsername } from '@/utils/getUsername'
 import LinkOverlay from '@/components/Elements/LinkOverlay/LinkOverlay'
+import { LinkButton } from '@/components/Elements'
 
 interface HistoryCardArrowProps {
   isRightAligned?: boolean
@@ -206,6 +207,10 @@ export const HistoryCard = ({
           ))}
         </Flex>
       )}
+
+      <LinkButton mt={2} size="sm" href={`/create-wiki?revision=${activityId}`}>
+        Edit
+      </LinkButton>
 
       {/* Transaction address and restore button */}
       <HStack

--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -272,8 +272,6 @@ const CreateWikiContent = () => {
         postWiki.initiate({ data: finalWiki }),
       )
 
-      console.log({ finalWiki, wikiResult })
-
       if (wikiResult && 'data' in wikiResult) {
         saveHashInTheBlockchain(String(wikiResult.data), await getWikiSlug())
       } else {

--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -272,6 +272,8 @@ const CreateWikiContent = () => {
         postWiki.initiate({ data: finalWiki }),
       )
 
+      console.log({ finalWiki, wikiResult })
+
       if (wikiResult && 'data' in wikiResult) {
         saveHashInTheBlockchain(String(wikiResult.data), await getWikiSlug())
       } else {

--- a/src/pages/wiki/[slug]/history.tsx
+++ b/src/pages/wiki/[slug]/history.tsx
@@ -15,10 +15,12 @@ import { skipToken } from '@reduxjs/toolkit/dist/query'
 import { GetServerSideProps } from 'next'
 import { useRouter } from 'next/router'
 import React from 'react'
+import { useAccount } from 'wagmi'
 
 const History = () => {
   const router = useRouter()
   const { slug } = router.query
+  const { isConnected } = useAccount()
   const { data: wiki } = useGetWikiQuery(
     typeof slug === 'string' ? slug : skipToken,
     {
@@ -82,6 +84,7 @@ const History = () => {
             wikiHistory?.map((activity, index) => {
               return (
                 <HistoryCard
+                  isUserLoggedIn={isConnected}
                   key={activity.id}
                   activityId={activity.id}
                   isRightAligned={isHistoryFullWidth ? true : index % 2 === 0}

--- a/src/services/activities/index.ts
+++ b/src/services/activities/index.ts
@@ -6,9 +6,11 @@ import {
   GET_ACTIVITIES_BY_ID,
   GET_ACTIVITIES_BY_WIKI,
   GET_LATEST_ACTIVITY_BY_WIKI,
+  GET_WIKI_BY_ACTIVITY_ID,
 } from '@/services/activities/queries'
 import config from '@/config'
 import { Activity } from '@/types/ActivityDataType'
+import { Wiki } from '@/types/Wiki'
 
 type GetActivitiesResponse = {
   activities: Activity[]
@@ -60,6 +62,14 @@ export const activitiesApi = createApi({
       transformResponse: (response: GetActivityByIdResponse) =>
         response.activityById,
     }),
+    getWikiByActivityId: builder.query<Wiki, string>({
+      query: (id: string) => ({
+        document: GET_WIKI_BY_ACTIVITY_ID,
+        variables: { id },
+      }),
+      transformResponse: (response: GetActivityByIdResponse) =>
+        response.activityById.content[0],
+    }),
     getLatestIPFSByWiki: builder.query<string, string>({
       query: (wikiId: string) => ({
         document: GET_LATEST_ACTIVITY_BY_WIKI,
@@ -84,6 +94,7 @@ export const {
   useGetActivityByWikiQuery,
   useGetActivityByIdQuery,
   useGetLatestIPFSByWikiQuery,
+  useGetWikiByActivityIdQuery,
   util: { getRunningOperationPromises },
 } = activitiesApi
 
@@ -92,4 +103,5 @@ export const {
   getActivityByWiki,
   getLatestIPFSByWiki,
   getActivityById,
+  getWikiByActivityId,
 } = activitiesApi.endpoints

--- a/src/services/activities/queries.ts
+++ b/src/services/activities/queries.ts
@@ -131,3 +131,54 @@ export const GET_ACTIVITIES_BY_ID = gql`
     }
   }
 `
+export const GET_WIKI_BY_ACTIVITY_ID = gql`
+  query GetWikiByActivityId($id: String!) {
+    activityById(id: $id) {
+      content {
+        id
+        ipfs
+        transactionHash
+        created
+        updated
+        title
+        summary
+        content
+        categories {
+          id
+          title
+        }
+        tags {
+          id
+        }
+        images {
+          id
+          type
+        }
+        media {
+          name
+          id
+          size
+          source
+        }
+        metadata {
+          id
+          value
+        }
+        user {
+          id
+          profile {
+            username
+            avatar
+          }
+        }
+        author {
+          id
+          profile {
+            username
+            avatar
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/utils/create-wiki.ts
+++ b/src/utils/create-wiki.ts
@@ -23,6 +23,7 @@ import {
 import { useToast } from '@chakra-ui/toast'
 import { store } from '@/store/store'
 import { Dict } from '@chakra-ui/utils'
+import { useGetActivityByIdQuery } from '@/services/activities'
 import { logEvent } from './googleAnalytics'
 
 export const initialEditorValue = ` `
@@ -112,7 +113,7 @@ export const useCreateWikiEffects = (
     isPublished: boolean
   }>,
 ) => {
-  const { slug, activeStep, setIsNewCreateWiki, dispatch } =
+  const { slug, revision, activeStep, setIsNewCreateWiki, dispatch } =
     useCreateWikiContext()
 
   useEffect(() => {
@@ -123,7 +124,7 @@ export const useCreateWikiEffects = (
 
   // Reset the State to new wiki if there is no slug
   useEffect(() => {
-    if (!slug) {
+    if (!slug && !revision) {
       setIsNewCreateWiki(true)
       // fetch draft data from local storage
       const draft = getDraftFromLocalStorage()
@@ -303,13 +304,17 @@ export const useGetSignedHash = (deadline: number) => {
 }
 
 export const useCreateWikiState = (router: NextRouter) => {
-  const { isLoading: isLoadingWiki, data: wikiData } = useGetWikiQuery(
-    typeof router.query.slug === 'string' ? router.query.slug : skipToken,
-    {
-      skip: router.isFallback,
-    },
-  )
-  const { slug } = router.query
+  const { slug, revision } = router.query
+
+  const { isLoading: isLoadingLatestWiki, data: latestWikiData } =
+    useGetWikiQuery(!revision && typeof slug === 'string' ? slug : skipToken)
+
+  const { isLoading: isLoadingRevisionWiki, data: revisionWikiData } =
+    useGetActivityByIdQuery(typeof revision === 'string' ? revision : skipToken)
+
+  const isLoadingWiki = isLoadingLatestWiki || isLoadingRevisionWiki
+  const wikiData = revisionWikiData?.content[0] || latestWikiData
+
   const [openTxDetailsDialog, setOpenTxDetailsDialog] = useState<boolean>(false)
   const [isWritingCommitMsg, setIsWritingCommitMsg] = useState<boolean>(false)
   const [txHash, setTxHash] = useState<string>()
@@ -338,6 +343,7 @@ export const useCreateWikiState = (router: NextRouter) => {
     wikiData,
     dispatch,
     slug,
+    revision,
     toast,
     openTxDetailsDialog,
     setOpenTxDetailsDialog,

--- a/src/utils/create-wiki.ts
+++ b/src/utils/create-wiki.ts
@@ -23,7 +23,7 @@ import {
 import { useToast } from '@chakra-ui/toast'
 import { store } from '@/store/store'
 import { Dict } from '@chakra-ui/utils'
-import { useGetActivityByIdQuery } from '@/services/activities'
+import { useGetWikiByActivityIdQuery } from '@/services/activities'
 import { logEvent } from './googleAnalytics'
 
 export const initialEditorValue = ` `
@@ -307,13 +307,24 @@ export const useCreateWikiState = (router: NextRouter) => {
   const { slug, revision } = router.query
 
   const { isLoading: isLoadingLatestWiki, data: latestWikiData } =
-    useGetWikiQuery(!revision && typeof slug === 'string' ? slug : skipToken)
+    useGetWikiQuery(
+      typeof revision !== 'string' && typeof slug === 'string'
+        ? slug
+        : skipToken,
+    )
 
   const { isLoading: isLoadingRevisionWiki, data: revisionWikiData } =
-    useGetActivityByIdQuery(typeof revision === 'string' ? revision : skipToken)
+    useGetWikiByActivityIdQuery(
+      typeof revision === 'string' ? revision : skipToken,
+    )
+
+  console.log({
+    revision,
+    revisionWikiData,
+  })
 
   const isLoadingWiki = isLoadingLatestWiki || isLoadingRevisionWiki
-  const wikiData = revisionWikiData?.content[0] || latestWikiData
+  const wikiData = revisionWikiData || latestWikiData
 
   const [openTxDetailsDialog, setOpenTxDetailsDialog] = useState<boolean>(false)
   const [isWritingCommitMsg, setIsWritingCommitMsg] = useState<boolean>(false)

--- a/src/utils/create-wiki.ts
+++ b/src/utils/create-wiki.ts
@@ -318,11 +318,6 @@ export const useCreateWikiState = (router: NextRouter) => {
       typeof revision === 'string' ? revision : skipToken,
     )
 
-  console.log({
-    revision,
-    revisionWikiData,
-  })
-
   const isLoadingWiki = isLoadingLatestWiki || isLoadingRevisionWiki
   const wikiData = revisionWikiData || latestWikiData
 


### PR DESCRIPTION
Closes https://github.com/EveripediaNetwork/issues/issues/640

# Changes
- added ability to restore data from a revision to create-wiki page with ```/create-wiki?revision={SOME_REVISION_ID}```
- added new ```getWikiFromActivityId``` endpoint to rtk query
- added button in history cards to allow users to fetch data from particular edit to create-wiki page (only shown to logged in users)

# Links
- https://monopedia-ui-git-history-clone-edit-prediqt.vercel.app/wiki/sushiswap/history

# Screenshots
![CleanShot 2022-08-22 at 22 07 20@2x](https://user-images.githubusercontent.com/52039218/185973433-7559131a-fe21-4f54-ae96-fde7b688f316.png)

