### PR TITLE
Makes discover more section to use popular tags end point

### DIFF
--- a/src/components/Landing/DiscoverMore.tsx
+++ b/src/components/Landing/DiscoverMore.tsx
@@ -1,27 +1,12 @@
-import { getTags } from '@/services/tags'
-import { store } from '@/store/store'
-import { Tag } from '@/types/Wiki'
 import { Box, Heading, Wrap } from '@chakra-ui/react'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { Link } from '../Elements'
 
-const DiscoverMore = () => {
-  const [data, setData] = useState<Tag[] | null>(null)
-
-  useEffect(() => {
-    const fetchData = async () => {
-      const { data: tagsData } = await store.dispatch(
-        getTags.initiate({
-          startDate: Math.floor(Date.now() / 1000) - 60 * 60 * 24 * 30,
-          endDate: Math.floor(Date.now() / 1000),
-        }),
-      )
-      if (tagsData) setData(tagsData)
-    }
-    fetchData()
-  }, [])
-
-  if (!data) return null
+interface DiscoverMoreProps {
+  tagsData: { id: string }[]
+}
+const DiscoverMore = ({ tagsData }: DiscoverMoreProps) => {
+  if (!tagsData) return null
 
   return (
     <Box bgColor="gray.50" _dark={{ bgColor: 'whiteAlpha.50' }} p={8} pb={20}>
@@ -30,7 +15,7 @@ const DiscoverMore = () => {
           Discover More on everipedia
         </Heading>
         <Wrap mt={8} spacing={4}>
-          {data?.map(tag => (
+          {tagsData?.map(tag => (
             <Link
               borderWidth="1px"
               px={4}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -48,7 +48,7 @@ export const Index = ({
   )
 }
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   const { data: promotedWikis } = await store.dispatch(
     getPromotedWikis.initiate(),
   )

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,15 +13,24 @@ import {
   getCategories,
   getRunningOperationPromises as getCategoriesRunningOperationPromises,
 } from '@/services/categories'
+import {
+  getTags,
+  getRunningOperationPromises as getTagsRunningOperationPromises,
+} from '@/services/tags'
 import { Category } from '@/types/CategoryDataTypes'
 import DiscoverMore from '@/components/Landing/DiscoverMore'
 
 interface HomePageProps {
   promotedWikis: Wiki[]
   categories: Category[]
+  popularTags: { id: string }[]
 }
 
-export const Index = ({ promotedWikis, categories }: HomePageProps) => {
+export const Index = ({
+  promotedWikis,
+  categories,
+  popularTags,
+}: HomePageProps) => {
   return (
     <Flex direction="column" mx="auto" w="full" pt={{ base: 6, lg: 20 }}>
       <Hero wiki={promotedWikis && promotedWikis[0]} />
@@ -34,23 +43,33 @@ export const Index = ({ promotedWikis, categories }: HomePageProps) => {
         <TrendingWikis drops={promotedWikis} />
         <CategoriesList categories={categories} />
       </Box>
-      <DiscoverMore />
+      <DiscoverMore tagsData={popularTags} />
     </Flex>
   )
 }
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   const { data: promotedWikis } = await store.dispatch(
     getPromotedWikis.initiate(),
   )
   const { data: categories } = await store.dispatch(getCategories.initiate())
 
+  const { data: tagsData } = await store.dispatch(
+    getTags.initiate({
+      startDate: Math.floor(Date.now() / 1000) - 60 * 60 * 24 * 30,
+      endDate: Math.floor(Date.now() / 1000),
+    }),
+  )
+
   await Promise.all(getWikisRunningOperationPromises())
   await Promise.all(getCategoriesRunningOperationPromises())
+  await Promise.all(getTagsRunningOperationPromises())
+
   return {
     props: {
       promotedWikis: promotedWikis || [],
       categories: categories || [],
+      popularTags: tagsData || [],
     },
   }
 }

--- a/src/services/tags/index.ts
+++ b/src/services/tags/index.ts
@@ -6,7 +6,7 @@ import { Tag } from '@/types/Wiki'
 import { GET_TAGS } from './queries'
 
 type GetTagsResponse = {
-  mostUsedTags: Tag[]
+  tagsPopular: Tag[]
 }
 
 export const tagsApi = createApi({
@@ -29,7 +29,7 @@ export const tagsApi = createApi({
           endDate,
         },
       }),
-      transformResponse: (response: GetTagsResponse) => response.mostUsedTags,
+      transformResponse: (response: GetTagsResponse) => response.tagsPopular,
     }),
   }),
 })

--- a/src/services/tags/queries.ts
+++ b/src/services/tags/queries.ts
@@ -2,7 +2,7 @@ import { gql } from 'graphql-request'
 
 export const GET_TAGS = gql`
   query GetTags($startDate: Int!, $endDate: Int!) {
-    mostUsedTags(startDate: $startDate, endDate: $endDate) {
+    tagsPopular(startDate: $startDate, endDate: $endDate) {
       id
     }
   }


### PR DESCRIPTION
# Changes
- makes discover more section to use popular tags end point (Now there will be 15 tags in the section)
- makes popular tags to be called on ssr

# Links
- https://monopedia-ui-git-tagspopular-prediqt.vercel.app/