### PR TITLE
Design Implementation sync extended

### DIFF
--- a/src/components/About/AboutTestimonial.tsx
+++ b/src/components/About/AboutTestimonial.tsx
@@ -32,7 +32,7 @@ const AboutTestimonial = ({
         {author}
       </Text>
       <Flex direction={{ base: 'column', md: 'row' }}>
-        <Text color="brand.500">{designation}</Text> {location && '⠀•⠀'}
+        <Text color="brandLinkColor">{designation}</Text> {location && '⠀•⠀'}
         <Text>{location}</Text>
       </Flex>
     </Box>

--- a/src/components/Activity/ActivityCard.tsx
+++ b/src/components/Activity/ActivityCard.tsx
@@ -104,7 +104,7 @@ const ActivityCard = ({
             {type && (
               <Text
                 fontSize="sm"
-                color="brand.500"
+                color="brandLinkColor"
                 fontWeight="medium"
                 mb="8px !important"
               >
@@ -119,7 +119,7 @@ const ActivityCard = ({
                   <Text
                     as="a"
                     display={{ base: 'none', md: 'block' }}
-                    color="brand.500"
+                    color="brandLinkColor"
                     fontWeight="bold"
                     cursor="pointer"
                     fontSize={{ base: '12px', lg: '14px' }}
@@ -154,7 +154,7 @@ const ActivityCard = ({
               <Text fontSize="14px" color="linkColor">
                 <Link
                   href={`/account/${editor.id}`}
-                  color="brand.500"
+                  color="brandLinkColor"
                   fontWeight="bold"
                 >
                   {getUsername(editor)}

--- a/src/components/Elements/RelatedTopics/RelatedTopics.tsx
+++ b/src/components/Elements/RelatedTopics/RelatedTopics.tsx
@@ -10,7 +10,8 @@ const RelatedTopics = ({ topics }: RelatedTopicsProp) => (
     position="sticky"
     top="100px"
     display="inline-block"
-    bgColor="pageBg"
+    bgColor="blackAlpha.50"
+    _dark={{ bgColor: 'whiteAlpha.50' }}
     p={10}
     borderRadius={12}
   >
@@ -21,8 +22,8 @@ const RelatedTopics = ({ topics }: RelatedTopicsProp) => (
     <List spacing={2}>
       {topics.map(topic => (
         <ListItem mt="20px">
-          <Link href={topic.url} scroll={!!topic.isSectionLink} passHref>
-            <Link href="passRef">{topic.name}</Link>
+          <Link href={topic.url} scroll={!!topic.isSectionLink}>
+            {topic.name}
           </Link>
         </ListItem>
       ))}

--- a/src/components/Landing/HeroCard.tsx
+++ b/src/components/Landing/HeroCard.tsx
@@ -65,7 +65,7 @@ export const HeroCard = ({ wiki }: { wiki: Wiki | undefined }) => {
             <Text fontSize="14px" color="linkColor">
               <Link
                 href={`/account/${wiki?.user?.id}`}
-                color="brand.500"
+                color="brandLinkColor"
                 fontWeight="bold"
               >
                 {getUsername(wiki?.user, username)}

--- a/src/components/Layout/Editor/WikiScoreIndicator.tsx
+++ b/src/components/Layout/Editor/WikiScoreIndicator.tsx
@@ -72,7 +72,7 @@ const WikiScoreIndicator = ({ wiki }: { wiki: Wiki }) => {
               determining factors such as number of words, citations, tags,
               metalinks etc.{' '}
             </chakra.span>
-            <Link color="brand.500" href="/">
+            <Link color="brandLinkColor" href="/">
               learn more
             </Link>
           </Text>

--- a/src/components/Layout/Navbar/ColorModeToggle.tsx
+++ b/src/components/Layout/Navbar/ColorModeToggle.tsx
@@ -42,7 +42,7 @@ export const ColorModeToggle = ({
           <Switch
             ml="auto"
             isChecked={colorMode === 'dark'}
-            onChange={toggleColorMode}
+            pointerEvents="none"
           />
         </Flex>
       </MenuItem>

--- a/src/components/Profile/Collections.tsx
+++ b/src/components/Profile/Collections.tsx
@@ -24,9 +24,9 @@ export const Collections = () => (
       {SECTIONS.map((section, sid) => (
         <CustomTab
           _selected={{
-            color: 'brand.500 !important',
+            color: 'brandLinkColor !important',
             _after: {
-              background: 'brand.500 !important',
+              background: 'brandLinkColor !important',
             },
           }}
           key={sid}

--- a/src/components/Settings/ImageUpload.tsx
+++ b/src/components/Settings/ImageUpload.tsx
@@ -67,7 +67,7 @@ const ImageUpload = ({
             <Spinner
               size="xl"
               thickness="6px"
-              color="brand.500"
+              color="brandLinkColor"
               display="block"
             />
           </Box>

--- a/src/components/Wiki/History/HistoryCard.tsx
+++ b/src/components/Wiki/History/HistoryCard.tsx
@@ -65,7 +65,7 @@ const HistoryCardArrow = ({
         w={2}
         h={2}
         borderRadius="100%"
-        bgColor="brand.500"
+        bgColor="brandLinkColor"
       />
     </HStack>
   )
@@ -142,7 +142,7 @@ export const HistoryCard = ({
             address={lastEditor.id}
             avatarIPFS={lastEditor.profile?.avatar}
           />
-          <Link href={`/account/${lastEditor.id}`} color="brand.500">
+          <Link href={`/account/${lastEditor.id}`} color="brandLinkColor">
             {getUsername(lastEditor, userENSDomain)}
           </Link>
         </HStack>
@@ -177,7 +177,7 @@ export const HistoryCard = ({
             as={MdFormatQuote}
             fontSize="20px"
             bgColor="cardBg"
-            color="brand.500"
+            color="brandLinkColor"
           />
           <Text fontSize="sm" color="text.500" my={2}>
             <i>{shortenText(commitMessage, 90)}</i>
@@ -232,7 +232,7 @@ export const HistoryCard = ({
             </Text>
             <Link
               href={`${config.blockExplorerUrl}/tx/${transactionAddress}`}
-              color="brand.500"
+              color="brandLinkColor"
               ml={2}
               isExternal
               fontSize="sm"
@@ -246,7 +246,7 @@ export const HistoryCard = ({
             </Text>
             <Link
               href={`${config.pinataBaseUrl}${IPFS}`}
-              color="brand.500"
+              color="brandLinkColor"
               ml={2}
               isExternal
               fontSize="sm"

--- a/src/components/Wiki/WikiAccordion/AccordionWidget.tsx
+++ b/src/components/Wiki/WikiAccordion/AccordionWidget.tsx
@@ -36,7 +36,7 @@ const AccordionWidget = ({ type, title, titleTag, content }: WikiInsights) => {
       return (
         <Link
           target="_blank"
-          color="brand.500"
+          color="brandLinkColor"
           fontSize="14px"
           href={contentURL}
         >
@@ -71,7 +71,11 @@ const AccordionWidget = ({ type, title, titleTag, content }: WikiInsights) => {
             address={content.id}
             avatarIPFS={content.profile?.avatar}
           />
-          <Link fontSize="xs" href={`/account/${content.id}`} color="brand.500">
+          <Link
+            fontSize="xs"
+            href={`/account/${content.id}`}
+            color="brandLinkColor"
+          >
             {getUsername(content, userENSDomain)}
           </Link>
         </HStack>

--- a/src/components/Wiki/WikiPage/CustomRenderers/CiteMarksRender.tsx
+++ b/src/components/Wiki/WikiPage/CustomRenderers/CiteMarksRender.tsx
@@ -95,6 +95,7 @@ const CiteMarksRender = ({ text, href }: { text: string; href?: string }) => {
           onBlur={() => {}}
           href={href}
           borderRadius="100px"
+          color="brandLinkColor"
           _focus={{ outline: 'none', textDecoration: 'underline' }}
         >
           <Text

--- a/src/components/Wiki/WikiPage/CustomRenderers/WikiLinkRender.tsx
+++ b/src/components/Wiki/WikiPage/CustomRenderers/WikiLinkRender.tsx
@@ -33,6 +33,14 @@ const WikiLinkRender = ({
   const linkRef = React.useRef<HTMLAnchorElement>(null)
   const { data: wiki } = useGetWikiPreviewQuery(slug)
 
+  const [isMounted, setIsMounted] = React.useState(false)
+  React.useEffect(() => {
+    setIsMounted(true)
+  }, [])
+  if (!isMounted) {
+    return <a href={href}>{text}</a>
+  }
+
   return (
     <Popover
       isOpen={isOpen}
@@ -48,6 +56,7 @@ const WikiLinkRender = ({
           onFocus={() => {}}
           onBlur={() => {}}
           href={href}
+          color="brandLinkColor"
         >
           {text}
         </a>

--- a/src/components/Wiki/WikiPage/InsightComponents/ProfileSummary.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/ProfileSummary.tsx
@@ -85,7 +85,7 @@ const ProfileSummary = ({ wiki }: ProfileSummaryProps) => {
               rel="nofollow"
               target="_blank"
               href={parseLink(contractURL)}
-              color="brand.500"
+              color="brandLinkColor"
             >
               <Flex align="center" gap="2">
                 <Text fontSize="14px">{shortenText(contractURL, 20)}</Text>
@@ -100,7 +100,7 @@ const ProfileSummary = ({ wiki }: ProfileSummaryProps) => {
               rel="nofollow"
               target="_blank"
               href={parseLink(websiteLink)}
-              color="brand.500"
+              color="brandLinkColor"
             >
               <Flex align="center" gap="2">
                 <Text fontSize="14px">{shortenText(websiteLink, 20)}</Text>
@@ -130,10 +130,10 @@ const ProfileSummary = ({ wiki }: ProfileSummaryProps) => {
                     >
                       <IconButton
                         color="secondaryDark"
-                        _hover={{ color: 'brand.500' }}
+                        _hover={{ color: 'brandLinkColor' }}
                         _dark={{
                           color: 'darkGrey',
-                          _hover: { color: 'brand.500' },
+                          _hover: { color: 'brandLinkColor' },
                         }}
                         key={i}
                         aria-label={`Open ${social.id}`}
@@ -153,7 +153,7 @@ const ProfileSummary = ({ wiki }: ProfileSummaryProps) => {
             {explorerLinksData.map(item => (
               <HStack>
                 <Link
-                  color="brand.500"
+                  color="brandLinkColor"
                   fontSize="14px"
                   key={item.id}
                   href={parseLink(item.value)}
@@ -165,7 +165,7 @@ const ProfileSummary = ({ wiki }: ProfileSummaryProps) => {
                 >
                   {LINK_OPTIONS.find(option => option.id === item.id)?.label}
                 </Link>
-                <Icon color="brand.500" as={RiExternalLinkLine} />
+                <Icon color="brandLinkColor" as={RiExternalLinkLine} />
               </HStack>
             ))}
           </ProfileListItem>

--- a/src/components/Wiki/WikiPage/InsightComponents/WikiDetails.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/WikiDetails.tsx
@@ -72,7 +72,7 @@ export const WikiDetails = ({
                       key={i}
                       isExternal
                       href={`/categories/${category.id}`}
-                      color="brand.500"
+                      color="brandLinkColor"
                     >
                       {category.title}
                     </Link>
@@ -107,7 +107,7 @@ export const WikiDetails = ({
                 <Link
                   target="_blank"
                   href={`https://ipfs.everipedia.org/ipfs/${ipfsHash}`}
-                  color="brand.500"
+                  color="brandLinkColor"
                 >
                   <Text>{shortenAccount(ipfsHash || '')}</Text>
                 </Link>
@@ -125,7 +125,7 @@ export const WikiDetails = ({
               <Link
                 target="_blank"
                 href={`${config.blockExplorerUrl}/tx/${txHash}`}
-                color="brand.500"
+                color="brandLinkColor"
               >
                 <Text>{shortenAccount(txHash || '')}</Text>
               </Link>
@@ -159,7 +159,10 @@ export const WikiDetails = ({
                     avatarIPFS={createdBy.profile?.avatar}
                     size="24"
                   />
-                  <Link href={`/account/${createdBy.id}`} color="brand.500">
+                  <Link
+                    href={`/account/${createdBy.id}`}
+                    color="brandLinkColor"
+                  >
                     {getUsername(createdBy, username)}
                   </Link>
                 </HStack>

--- a/src/components/Wiki/WikiPage/WikiActionBar.tsx
+++ b/src/components/Wiki/WikiPage/WikiActionBar.tsx
@@ -82,7 +82,7 @@ const WikiActionBar = ({ wiki }: WikiActionBarProps) => {
             color={
               // eslint-disable-next-line no-nested-ternary
               item.isActive
-                ? 'brand.600'
+                ? 'brandLinkColor'
                 : // eslint-disable-next-line no-nested-ternary
                 item.isDisabled
                 ? 'wikiActionBtnDisabled'

--- a/src/components/Wiki/WikiPage/WikiReferences.tsx
+++ b/src/components/Wiki/WikiPage/WikiReferences.tsx
@@ -66,7 +66,7 @@ const WikiReferences = ({ references }: WikiReferencesProps) => {
               },
             }}
           >
-            <Text color="brand.500">[{index + 1}] </Text>
+            <Text color="brandLinkColor">[{index + 1}] </Text>
             <Box>
               <Flex flexWrap="wrap" gap={2}>
                 <Tag colorScheme="brand" as="h3" size="sm">
@@ -86,7 +86,7 @@ const WikiReferences = ({ references }: WikiReferencesProps) => {
                       <Link
                         key={i}
                         href={`#cite-mark-${ref.id}-${i + 1}`}
-                        color="brand.500"
+                        color="brandLinkColor"
                         ml="0 !important"
                         fontWeight="medium"
                         fontSize="sm"

--- a/src/components/Wiki/WikiPage/WikiTableOfContents.tsx
+++ b/src/components/Wiki/WikiPage/WikiTableOfContents.tsx
@@ -136,11 +136,11 @@ const WikiTableOfContents = ({ isAlertAtTop }: WikiTableOfContentsProps) => {
               {toc.map(({ level, id, title }) => (
                 <Box key={id} pl={`calc(${(level - 1) * 20}px)`}>
                   <Text
-                    color={activeId === id ? 'brand.500' : 'unset'}
+                    color={activeId === id ? 'brandLinkColor' : 'unset'}
                     boxShadow={
                       activeId === id ? '-2px 0px 0px 0px #ff5caa' : '0'
                     }
-                    outlineColor="brand.500"
+                    outlineColor="brandLinkColor"
                     pl={2}
                   >
                     <Link href={`#${id}`}>{title}</Link>

--- a/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
+++ b/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
@@ -85,7 +85,7 @@ const WikiPreviewCard = ({
           <Box>
             <HStack flexWrap="wrap" mt={2} justify="space-between">
               {showLatestEditor && (
-                <HStack fontSize="sm" py={2} color="brand.500">
+                <HStack fontSize="sm" py={2} color="brandLinkColor">
                   <DisplayAvatar
                     address={wiki.user?.id}
                     avatarIPFS={wiki.user.profile?.avatar}

--- a/src/pages/static/assets/global.css
+++ b/src/pages/static/assets/global.css
@@ -146,8 +146,11 @@ html {
 .toastui-editor-contents a {
   color: #ec67a8 !important;
 }
-
-.toastui-editor-contents blockquote {
+html[data-theme='dark'],
+.toastui-editor-contents a {
+  color: #ea3b87 !important;
+}
+.toastui-editor-contents .toastui-editor-contents blockquote {
   color: #57606a !important;
   border-left: 0.25em solid #d0d7de !important;
 }

--- a/src/pages/static/assets/markdown.css
+++ b/src/pages/static/assets/markdown.css
@@ -28,6 +28,10 @@
   text-decoration: none;
 }
 
+html[data-theme='dark'] .markdown-body a {
+  color: #ea3b87;
+}
+
 .markdown-body a:active,
 .markdown-body a:hover {
   outline-width: 0;

--- a/src/pages/static/privacy.tsx
+++ b/src/pages/static/privacy.tsx
@@ -276,7 +276,7 @@ const Privacy = () => (
           and disable cookies, and other tracking/recording tools. (To learn
           more about behavioral advertising and to learn how to opt-out, you may
           wish to visit{' '}
-          <Link href="http://aboutads.info" color="brand.500">
+          <Link href="http://aboutads.info" color="brandLinkColor">
             http://aboutads.info
           </Link>
           ). Depending on your mobile device, you may not be able to control
@@ -505,14 +505,14 @@ const Privacy = () => (
           or local laws, among other things.
           <br /> Bill text:{' '}
           <Link
-            color="brand.500"
+            color="brandLinkColor"
             href="https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=201720180AB375"
           >
             https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=201720180AB375
           </Link>
           <br />
           More info:{' '}
-          <Link color="brand.500" href="https://www.caprivacy.org/">
+          <Link color="brandLinkColor" href="https://www.caprivacy.org/">
             https://www.caprivacy.org/
           </Link>
         </Text>

--- a/src/pages/static/terms.tsx
+++ b/src/pages/static/terms.tsx
@@ -160,11 +160,11 @@ const Terms = () => (
           United States of America <br />
           or via email: webmaster@everipedia.org <br />
           or submit them via the{' '}
-          <Link color="brand.500" href="https://everipedia.org/contact-us">
+          <Link color="brandLinkColor" href="https://everipedia.org/contact-us">
             Contact Us
           </Link>{' '}
           submission form:{' '}
-          <Link color="brand.500" href="https://everipedia.org/contact-us">
+          <Link color="brandLinkColor" href="https://everipedia.org/contact-us">
             https://everipedia.org/contact-us
           </Link>
         </Text>
@@ -179,7 +179,7 @@ const Terms = () => (
           Everipedia&apos;s Content: Everipedia&apos;s articles are licensed
           under a{' '}
           <Link
-            color="brand.500"
+            color="brandLinkColor"
             href="https://creativecommons.org/licenses/by/4.0/"
           >
             Creative Commons Attribution 4.0 International License.

--- a/src/pages/tags/[tag].tsx
+++ b/src/pages/tags/[tag].tsx
@@ -79,7 +79,12 @@ const TagPage: NextPage<TagPageProps> = ({ tagId, wikis }: TagPageProps) => {
         <Box mt={7}>
           <Text fontSize={17} width="min(90%, 1200px)" mx="auto">
             You are seeing the wikis that are tagged with
-            <Link mx={1} href={`/tags/${tagId}`} color="brand.500" passHref>
+            <Link
+              mx={1}
+              href={`/tags/${tagId}`}
+              color="brandLinkColor"
+              passHref
+            >
               {tagId}
             </Link>
             . If you are interested in seeing other topics in common, you can

--- a/src/pages/wiki/[slug]/history.tsx
+++ b/src/pages/wiki/[slug]/history.tsx
@@ -36,7 +36,7 @@ const History = () => {
 
   const isHistoryFullWidth = useBreakpointValue({ base: true, lg: false })
   return (
-    <Box bgColor="gray.200" _dark={{ bgColor: 'gray.800' }} mt={-3} pt={8}>
+    <Box bgColor="pageBg" mt={-3} pt={8}>
       <Box w="min(90%, 1100px)" mx="auto" mt={{ base: '10', lg: '16' }}>
         <Heading textAlign="center">Wiki History</Heading>
         <Text textAlign="center" mt={4} mb={8} color="linkColor">
@@ -75,7 +75,7 @@ const History = () => {
               w={isHistoryFullWidth ? '1px' : 'calc(50% + 1px)'}
               h="100%"
               borderRightWidth={2}
-              borderColor="brand.500"
+              borderColor="brandLinkColor"
             />
           )}
 

--- a/src/theme/components/Button.ts
+++ b/src/theme/components/Button.ts
@@ -11,7 +11,7 @@ export const Button = {
   },
   variants: {
     social: ({ colorMode }: ThemeProps) => ({
-      bg: colorMode === 'dark' ? 'brand.800' : 'brand.500',
+      bg: colorMode === 'dark' ? 'brand.800' : 'brandLinkColor',
       color: 'white',
       mr: 2,
       mb: 4,
@@ -25,7 +25,7 @@ export const Button = {
       },
     }),
     solid: ({ colorMode }: ThemeProps) => ({
-      bg: colorMode === 'dark' ? 'brand.800' : 'brand.500',
+      bg: colorMode === 'dark' ? 'brand.800' : 'brandLinkColor',
       color: 'white',
       fontSize: 'md',
       _hover: {

--- a/src/theme/components/Link.ts
+++ b/src/theme/components/Link.ts
@@ -5,7 +5,7 @@ import { LinkProps } from 'next/link'
 export const Link = {
   variants: {
     link: (props: Dict<LinkProps> | StyleFunctionProps) => ({
-      color: mode('brand.500', 'brand.700')(props),
+      color: mode('brandLinkColor', 'brand.700')(props),
     }),
   },
 }

--- a/src/theme/semantic-tokens.ts
+++ b/src/theme/semantic-tokens.ts
@@ -17,6 +17,10 @@ export const semanticTokens: SemanticTokens = {
       default: 'gray.600',
       _dark: 'grey.200',
     },
+    brandLinkColor: {
+      default: 'brand.500',
+      _dark: 'brand.800',
+    },
     textColor: {
       default: 'gray.900',
       _dark: 'grey.200',
@@ -35,7 +39,7 @@ export const semanticTokens: SemanticTokens = {
     },
     pageBg: {
       default: 'gray.100',
-      _dark: '#212836',
+      _dark: 'gray.800',
     },
     hoverBg: {
       default: 'gray.100',


### PR DESCRIPTION
# Changes
- Changes links and other pink elements across all the site to have brand.800 in darkmode as per design
- Changes page background to gray.800 on all pages having two tone background
- Fixes hydration errors in wiki page due to internal wiki links (not related with design sync)

# Links
- https://monopedia-ui-git-links-darkmode-darker-prediqt.vercel.app/