### PR TITLE
UI Fix For Admin Panel

### DIFF
--- a/src/components/Admin/WikiCreatedInsight/HideWikiNotification.tsx
+++ b/src/components/Admin/WikiCreatedInsight/HideWikiNotification.tsx
@@ -125,7 +125,7 @@ export const HideWikiNotification = ({
             fontWeight="normal"
           >
             You are about to {IsHide ? 'archive' : 'unarchive'} the selected
-            wiki.Do you wish to continue with this action?
+            wiki. Do you wish to continue with this action?
           </Text>
           <ButtonGroup px={2} pt={2} w="full" spacing={8}>
             <Button w="full" variant="outline">

--- a/src/components/Admin/WikiCreatedInsight/InsightTableCreatedWiki.tsx
+++ b/src/components/Admin/WikiCreatedInsight/InsightTableCreatedWiki.tsx
@@ -20,6 +20,7 @@ import {
   MenuItem,
   MenuList,
   Avatar,
+  Box,
 } from '@chakra-ui/react'
 import config from '@/config'
 import React, { useEffect, useState } from 'react'
@@ -82,19 +83,20 @@ export const InsightTableWikiCreated = (
         <Thead bg="wikiTitleBg">
           <Tr>
             <Th color="#718096" textTransform="none" fontWeight="medium">
-              Wiki Title
+              <Text fontWeight="bold">Wiki Title</Text>
             </Th>
             <Th color="#718096" textTransform="none" fontWeight="medium">
-              Date/Time
+              <Text fontWeight="bold">Date/Time</Text>
             </Th>
             <Th color="#718096" textTransform="none" fontWeight="medium">
-              Tags
+              <Text fontWeight="bold">Tags</Text>
             </Th>
             <Th color="#718096" textTransform="none" fontWeight="medium">
               <HStack spacing={3}>
-                <Text>Status</Text>
+                <Text fontWeight="bold">Status</Text>
                 <Icon
-                  fontSize="10px"
+                  fontSize="15px"
+                  fontWeight="black"
                   cursor="pointer"
                   color="#718096"
                   as={RiArrowDownLine}
@@ -176,8 +178,9 @@ export const InsightTableWikiCreated = (
                       variant="solid"
                       bg="#F9F5FF"
                       color="#FE6FB5"
+                      py="2"
                     >
-                      <TagLabel>Normal</TagLabel>
+                      <TagLabel fontWeight="bold">Normal</TagLabel>
                     </Tag>
                     {item.promoted && (
                       <Tag
@@ -199,16 +202,21 @@ export const InsightTableWikiCreated = (
                     variant="solid"
                     color={!item.hidden ? '#38A169' : '#DD6B20'}
                     bg={!item.hidden ? '#F0FFF4' : '#FFF5F5'}
-                    px="2"
+                    py="2"
                   >
                     <HStack spacing={2}>
-                      <Icon
-                        fontSize="20px"
-                        cursor="pointer"
-                        color={!item.hidden ? '#38A169' : '#DD6B20'}
-                        as={BsDot}
+                      <Box
+                        w="8px"
+                        h="8px"
+                        bg={!item.hidden ? '#38A169' : '#DD6B20'}
+                        borderRadius="100px"
                       />
-                      <TagLabel>{item.hidden ? 'Archived' : 'Active'}</TagLabel>
+                      <TagLabel
+                        fontWeight="bold"
+                        color={!item.hidden ? '#38A169' : '#9C4221'}
+                      >
+                        {item.hidden ? 'Archived' : 'Active'}
+                      </TagLabel>
                     </HStack>
                   </Tag>
                 </Td>

--- a/src/components/Admin/WikiCreatedInsight/InsightTableCreatedWiki.tsx
+++ b/src/components/Admin/WikiCreatedInsight/InsightTableCreatedWiki.tsx
@@ -92,10 +92,10 @@ export const InsightTableWikiCreated = (
               <Text fontWeight="bold">Tags</Text>
             </Th>
             <Th color="#718096" textTransform="none" fontWeight="medium">
-              <HStack spacing={3}>
+              <HStack spacing={1}>
                 <Text fontWeight="bold">Status</Text>
                 <Icon
-                  fontSize="15px"
+                  fontSize="17px"
                   fontWeight="black"
                   cursor="pointer"
                   color="#718096"
@@ -177,10 +177,13 @@ export const InsightTableWikiCreated = (
                       borderRadius="full"
                       variant="solid"
                       bg="#F9F5FF"
+                      _dark={{ bg: '#FFB3D7', color: '#FF409B' }}
                       color="#FE6FB5"
-                      py="2"
+                      py="1"
                     >
-                      <TagLabel fontWeight="bold">Normal</TagLabel>
+                      <TagLabel fontSize="13px" fontWeight="medium">
+                        Normal
+                      </TagLabel>
                     </Tag>
                     {item.promoted && (
                       <Tag
@@ -188,9 +191,13 @@ export const InsightTableWikiCreated = (
                         borderRadius="full"
                         variant="solid"
                         bg="#EBF8FF"
+                        _dark={{ bg: '#90CDF4' }}
                         color="#385C8A"
                       >
-                        <TagLabel> Promoted </TagLabel>
+                        <TagLabel fontSize="13px" fontWeight="medium">
+                          {' '}
+                          Promoted{' '}
+                        </TagLabel>
                       </Tag>
                     )}
                   </HStack>
@@ -201,19 +208,23 @@ export const InsightTableWikiCreated = (
                     borderRadius="full"
                     variant="solid"
                     color={!item.hidden ? '#38A169' : '#DD6B20'}
+                    _dark={{ bg: item.hidden ? '#FBD38D' : '#F0FFF4' }}
                     bg={!item.hidden ? '#F0FFF4' : '#FFF5F5'}
-                    py="2"
+                    py="1"
                   >
                     <HStack spacing={2}>
                       <Box
                         w="8px"
                         h="8px"
                         bg={!item.hidden ? '#38A169' : '#DD6B20'}
+                        _dark={{ bg: item.hidden ? '#AE5D35' : '#38A169' }}
                         borderRadius="100px"
                       />
                       <TagLabel
-                        fontWeight="bold"
+                        fontWeight="medium"
                         color={!item.hidden ? '#38A169' : '#9C4221'}
+                        _dark={{ color: item.hidden ? '#AE5D35' : '#38A169' }}
+                        fontSize="13px"
                       >
                         {item.hidden ? 'Archived' : 'Active'}
                       </TagLabel>
@@ -221,7 +232,12 @@ export const InsightTableWikiCreated = (
                   </Tag>
                 </Td>
                 <Td>
-                  <Flex w="100%" gap={2} align="center">
+                  <Flex
+                    w="100%"
+                    gap={2}
+                    alignItems="center"
+                    justifyContent="flex-end"
+                  >
                     <HStack spacing={5}>
                       <Menu>
                         <MenuButton
@@ -256,6 +272,10 @@ export const InsightTableWikiCreated = (
                               }}
                               py="1"
                               px="1"
+                              isDisabled={
+                                (!item.hidden && o === 'Unarchive') ||
+                                (item.hidden && o === 'Archive')
+                              }
                             >
                               {o}
                             </MenuItem>
@@ -265,6 +285,7 @@ export const InsightTableWikiCreated = (
                       {!item.promoted ? (
                         <Text
                           color="#FF5CAA"
+                          _dark={{ color: '#F11a82' }}
                           cursor="pointer"
                           fontWeight="semibold"
                           onClick={() => {

--- a/src/components/Admin/WikiCreatedInsight/PromoteCreatedWikisModal.tsx
+++ b/src/components/Admin/WikiCreatedInsight/PromoteCreatedWikisModal.tsx
@@ -297,6 +297,7 @@ export const PromoteCreatedWikisModal = ({
 
   const HompageSelected = () => {
     if (activeStep === 0) {
+      setStep2Titles('Promote to Hero Section')
       nextStep()
       setInitGetSearchedWikis(false)
       setbuttonOne('cancel')
@@ -313,7 +314,7 @@ export const PromoteCreatedWikisModal = ({
     <>
       {activeStep === 0 && (
         <Text textAlign="center">
-          Select the appropraite action you would like to take for this wiki
+          Select the appropriate action you would like to take for this wiki
         </Text>
       )}
       {activeStep === 1 && (
@@ -418,6 +419,7 @@ export const PromoteCreatedWikisModal = ({
                     p={4}
                     onClick={HompageSelected}
                     size="sm"
+                    variant="ghost"
                     fontSize="xs"
                   >
                     {buttonOne}
@@ -425,7 +427,6 @@ export const PromoteCreatedWikisModal = ({
                   <Button
                     size="sm"
                     fontSize="xs"
-                    variant="ghost"
                     borderWidth="1px"
                     onClick={TrendingwikiSelected}
                   >

--- a/src/components/Admin/WikiCreatedInsight/WikiInsightTable.tsx
+++ b/src/components/Admin/WikiCreatedInsight/WikiInsightTable.tsx
@@ -30,7 +30,8 @@ import {
 import React, { useEffect, useState, useMemo } from 'react'
 import { FiSearch } from 'react-icons/fi'
 import { MdFilterList } from 'react-icons/md'
-import { BiSortDown, BiSort, BiSortUp } from 'react-icons/bi'
+import { BiSortDown, BiSortUp } from 'react-icons/bi'
+import { RiArrowUpDownLine } from 'react-icons/ri'
 import { InsightTableWikiCreated } from './InsightTableCreatedWiki'
 
 export const WikiInsightTable = () => {
@@ -60,7 +61,7 @@ export const WikiInsightTable = () => {
 
   const sortIcon = useMemo(() => {
     if (sortTableBy === 'default') {
-      return <BiSort fontSize="1.3rem" />
+      return <RiArrowUpDownLine fontSize="1.3rem" />
     }
     if (sortTableBy === 'Newest' || sortTableBy === 'AlpaUp') {
       return <BiSortUp fontSize="1.3rem" />
@@ -68,7 +69,7 @@ export const WikiInsightTable = () => {
     if (sortTableBy === 'Oldest' || sortTableBy === 'AlpaDown') {
       return <BiSortDown fontSize="1.3rem" />
     }
-    return <BiSort fontSize="1.3rem" />
+    return <RiArrowUpDownLine fontSize="1.3rem" />
   }, [wiki, sortTableBy])
 
   enum FilterTypes {
@@ -318,12 +319,12 @@ export const WikiInsightTable = () => {
                 _expanded={{ bg: 'brand.500', color: 'white' }}
                 py={2}
                 px={10}
-                rightIcon={<MdFilterList fontSize="25px" />}
+                leftIcon={<MdFilterList fontSize="25px" />}
                 variant="outline"
                 fontWeight="medium"
                 onClick={onToggle}
               >
-                Filter
+                Filters
               </Button>
             </PopoverTrigger>
             <PopoverContent w="fit-content">

--- a/src/components/Admin/WikiCreatedInsight/WikiInsightTable.tsx
+++ b/src/components/Admin/WikiCreatedInsight/WikiInsightTable.tsx
@@ -290,6 +290,7 @@ export const WikiInsightTable = () => {
                 px={5}
                 leftIcon={sortIcon}
                 variant="outline"
+                fontWeight="medium"
               >
                 Sort
               </Button>
@@ -317,7 +318,7 @@ export const WikiInsightTable = () => {
                 _expanded={{ bg: 'brand.500', color: 'white' }}
                 py={2}
                 px={10}
-                rightIcon={<MdFilterList />}
+                rightIcon={<MdFilterList fontSize="25px" />}
                 variant="outline"
                 fontWeight="medium"
                 onClick={onToggle}

--- a/src/components/Admin/WikiDataGraph.tsx
+++ b/src/components/Admin/WikiDataGraph.tsx
@@ -57,7 +57,7 @@ export const WikiDataGraph = ({
             </Text>
           </VStack>
           <Select
-            w="30%"
+            w={{ lg: '20%', base: '40%' }}
             icon={<MdArrowDropDown />}
             onChange={e => {
               handleGraphFilterChange(e.target.value)

--- a/src/components/Admin/WikiEditorInsight/InsightTableWikiEditors.tsx
+++ b/src/components/Admin/WikiEditorInsight/InsightTableWikiEditors.tsx
@@ -101,25 +101,25 @@ export const InsightTableWikiEditors = (
               textTransform="capitalize"
               fontWeight="semibold"
             >
-              Names
+              <Text fontWeight="bold">Names</Text>
             </Th>
             <Th color="#718096" textTransform="capitalize" fontWeight="normal">
-              No. of created wikis
+              <Text fontWeight="bold">No. of created wikis</Text>
             </Th>
             <Th color="#718096" textTransform="capitalize" fontWeight="medium">
-              No. of edited wikis
+              <Text fontWeight="bold">No. of edited wikis</Text>
             </Th>
             <Th color="#718096" textTransform="capitalize" fontWeight="medium">
-              Total No. of wikis
+              <Text fontWeight="bold">Total No. of wikis</Text>
             </Th>
             <Th color="#718096" textTransform="capitalize" fontWeight="medium">
-              Last created wiki
+              <Text fontWeight="bold">Last created wiki</Text>
             </Th>
             <Th color="#718096" textTransform="capitalize" fontWeight="medium">
-              Lastest activity
+              <Text fontWeight="bold">Lastest activity</Text>
             </Th>
             <Th color="#718096" textTransform="capitalize" fontWeight="medium">
-              Status
+              <Text fontWeight="bold">Status</Text>
             </Th>
             <Th color="#718096" textTransform="capitalize" fontWeight="medium">
               Action

--- a/src/components/Admin/WikiEditorInsight/WikiEditorsInsight.tsx
+++ b/src/components/Admin/WikiEditorInsight/WikiEditorsInsight.tsx
@@ -340,6 +340,7 @@ export const WikiEditorsInsightTable = () => {
             px={10}
             rightIcon={sortIcon}
             variant="outline"
+            fontWeight="medium"
           >
             Sort
           </Button>
@@ -351,10 +352,10 @@ export const WikiEditorsInsightTable = () => {
                 _expanded={{ bg: 'brand.500', color: 'white' }}
                 py={2}
                 px={10}
-                rightIcon={<MdFilterList />}
+                rightIcon={<MdFilterList fontSize="25px" />}
                 variant="outline"
-                fontWeight="medium"
                 onClick={onToggleFilter}
+                fontWeight="medium"
               >
                 Filter
               </Button>

--- a/src/components/Admin/WikiEditorInsight/WikiEditorsInsight.tsx
+++ b/src/components/Admin/WikiEditorInsight/WikiEditorsInsight.tsx
@@ -25,8 +25,9 @@ import {
   VStack,
 } from '@chakra-ui/react'
 import React, { useEffect, useMemo, useState } from 'react'
-import { BiSortDown, BiSort, BiSortUp } from 'react-icons/bi'
+import { BiSortDown, BiSortUp } from 'react-icons/bi'
 
+import { RiArrowUpDownLine } from 'react-icons/ri'
 import { FiSearch } from 'react-icons/fi'
 import { MdFilterList } from 'react-icons/md'
 import { DeleteEditorModal } from './DeleteEditorModal'
@@ -84,7 +85,7 @@ export const WikiEditorsInsightTable = () => {
 
   const sortIcon = useMemo(() => {
     if (sortTableBy === 'default') {
-      return <BiSort fontSize="1.3rem" />
+      return <RiArrowUpDownLine fontSize="1.3rem" />
     }
     if (sortTableBy === 'ascending') {
       return <BiSortUp fontSize="1.3rem" />
@@ -92,7 +93,7 @@ export const WikiEditorsInsightTable = () => {
     if (sortTableBy === 'descending') {
       return <BiSortDown fontSize="1.3rem" />
     }
-    return <BiSort fontSize="1.3rem" />
+    return <RiArrowUpDownLine fontSize="1.3rem" />
   }, [editors, sortTableBy])
 
   const editorsFilteredArr = useMemo(() => {
@@ -352,12 +353,12 @@ export const WikiEditorsInsightTable = () => {
                 _expanded={{ bg: 'brand.500', color: 'white' }}
                 py={2}
                 px={10}
-                rightIcon={<MdFilterList fontSize="25px" />}
+                leftIcon={<MdFilterList fontSize="25px" />}
                 variant="outline"
                 onClick={onToggleFilter}
                 fontWeight="medium"
               >
-                Filter
+                Filters
               </Button>
             </PopoverTrigger>
             <PopoverContent w="fit-content">


### PR DESCRIPTION
# PR title goes here
- [x]  Reduce width of date selector on graph. 
- [x] Arrow used in sort is different from the figma design
- [x] Status for wikis not archived is wrong.
- [x] The wiki table is not scaling well on larger screens
- [x] Tags on wiki table are overlapping on desktop screen
- [x] Typo on promote modal,
- [x] The primary buttons on the modals are wrong. 
- [x] This should be 'slot' and not sort 
- [x] The archive modal is not properly punctuated.
- [x] There is no status for editors' table. 
- [ ] The horizontal axis should be named in correlation
- [ ] Clicking on the question mark beside the promote button on promoted wikis should show a popup
- [ ] fix sort functionality, not accurate yet. 
- [ ] the pink colors are all wrong in dark mode
- [ ] The margin between the parge and the footer is too small

## Notes or observations

_jot down something here_

## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/680
