### PR TITLE
Fixes profile social links not working if full url is given instead of handle

### DIFF
--- a/src/data/UserSocialLinksData.ts
+++ b/src/data/UserSocialLinksData.ts
@@ -4,7 +4,10 @@ export const UserSocialLinksData = {
   twitter: {
     label: 'Twitter',
     icon: RiTwitterLine,
-    urlPrefix: (username?: string) => `https://twitter.com/${username}`,
+    urlPrefix: (username?: string) => {
+      if (username?.startsWith('https://twitter.com')) return username
+      return `https://twitter.com/${username}`
+    },
   },
   website: {
     label: 'Website',
@@ -14,6 +17,9 @@ export const UserSocialLinksData = {
   instagram: {
     label: 'Instagram',
     icon: RiInstagramLine,
-    urlPrefix: (username?: string) => `https://instagram.com/${username}`,
+    urlPrefix: (username?: string) => {
+      if (username?.startsWith('https://instagram.com')) return username
+      return `https://instagram.com/${username}`
+    },
   },
 }


### PR DESCRIPTION
Fixes https://github.com/EveripediaNetwork/issues/issues/661

# Changes
- made user profile page to render the social link as it is if it matches the social link format

# Links 
- Before fix: https://beta.everipedia.org/account/Simplypheyie
- After fix: https://monopedia-ui-git-profile-links-filter-prediqt.vercel.app/account/Simplypheyie

# Screenshots
![screely-1661869433486](https://user-images.githubusercontent.com/52039218/187462710-87912f04-58c6-44d7-a877-e8983535b92a.png)
