### PR TITLE
Fixes 900+ Redundant requests to ENS 

### DIFF
--- a/src/components/Elements/Avatar/Avatar.tsx
+++ b/src/components/Elements/Avatar/Avatar.tsx
@@ -30,7 +30,10 @@ const DisplayAvatar = ({
   size = 26,
   ...rest
 }: DisplayAvatarProps) => {
-  const [avatar, ,] = useENSData(address)
+  const [avatar, ,] = useENSData(
+    address,
+    avatarIPFS ? avatarIPFS?.length > 0 : false,
+  )
 
   const { avatar: fetchedAvatarIPFS, setAccount } = useUserProfileData(
     undefined,

--- a/src/components/Landing/TrendingWikis.tsx
+++ b/src/components/Landing/TrendingWikis.tsx
@@ -31,6 +31,7 @@ const TrendingWikiCard = ({ wiki }: { wiki: Wiki }) => {
     }
     return lastEditedTime
   }
+
   return (
     <LinkBox flex="none">
       <chakra.div p={2} mx="auto">
@@ -120,11 +121,9 @@ const TrendingWikiCard = ({ wiki }: { wiki: Wiki }) => {
 const TrendingWikis = ({ drops = [] }: { drops?: Wiki[] }) => {
   const { t } = useTranslation()
   const [isMounted, setIsMounted] = React.useState(false)
-
   React.useEffect(() => {
     setIsMounted(true)
   }, [])
-
   if (!isMounted) return null
 
   return (

--- a/src/hooks/useENSData.ts
+++ b/src/hooks/useENSData.ts
@@ -3,7 +3,10 @@ import { useAppDispatch, useAppSelector } from '@/store/hook'
 import { addENSAddress } from '@/store/slices/ens-slice'
 import { provider } from '@/utils/getProvider'
 
-export const useENSData = (address: string | undefined | null) => {
+export const useENSData = (
+  address: string | undefined | null,
+  skip = false,
+) => {
   const [avatar, setAvatar] = useState<string>()
   const [username, setUsername] = useState<string>()
   const [loading, setLoading] = useState<boolean>(false)
@@ -11,6 +14,7 @@ export const useENSData = (address: string | undefined | null) => {
   const dispatch = useAppDispatch()
 
   useEffect(() => {
+    if (skip) return
     const getAvatar = async (addrs: string) => {
       const name = await provider.lookupAddress(addrs)
       let avatarURI

--- a/src/hooks/useENSData.ts
+++ b/src/hooks/useENSData.ts
@@ -3,10 +3,7 @@ import { useAppDispatch, useAppSelector } from '@/store/hook'
 import { addENSAddress } from '@/store/slices/ens-slice'
 import { provider } from '@/utils/getProvider'
 
-export const useENSData = (
-  address: string | undefined | null,
-  skip = false,
-) => {
+export const useENSData = (address?: string | null, skip = false) => {
   const [avatar, setAvatar] = useState<string>()
   const [username, setUsername] = useState<string>()
   const [loading, setLoading] = useState<boolean>(false)


### PR DESCRIPTION
Fixes https://github.com/EveripediaNetwork/issues/issues/660

# Changes
- avatars in trending wiki cards are triggering ens lookup for each render. added a skip functionality for useENSData and using it in avatar component to avoid calling ens requests when it is not required.

# Links
- https://monopedia-ui-git-fix-900-requests-prediqt.vercel.app/