### PR TITLE
680 admin dashboard fixes

### DIFF
--- a/src/components/Admin/WikiCreatedInsight/HideWikiNotification.tsx
+++ b/src/components/Admin/WikiCreatedInsight/HideWikiNotification.tsx
@@ -125,7 +125,7 @@ export const HideWikiNotification = ({
             fontWeight="normal"
           >
             You are about to {IsHide ? 'archive' : 'unarchive'} the selected
-            wiki.Do you wish to continue with this action?
+            wiki. Do you wish to continue with this action?
           </Text>
           <ButtonGroup px={2} pt={2} w="full" spacing={8}>
             <Button w="full" variant="outline">

--- a/src/components/Admin/WikiCreatedInsight/HideWikiNotification.tsx
+++ b/src/components/Admin/WikiCreatedInsight/HideWikiNotification.tsx
@@ -128,7 +128,7 @@ export const HideWikiNotification = ({
               ? ' You are about to archive the selected wiki. Do you wish to continue with this action?'
               : 'This archive is currently archived. Do you want to unarchive this wiki?'}
           </Text>
-          <ButtonGroup px={2} pt={2} w="full" spacing={8}>
+          <ButtonGroup px={2} pt={2} w="full" spacing={8} onClick={onClose}>
             <Button w="full" variant="outline">
               Cancel
             </Button>

--- a/src/components/Admin/WikiCreatedInsight/HideWikiNotification.tsx
+++ b/src/components/Admin/WikiCreatedInsight/HideWikiNotification.tsx
@@ -107,7 +107,7 @@ export const HideWikiNotification = ({
               mr={5}
             />
             <Text flex="1" fontSize="xl" fontWeight="black">
-              {IsHide ? 'Archive' : 'Unarchive'} Wiki
+              {IsHide ? 'Archive Wiki' : 'Archive Wiki Details'}
             </Text>
             <Icon
               cursor="pointer"
@@ -124,8 +124,9 @@ export const HideWikiNotification = ({
             textAlign="center"
             fontWeight="normal"
           >
-            You are about to {IsHide ? 'archive' : 'unarchive'} the selected
-            wiki. Do you wish to continue with this action?
+            {IsHide
+              ? ' You are about to archive the selected wiki. Do you wish to continue with this action?'
+              : 'This archive is currently archived. Do you want to unarchive this wiki?'}
           </Text>
           <ButtonGroup px={2} pt={2} w="full" spacing={8}>
             <Button w="full" variant="outline">

--- a/src/components/Admin/WikiCreatedInsight/InsightTableCreatedWiki.tsx
+++ b/src/components/Admin/WikiCreatedInsight/InsightTableCreatedWiki.tsx
@@ -21,6 +21,9 @@ import {
   MenuList,
   Avatar,
   Box,
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogOverlay,
 } from '@chakra-ui/react'
 import config from '@/config'
 import React, { useEffect, useState } from 'react'
@@ -30,11 +33,13 @@ import {
   RiArrowDownLine,
   RiQuestionLine,
   RiArrowDropDownLine,
+  RiCloseLine,
 } from 'react-icons/ri'
 import { BsDot } from 'react-icons/bs'
 import { Wikis } from '@/types/admin'
 import { PromoteCreatedWikisModal } from './PromoteCreatedWikisModal'
 import { HideWikiNotification } from './HideWikiNotification'
+import { FocusableElement } from '@chakra-ui/utils'
 
 type InsightTableWikiCreatedProps = {
   wikiCreatedInsightData: Wikis[]
@@ -47,6 +52,7 @@ export const InsightTableWikiCreated = (
   const { wikiCreatedInsightData, hideWikisFunc } = props
   const { isOpen, onOpen, onClose } = useDisclosure()
   const [wikiChosenId, setWikiChosenId] = useState('')
+  const [sectionType, setsectionType] = useState('')
   const [wikiChosenTitle, setWikiChosenTitle] = useState('')
   const [wikiChosenIdPromote, setWikiChosenIdPromote] = useState('')
   const {
@@ -54,10 +60,25 @@ export const InsightTableWikiCreated = (
     onOpen: onOpenWikiHideNotification,
     onClose: onCloseWikiHideNotification,
   } = useDisclosure()
+  const cancelRef = React.useRef<FocusableElement>(null)
+  const {
+    isOpen: isOpenPromotion,
+    onOpen: onOpenPromotion,
+    onClose: onClosePromotion,
+  } = useDisclosure()
   const [isHide, setIsHide] = useState(true)
   const [hideNotify, setHideNotify] = useState(false)
   const VisibilityOptions = ['Archive', 'Unarchive']
 
+  const findSection = (promotedNum: number) => {
+    let num = wikiCreatedInsightData && wikiCreatedInsightData[0].promoted
+    if (promotedNum === num) {
+      setsectionType('hero section')
+    } else {
+      setsectionType('trending wiki section')
+    }
+    onOpenPromotion()
+  }
   const shouldArchive = (e: string, ishidden: boolean, wikiId: string) => {
     if (ishidden && e === 'Unarchive') {
       setIsHide(false)
@@ -295,8 +316,15 @@ export const InsightTableWikiCreated = (
                           Promote
                         </Text>
                       ) : (
-                        <HStack spacing={2}>
-                          <Text color="#E2E8F0" cursor="pointer">
+                        <HStack
+                          spacing={2}
+                          onClick={() => findSection(item.promoted)}
+                        >
+                          <Text
+                            color="#E2E8F0"
+                            _dark={{ color: '#495a68' }}
+                            cursor="pointer"
+                          >
                             Promote
                           </Text>
                           <Icon
@@ -313,6 +341,50 @@ export const InsightTableWikiCreated = (
               </Tr>
             )
           })}
+          <AlertDialog
+            motionPreset="slideInBottom"
+            leastDestructiveRef={cancelRef}
+            onClose={onClosePromotion}
+            isOpen={isOpenPromotion}
+            isCentered
+          >
+            <AlertDialogOverlay />
+
+            <AlertDialogContent>
+              <Box p={8}>
+                <Flex>
+                  <Icon
+                    cursor="pointer"
+                    fontSize="3xl"
+                    fontWeight={600}
+                    as={RiQuestionLine}
+                    color="#898787"
+                    mr={5}
+                  />
+                  <Text flex="1" fontSize="xl" fontWeight="black">
+                    Promotion Details
+                  </Text>
+                  <Icon
+                    cursor="pointer"
+                    fontSize="3xl"
+                    fontWeight={600}
+                    as={RiCloseLine}
+                    onClick={onClosePromotion}
+                  />
+                </Flex>
+                <Text
+                  my="6"
+                  w="90%"
+                  lineHeight="2"
+                  textAlign="center"
+                  fontWeight="normal"
+                >
+                  This wiki is currently promoted to the {sectionType} of the
+                  home page
+                </Text>
+              </Box>
+            </AlertDialogContent>
+          </AlertDialog>
           <HideWikiNotification
             isOpen={isOpenWikiHideNotification}
             onClose={onCloseWikiHideNotification}

--- a/src/components/Admin/WikiCreatedInsight/InsightTableCreatedWiki.tsx
+++ b/src/components/Admin/WikiCreatedInsight/InsightTableCreatedWiki.tsx
@@ -14,6 +14,11 @@ import {
   HStack,
   Link,
   useDisclosure,
+  MenuButton,
+  Button,
+  Menu,
+  MenuItem,
+  MenuList,
   Avatar,
   Box,
   AlertDialog,
@@ -24,7 +29,12 @@ import config from '@/config'
 import React, { useEffect, useState } from 'react'
 import shortenAccount from '@/utils/shortenAccount'
 import { shortenText } from '@/utils/shortenText'
-import { RiArrowDownLine, RiQuestionLine, RiCloseLine } from 'react-icons/ri'
+import {
+  RiArrowDownLine,
+  RiQuestionLine,
+  RiArrowDropDownLine,
+  RiCloseLine,
+} from 'react-icons/ri'
 import { BsDot } from 'react-icons/bs'
 import { Wikis } from '@/types/admin'
 import { FocusableElement } from '@chakra-ui/utils'
@@ -58,6 +68,7 @@ export const InsightTableWikiCreated = (
   } = useDisclosure()
   const [isHide, setIsHide] = useState(true)
   const [hideNotify, setHideNotify] = useState(false)
+  const VisibilityOptions = ['Archive', 'Unarchive']
 
   const findSection = (promotedNum: number) => {
     const num = wikiCreatedInsightData && wikiCreatedInsightData[0].promoted
@@ -68,12 +79,12 @@ export const InsightTableWikiCreated = (
     }
     onOpenPromotion()
   }
-  const shouldArchive = (ishidden: boolean, wikiId: string) => {
-    if (ishidden) {
+  const shouldArchive = (e: string, ishidden: boolean, wikiId: string) => {
+    if (ishidden && e === 'Unarchive') {
       setIsHide(false)
       onOpenWikiHideNotification()
       setWikiChosenId(wikiId)
-    } else if (!ishidden) {
+    } else if (!ishidden && e === 'Archive') {
       onOpenWikiHideNotification()
       setWikiChosenId(wikiId)
     }
@@ -247,9 +258,51 @@ export const InsightTableWikiCreated = (
                     gap={2}
                     alignItems="center"
                     justifyContent="flex-end"
-                    pr={5}
                   >
                     <HStack spacing={5}>
+                      <Menu>
+                        <MenuButton
+                          transition="all 0.2s"
+                          borderRadius="md"
+                          _expanded={{ bg: 'brand.500', color: 'white' }}
+                        >
+                          <Button
+                            borderColor="#E2E8F0"
+                            _dark={{ borderColor: '#2c323d' }}
+                            py={2}
+                            px={5}
+                            variant="outline"
+                            fontWeight="light"
+                          >
+                            <Text px={2}> Archive </Text>
+                            <Icon
+                              fontSize="2xl"
+                              fontWeight="bold"
+                              cursor="pointer"
+                              color="#718096"
+                              as={RiArrowDropDownLine}
+                            />
+                          </Button>
+                        </MenuButton>
+                        <MenuList px={1}>
+                          {VisibilityOptions.map((o, m) => (
+                            <MenuItem
+                              key={m}
+                              onClick={() => {
+                                shouldArchive(o, item.hidden, item.id)
+                              }}
+                              py="1"
+                              px="1"
+                              isDisabled={
+                                (!item.hidden && o === 'Unarchive') ||
+                                (item.hidden && o === 'Archive')
+                              }
+                            >
+                              {o}
+                            </MenuItem>
+                          ))}
+                        </MenuList>
+                      </Menu>
                       {!item.promoted ? (
                         <Text
                           color="#FF5CAA"
@@ -277,38 +330,7 @@ export const InsightTableWikiCreated = (
                           <Icon
                             fontSize="20px"
                             cursor="pointer"
-                            color="#F11a82"
-                            as={RiQuestionLine}
-                          />
-                        </HStack>
-                      )}
-
-                      {!item.hidden ? (
-                        <Text
-                          cursor="pointer"
-                          fontWeight="medium"
-                          onClick={() => {
-                            shouldArchive(item.hidden, item.id)
-                          }}
-                        >
-                          Archive
-                        </Text>
-                      ) : (
-                        <HStack
-                          spacing={2}
-                          onClick={() => shouldArchive(item.hidden, item.id)}
-                        >
-                          <Text
-                            color="#E2E8F0"
-                            _dark={{ color: '#495a68' }}
-                            cursor="pointer"
-                          >
-                            Archive
-                          </Text>
-                          <Icon
-                            fontSize="20px"
-                            cursor="pointer"
-                            color="#F11a82"
+                            color="#718096"
                             as={RiQuestionLine}
                           />
                         </HStack>

--- a/src/components/Admin/WikiCreatedInsight/InsightTableCreatedWiki.tsx
+++ b/src/components/Admin/WikiCreatedInsight/InsightTableCreatedWiki.tsx
@@ -20,6 +20,7 @@ import {
   MenuItem,
   MenuList,
   Avatar,
+  Box,
 } from '@chakra-ui/react'
 import config from '@/config'
 import React, { useEffect, useState } from 'react'
@@ -82,19 +83,20 @@ export const InsightTableWikiCreated = (
         <Thead bg="wikiTitleBg">
           <Tr>
             <Th color="#718096" textTransform="none" fontWeight="medium">
-              Wiki Title
+              <Text fontWeight="bold">Wiki Title</Text>
             </Th>
             <Th color="#718096" textTransform="none" fontWeight="medium">
-              Date/Time
+              <Text fontWeight="bold">Date/Time</Text>
             </Th>
             <Th color="#718096" textTransform="none" fontWeight="medium">
-              Tags
+              <Text fontWeight="bold">Tags</Text>
             </Th>
             <Th color="#718096" textTransform="none" fontWeight="medium">
               <HStack spacing={3}>
-                <Text>Status</Text>
+                <Text fontWeight="bold">Status</Text>
                 <Icon
-                  fontSize="10px"
+                  fontSize="15px"
+                  fontWeight="black"
                   cursor="pointer"
                   color="#718096"
                   as={RiArrowDownLine}
@@ -176,8 +178,9 @@ export const InsightTableWikiCreated = (
                       variant="solid"
                       bg="#F9F5FF"
                       color="#FE6FB5"
+                      py="2"
                     >
-                      <TagLabel>Normal</TagLabel>
+                      <TagLabel fontWeight="bold">Normal</TagLabel>
                     </Tag>
                     {item.promoted && (
                       <Tag
@@ -199,16 +202,21 @@ export const InsightTableWikiCreated = (
                     variant="solid"
                     color={!item.hidden ? '#38A169' : '#DD6B20'}
                     bg={!item.hidden ? '#F0FFF4' : '#FFF5F5'}
-                    px="2"
+                    py="2"
                   >
                     <HStack spacing={2}>
-                      <Icon
-                        fontSize="20px"
-                        cursor="pointer"
-                        color={!item.hidden ? '#38A169' : '#DD6B20'}
-                        as={BsDot}
+                      <Box
+                        w="8px"
+                        h="8px"
+                        bg={!item.hidden ? '#38A169' : '#DD6B20'}
+                        borderRadius="100px"
                       />
-                      <TagLabel>{item.hidden ? 'Archived' : 'Active'}</TagLabel>
+                      <TagLabel
+                        fontWeight="bold"
+                        color={!item.hidden ? '#38A169' : '#9C4221'}
+                      >
+                        {item.hidden ? 'Archived' : 'Active'}
+                      </TagLabel>
                     </HStack>
                   </Tag>
                 </Td>

--- a/src/components/Admin/WikiCreatedInsight/InsightTableCreatedWiki.tsx
+++ b/src/components/Admin/WikiCreatedInsight/InsightTableCreatedWiki.tsx
@@ -37,9 +37,9 @@ import {
 } from 'react-icons/ri'
 import { BsDot } from 'react-icons/bs'
 import { Wikis } from '@/types/admin'
+import { FocusableElement } from '@chakra-ui/utils'
 import { PromoteCreatedWikisModal } from './PromoteCreatedWikisModal'
 import { HideWikiNotification } from './HideWikiNotification'
-import { FocusableElement } from '@chakra-ui/utils'
 
 type InsightTableWikiCreatedProps = {
   wikiCreatedInsightData: Wikis[]
@@ -71,7 +71,7 @@ export const InsightTableWikiCreated = (
   const VisibilityOptions = ['Archive', 'Unarchive']
 
   const findSection = (promotedNum: number) => {
-    let num = wikiCreatedInsightData && wikiCreatedInsightData[0].promoted
+    const num = wikiCreatedInsightData && wikiCreatedInsightData[0].promoted
     if (promotedNum === num) {
       setsectionType('hero section')
     } else {

--- a/src/components/Admin/WikiCreatedInsight/InsightTableCreatedWiki.tsx
+++ b/src/components/Admin/WikiCreatedInsight/InsightTableCreatedWiki.tsx
@@ -92,10 +92,10 @@ export const InsightTableWikiCreated = (
               <Text fontWeight="bold">Tags</Text>
             </Th>
             <Th color="#718096" textTransform="none" fontWeight="medium">
-              <HStack spacing={3}>
+              <HStack spacing={1}>
                 <Text fontWeight="bold">Status</Text>
                 <Icon
-                  fontSize="15px"
+                  fontSize="17px"
                   fontWeight="black"
                   cursor="pointer"
                   color="#718096"
@@ -177,10 +177,13 @@ export const InsightTableWikiCreated = (
                       borderRadius="full"
                       variant="solid"
                       bg="#F9F5FF"
+                      _dark={{ bg: '#FFB3D7', color: '#FF409B' }}
                       color="#FE6FB5"
-                      py="2"
+                      py="1"
                     >
-                      <TagLabel fontWeight="bold">Normal</TagLabel>
+                      <TagLabel fontSize="13px" fontWeight="medium">
+                        Normal
+                      </TagLabel>
                     </Tag>
                     {item.promoted && (
                       <Tag
@@ -188,9 +191,13 @@ export const InsightTableWikiCreated = (
                         borderRadius="full"
                         variant="solid"
                         bg="#EBF8FF"
+                        _dark={{ bg: '#90CDF4' }}
                         color="#385C8A"
                       >
-                        <TagLabel> Promoted </TagLabel>
+                        <TagLabel fontSize="13px" fontWeight="medium">
+                          {' '}
+                          Promoted{' '}
+                        </TagLabel>
                       </Tag>
                     )}
                   </HStack>
@@ -201,19 +208,23 @@ export const InsightTableWikiCreated = (
                     borderRadius="full"
                     variant="solid"
                     color={!item.hidden ? '#38A169' : '#DD6B20'}
+                    _dark={{ bg: item.hidden ? '#FBD38D' : '#F0FFF4' }}
                     bg={!item.hidden ? '#F0FFF4' : '#FFF5F5'}
-                    py="2"
+                    py="1"
                   >
                     <HStack spacing={2}>
                       <Box
                         w="8px"
                         h="8px"
                         bg={!item.hidden ? '#38A169' : '#DD6B20'}
+                        _dark={{ bg: item.hidden ? '#AE5D35' : '#38A169' }}
                         borderRadius="100px"
                       />
                       <TagLabel
-                        fontWeight="bold"
+                        fontWeight="medium"
                         color={!item.hidden ? '#38A169' : '#9C4221'}
+                        _dark={{ color: item.hidden ? '#AE5D35' : '#38A169' }}
+                        fontSize="13px"
                       >
                         {item.hidden ? 'Archived' : 'Active'}
                       </TagLabel>
@@ -221,7 +232,12 @@ export const InsightTableWikiCreated = (
                   </Tag>
                 </Td>
                 <Td>
-                  <Flex w="100%" gap={2} align="center">
+                  <Flex
+                    w="100%"
+                    gap={2}
+                    alignItems="center"
+                    justifyContent="flex-end"
+                  >
                     <HStack spacing={5}>
                       <Menu>
                         <MenuButton
@@ -256,6 +272,10 @@ export const InsightTableWikiCreated = (
                               }}
                               py="1"
                               px="1"
+                              isDisabled={
+                                (!item.hidden && o === 'Unarchive') ||
+                                (item.hidden && o === 'Archive')
+                              }
                             >
                               {o}
                             </MenuItem>
@@ -265,6 +285,7 @@ export const InsightTableWikiCreated = (
                       {!item.promoted ? (
                         <Text
                           color="#FF5CAA"
+                          _dark={{ color: '#F11a82' }}
                           cursor="pointer"
                           fontWeight="semibold"
                           onClick={() => {

--- a/src/components/Admin/WikiCreatedInsight/InsightTableCreatedWiki.tsx
+++ b/src/components/Admin/WikiCreatedInsight/InsightTableCreatedWiki.tsx
@@ -14,11 +14,6 @@ import {
   HStack,
   Link,
   useDisclosure,
-  MenuButton,
-  Button,
-  Menu,
-  MenuItem,
-  MenuList,
   Avatar,
   Box,
   AlertDialog,
@@ -29,12 +24,7 @@ import config from '@/config'
 import React, { useEffect, useState } from 'react'
 import shortenAccount from '@/utils/shortenAccount'
 import { shortenText } from '@/utils/shortenText'
-import {
-  RiArrowDownLine,
-  RiQuestionLine,
-  RiArrowDropDownLine,
-  RiCloseLine,
-} from 'react-icons/ri'
+import { RiArrowDownLine, RiQuestionLine, RiCloseLine } from 'react-icons/ri'
 import { BsDot } from 'react-icons/bs'
 import { Wikis } from '@/types/admin'
 import { FocusableElement } from '@chakra-ui/utils'
@@ -68,7 +58,6 @@ export const InsightTableWikiCreated = (
   } = useDisclosure()
   const [isHide, setIsHide] = useState(true)
   const [hideNotify, setHideNotify] = useState(false)
-  const VisibilityOptions = ['Archive', 'Unarchive']
 
   const findSection = (promotedNum: number) => {
     const num = wikiCreatedInsightData && wikiCreatedInsightData[0].promoted
@@ -79,12 +68,12 @@ export const InsightTableWikiCreated = (
     }
     onOpenPromotion()
   }
-  const shouldArchive = (e: string, ishidden: boolean, wikiId: string) => {
-    if (ishidden && e === 'Unarchive') {
+  const shouldArchive = (ishidden: boolean, wikiId: string) => {
+    if (ishidden) {
       setIsHide(false)
       onOpenWikiHideNotification()
       setWikiChosenId(wikiId)
-    } else if (!ishidden && e === 'Archive') {
+    } else if (!ishidden) {
       onOpenWikiHideNotification()
       setWikiChosenId(wikiId)
     }
@@ -258,51 +247,9 @@ export const InsightTableWikiCreated = (
                     gap={2}
                     alignItems="center"
                     justifyContent="flex-end"
+                    pr={5}
                   >
                     <HStack spacing={5}>
-                      <Menu>
-                        <MenuButton
-                          transition="all 0.2s"
-                          borderRadius="md"
-                          _expanded={{ bg: 'brand.500', color: 'white' }}
-                        >
-                          <Button
-                            borderColor="#E2E8F0"
-                            _dark={{ borderColor: '#2c323d' }}
-                            py={2}
-                            px={5}
-                            variant="outline"
-                            fontWeight="light"
-                          >
-                            <Text px={2}> Archive </Text>
-                            <Icon
-                              fontSize="2xl"
-                              fontWeight="bold"
-                              cursor="pointer"
-                              color="#718096"
-                              as={RiArrowDropDownLine}
-                            />
-                          </Button>
-                        </MenuButton>
-                        <MenuList px={1}>
-                          {VisibilityOptions.map((o, m) => (
-                            <MenuItem
-                              key={m}
-                              onClick={() => {
-                                shouldArchive(o, item.hidden, item.id)
-                              }}
-                              py="1"
-                              px="1"
-                              isDisabled={
-                                (!item.hidden && o === 'Unarchive') ||
-                                (item.hidden && o === 'Archive')
-                              }
-                            >
-                              {o}
-                            </MenuItem>
-                          ))}
-                        </MenuList>
-                      </Menu>
                       {!item.promoted ? (
                         <Text
                           color="#FF5CAA"
@@ -330,7 +277,38 @@ export const InsightTableWikiCreated = (
                           <Icon
                             fontSize="20px"
                             cursor="pointer"
-                            color="#718096"
+                            color="#F11a82"
+                            as={RiQuestionLine}
+                          />
+                        </HStack>
+                      )}
+
+                      {!item.hidden ? (
+                        <Text
+                          cursor="pointer"
+                          fontWeight="medium"
+                          onClick={() => {
+                            shouldArchive(item.hidden, item.id)
+                          }}
+                        >
+                          Archive
+                        </Text>
+                      ) : (
+                        <HStack
+                          spacing={2}
+                          onClick={() => shouldArchive(item.hidden, item.id)}
+                        >
+                          <Text
+                            color="#E2E8F0"
+                            _dark={{ color: '#495a68' }}
+                            cursor="pointer"
+                          >
+                            Archive
+                          </Text>
+                          <Icon
+                            fontSize="20px"
+                            cursor="pointer"
+                            color="#F11a82"
                             as={RiQuestionLine}
                           />
                         </HStack>

--- a/src/components/Admin/WikiCreatedInsight/PromoteCreatedWikisModal.tsx
+++ b/src/components/Admin/WikiCreatedInsight/PromoteCreatedWikisModal.tsx
@@ -71,7 +71,7 @@ export const PromoteCreatedWikisModal = ({
   const arrs = () => {
     const arr: any[] = []
     const data: any = promotedWikis && promotedWikis
-    let firtLevel = data[0].promoted
+    const firtLevel = data[0].promoted
     sethomepageLevel(firtLevel)
     for (let index = 1; index < data.length; index++) {
       arr.push(data[index].promoted)

--- a/src/components/Admin/WikiCreatedInsight/PromoteCreatedWikisModal.tsx
+++ b/src/components/Admin/WikiCreatedInsight/PromoteCreatedWikisModal.tsx
@@ -297,6 +297,7 @@ export const PromoteCreatedWikisModal = ({
 
   const HompageSelected = () => {
     if (activeStep === 0) {
+      setStep2Titles('Promote to Hero Section')
       nextStep()
       setInitGetSearchedWikis(false)
       setbuttonOne('cancel')
@@ -313,7 +314,7 @@ export const PromoteCreatedWikisModal = ({
     <>
       {activeStep === 0 && (
         <Text textAlign="center">
-          Select the appropraite action you would like to take for this wiki
+          Select the appropriate action you would like to take for this wiki
         </Text>
       )}
       {activeStep === 1 && (
@@ -418,6 +419,7 @@ export const PromoteCreatedWikisModal = ({
                     p={4}
                     onClick={HompageSelected}
                     size="sm"
+                    variant="ghost"
                     fontSize="xs"
                   >
                     {buttonOne}
@@ -425,7 +427,6 @@ export const PromoteCreatedWikisModal = ({
                   <Button
                     size="sm"
                     fontSize="xs"
-                    variant="ghost"
                     borderWidth="1px"
                     onClick={TrendingwikiSelected}
                   >

--- a/src/components/Admin/WikiCreatedInsight/PromoteCreatedWikisModal.tsx
+++ b/src/components/Admin/WikiCreatedInsight/PromoteCreatedWikisModal.tsx
@@ -48,6 +48,8 @@ export const PromoteCreatedWikisModal = ({
   const [step2Titles, setStep2Titles] = useState('Promote to Homepage')
   const [buttonOne, setbuttonOne] = useState('Promote to Hero section')
   const [buttonTwo, setbuttonTwo] = useState('Promote to Trending wikis')
+  const [homepageLevel, sethomepageLevel] = useState(0)
+  const [promotionArray, setPromotionArray] = useState<Array<[] | any>>()
   const [initGetSearchedWikis, setInitGetSearchedWikis] =
     useState<boolean>(true)
   const { data: promotedWikis } = useGetAllPromotedWikiCountQuery(0)
@@ -66,12 +68,23 @@ export const PromoteCreatedWikisModal = ({
     return value
   }
 
+  const arrs = () => {
+    const arr: any[] = []
+    const data: any = promotedWikis && promotedWikis
+    let firtLevel = data[0].promoted
+    sethomepageLevel(firtLevel)
+    for (let index = 1; index < data.length; index++) {
+      arr.push(data[index].promoted)
+    }
+
+    setPromotionArray(arr)
+  }
+
   const { data: wiki } = useGetSearchedWikisByTitleQuery(wikiChosenTitle, {
     skip: initGetSearchedWikis,
   })
   const [value, setValue] = useState('')
-  const homepageLevel = 7 /* for dev */
-  // const homepageLevel = 4  /* for prod */
+
   const toast = useToast()
   const ModalData = wiki?.filter(
     item => item.id === wikiChosenId && item.title === wikiChosenTitle,
@@ -223,6 +236,7 @@ export const PromoteCreatedWikisModal = ({
   const TrendingwikiSelected = async () => {
     if (activeStep === 0) {
       setStep2Titles('Promote to Trending wiki')
+      arrs()
       nextStep()
       setInitGetSearchedWikis(false)
       setbuttonOne('cancel')
@@ -298,6 +312,7 @@ export const PromoteCreatedWikisModal = ({
   const HompageSelected = () => {
     if (activeStep === 0) {
       setStep2Titles('Promote to Hero Section')
+      arrs()
       nextStep()
       setInitGetSearchedWikis(false)
       setbuttonOne('cancel')
@@ -330,14 +345,11 @@ export const PromoteCreatedWikisModal = ({
                   w="20%"
                   onChange={e => setValue(e.target.value)}
                 >
-                  {/* values are for dev */}
-                  <option value={6}> SLOT 1 </option>
-                  <option value={5}> SLOT 2</option>
-
-                  {/* values are for prod
-                  <option value={3}> SLOT 1</option>
-                  <option value={2}> SLOT 2 </option>
-                  <option value={1}> SLOT 3 </option> */}
+                  {promotionArray?.map((item, i) => (
+                    <option key={i} value={item}>
+                      SLOT {i + 1}
+                    </option>
+                  ))}
                 </Select>
               </Box>
             )}

--- a/src/components/Admin/WikiCreatedInsight/WikiInsightTable.tsx
+++ b/src/components/Admin/WikiCreatedInsight/WikiInsightTable.tsx
@@ -30,7 +30,8 @@ import {
 import React, { useEffect, useState, useMemo } from 'react'
 import { FiSearch } from 'react-icons/fi'
 import { MdFilterList } from 'react-icons/md'
-import { BiSortDown, BiSort, BiSortUp } from 'react-icons/bi'
+import { BiSortDown, BiSortUp } from 'react-icons/bi'
+import { RiArrowUpDownLine } from 'react-icons/ri'
 import { InsightTableWikiCreated } from './InsightTableCreatedWiki'
 
 export const WikiInsightTable = () => {
@@ -60,7 +61,7 @@ export const WikiInsightTable = () => {
 
   const sortIcon = useMemo(() => {
     if (sortTableBy === 'default') {
-      return <BiSort fontSize="1.3rem" />
+      return <RiArrowUpDownLine fontSize="1.3rem" />
     }
     if (sortTableBy === 'Newest' || sortTableBy === 'AlpaUp') {
       return <BiSortUp fontSize="1.3rem" />
@@ -68,7 +69,7 @@ export const WikiInsightTable = () => {
     if (sortTableBy === 'Oldest' || sortTableBy === 'AlpaDown') {
       return <BiSortDown fontSize="1.3rem" />
     }
-    return <BiSort fontSize="1.3rem" />
+    return <RiArrowUpDownLine fontSize="1.3rem" />
   }, [wiki, sortTableBy])
 
   enum FilterTypes {
@@ -318,12 +319,12 @@ export const WikiInsightTable = () => {
                 _expanded={{ bg: 'brand.500', color: 'white' }}
                 py={2}
                 px={10}
-                rightIcon={<MdFilterList fontSize="25px" />}
+                leftIcon={<MdFilterList fontSize="25px" />}
                 variant="outline"
                 fontWeight="medium"
                 onClick={onToggle}
               >
-                Filter
+                Filters
               </Button>
             </PopoverTrigger>
             <PopoverContent w="fit-content">

--- a/src/components/Admin/WikiCreatedInsight/WikiInsightTable.tsx
+++ b/src/components/Admin/WikiCreatedInsight/WikiInsightTable.tsx
@@ -290,6 +290,7 @@ export const WikiInsightTable = () => {
                 px={5}
                 leftIcon={sortIcon}
                 variant="outline"
+                fontWeight="medium"
               >
                 Sort
               </Button>
@@ -317,7 +318,7 @@ export const WikiInsightTable = () => {
                 _expanded={{ bg: 'brand.500', color: 'white' }}
                 py={2}
                 px={10}
-                rightIcon={<MdFilterList />}
+                rightIcon={<MdFilterList fontSize="25px" />}
                 variant="outline"
                 fontWeight="medium"
                 onClick={onToggle}

--- a/src/components/Admin/WikiDataGraph.tsx
+++ b/src/components/Admin/WikiDataGraph.tsx
@@ -57,7 +57,7 @@ export const WikiDataGraph = ({
             </Text>
           </VStack>
           <Select
-            w={{ lg: '20%', base: '40%' }}
+            w={{ lg: '27%', md: '39%', base: '50%' }}
             icon={<MdArrowDropDown />}
             onChange={e => {
               handleGraphFilterChange(e.target.value)

--- a/src/components/Admin/WikiDataGraph.tsx
+++ b/src/components/Admin/WikiDataGraph.tsx
@@ -57,7 +57,7 @@ export const WikiDataGraph = ({
             </Text>
           </VStack>
           <Select
-            w="30%"
+            w={{ lg: '20%', base: '40%' }}
             icon={<MdArrowDropDown />}
             onChange={e => {
               handleGraphFilterChange(e.target.value)

--- a/src/components/Admin/WikiEditorInsight/DeleteEditorModal.tsx
+++ b/src/components/Admin/WikiEditorInsight/DeleteEditorModal.tsx
@@ -54,7 +54,7 @@ export const DeleteEditorModal = ({
               />
             </Box>
             <Heading fontSize="xl">
-              {rest.isActive ? 'Ban' : 'Unban'} Editor
+              {rest.isActive ? 'Ban Editor' : 'Ban Editor Details'}
             </Heading>
           </HStack>
           <Flex

--- a/src/components/Admin/WikiEditorInsight/InsightTableWikiEditors.tsx
+++ b/src/components/Admin/WikiEditorInsight/InsightTableWikiEditors.tsx
@@ -12,20 +12,17 @@ import {
   Thead,
   Tr,
   AspectRatio,
-  Button,
   useDisclosure,
   Link,
-  Menu,
-  MenuButton,
-  MenuList,
-  MenuItem,
   Box,
   Tag,
+  HStack,
+  Icon,
 } from '@chakra-ui/react'
 import React, { useMemo } from 'react'
 import shortenAccount from '@/utils/shortenAccount'
 import { shortenText } from '@/utils/shortenText'
-import { BiChevronDown } from 'react-icons/bi'
+import { RiQuestionLine } from 'react-icons/ri'
 import { WikiImage } from '../../WikiImage'
 
 interface WikiEditorInsightDataInterface {
@@ -196,52 +193,39 @@ export const InsightTableWikiEditors = (
                     </Tag>
                   </Td>
                   <Td>
-                    <Menu>
-                      <MenuButton
-                        transition="all 0.2s"
-                        borderRadius="md"
-                        _expanded={{ bg: 'brand.500', color: 'white' }}
-                        _hover={{ bg: 'none' }}
-                        _active={{ bg: 'none', outline: 'none' }}
-                        _focus={{ bg: 'none', outline: 'none' }}
-                        w="fit-content"
+                    {item.active ? (
+                      <Text
+                        cursor="pointer"
+                        fontWeight="medium"
+                        onClick={() => {
+                          onOpen()
+                          toggleUserFunc(item.active, item.editorAddress)
+                        }}
                       >
-                        <MenuButton
-                          as={Button}
-                          rightIcon={<BiChevronDown />}
-                          bg="transparent"
-                          color="#718096"
-                          _hover={{ bg: 'none' }}
-                          _active={{ bg: 'none', outline: 'none' }}
-                          _focus={{ bg: 'none', outline: 'none' }}
-                          fontWeight="medium"
-                          p="0"
-                        >
-                          {item.active ? 'Ban' : 'Unban'}
-                        </MenuButton>
-                      </MenuButton>
-                      <MenuList>
-                        <MenuItem
-                          onClick={() => {
-                            onOpen()
-                            toggleUserFunc(item.active, item.editorAddress)
-                          }}
-                          py="5"
-                          px="3"
+                        Ban
+                      </Text>
+                    ) : (
+                      <HStack
+                        spacing={2}
+                        onClick={() =>
+                          toggleUserFunc(item.active, item.editorAddress)
+                        }
+                      >
+                        <Text
+                          color="#E2E8F0"
+                          _dark={{ color: '#495a68' }}
+                          cursor="pointer"
                         >
                           Ban
-                        </MenuItem>
-                        <MenuItem
-                          onClick={() => {
-                            toggleUserFunc(item.active, item.editorAddress)
-                          }}
-                          py="5"
-                          px="3"
-                        >
-                          Unban
-                        </MenuItem>
-                      </MenuList>
-                    </Menu>
+                        </Text>
+                        <Icon
+                          fontSize="20px"
+                          cursor="pointer"
+                          color="#F11a82"
+                          as={RiQuestionLine}
+                        />
+                      </HStack>
+                    )}
                   </Td>
                 </Tr>
               )

--- a/src/components/Admin/WikiEditorInsight/InsightTableWikiEditors.tsx
+++ b/src/components/Admin/WikiEditorInsight/InsightTableWikiEditors.tsx
@@ -101,25 +101,25 @@ export const InsightTableWikiEditors = (
               textTransform="capitalize"
               fontWeight="semibold"
             >
-              Names
+              <Text fontWeight="bold">Names</Text>
             </Th>
             <Th color="#718096" textTransform="capitalize" fontWeight="normal">
-              No. of created wikis
+              <Text fontWeight="bold">No. of created wikis</Text>
             </Th>
             <Th color="#718096" textTransform="capitalize" fontWeight="medium">
-              No. of edited wikis
+              <Text fontWeight="bold">No. of edited wikis</Text>
             </Th>
             <Th color="#718096" textTransform="capitalize" fontWeight="medium">
-              Total No. of wikis
+              <Text fontWeight="bold">Total No. of wikis</Text>
             </Th>
             <Th color="#718096" textTransform="capitalize" fontWeight="medium">
-              Last created wiki
+              <Text fontWeight="bold">Last created wiki</Text>
             </Th>
             <Th color="#718096" textTransform="capitalize" fontWeight="medium">
-              Lastest activity
+              <Text fontWeight="bold">Lastest activity</Text>
             </Th>
             <Th color="#718096" textTransform="capitalize" fontWeight="medium">
-              Status
+              <Text fontWeight="bold">Status</Text>
             </Th>
             <Th color="#718096" textTransform="capitalize" fontWeight="medium">
               Action

--- a/src/components/Admin/WikiEditorInsight/InsightTableWikiEditors.tsx
+++ b/src/components/Admin/WikiEditorInsight/InsightTableWikiEditors.tsx
@@ -142,21 +142,27 @@ export const InsightTableWikiEditors = (
                           src={item.editorAvatar}
                         />
                         <Flex flexDirection="column">
-                          <Text>{item.editorName}</Text>
-                          <Text color="#718096" fontSize="sm">
+                          <Text opacity={item.active ? 1 : 0.3}>
+                            {item.editorName}
+                          </Text>
+                          <Text
+                            color="#718096"
+                            fontSize="sm"
+                            opacity={item.active ? 1 : 0.3}
+                          >
                             {shortenAccount(item.editorAddress)}
                           </Text>
                         </Flex>
                       </Flex>
                     </Link>
                   </Td>
-                  <Td>
+                  <Td opacity={item.active ? 1 : 0.3}>
                     <Text color="#718096">{item.createdWikis.length}</Text>
                   </Td>
-                  <Td>
+                  <Td opacity={item.active ? 1 : 0.3}>
                     <Text color="#718096">{item.editiedWikis.length}</Text>
                   </Td>
-                  <Td>
+                  <Td opacity={item.active ? 1 : 0.3}>
                     <Text color="#718096">
                       {item.createdWikis.length + item.editiedWikis.length}
                     </Text>
@@ -175,7 +181,7 @@ export const InsightTableWikiEditors = (
                             }`}
                           />
                         </AspectRatio>
-                        <Text>
+                        <Text opacity={item.active ? 1 : 0.1}>
                           {item.lastCreatedWiki?.content[0]
                             ? shortenText(
                                 item.lastCreatedWiki?.content[0].title,
@@ -188,11 +194,25 @@ export const InsightTableWikiEditors = (
                   </Td>
                   <Td color="#718096">{item.latestActivity}</Td>
                   <Td>
-                    <Tag colorScheme={item.active ? 'green' : 'red'}>
+                    <Tag
+                      bg={item.active ? '#F0FFF4' : '#FBD38D'}
+                      display="flex"
+                      w="fit-content"
+                      gap="2"
+                      py="1"
+                      borderRadius="100px"
+                      color={item.active ? '#276749' : '#9C4221'}
+                    >
+                      <Box
+                        w="8px"
+                        h="8px"
+                        bg={item.active ? '#38A169' : '#DD6B20'}
+                        borderRadius="100px"
+                      />
                       {item.active ? 'Active' : 'Banned'}
                     </Tag>
                   </Td>
-                  <Td>
+                  <Td _dark={{ opacity: item.active ? 1 : 0.5 }}>
                     {item.active ? (
                       <Text
                         cursor="pointer"

--- a/src/components/Admin/WikiEditorInsight/WikiEditorsInsight.tsx
+++ b/src/components/Admin/WikiEditorInsight/WikiEditorsInsight.tsx
@@ -340,6 +340,7 @@ export const WikiEditorsInsightTable = () => {
             px={10}
             rightIcon={sortIcon}
             variant="outline"
+            fontWeight="medium"
           >
             Sort
           </Button>
@@ -351,10 +352,10 @@ export const WikiEditorsInsightTable = () => {
                 _expanded={{ bg: 'brand.500', color: 'white' }}
                 py={2}
                 px={10}
-                rightIcon={<MdFilterList />}
+                rightIcon={<MdFilterList fontSize="25px" />}
                 variant="outline"
-                fontWeight="medium"
                 onClick={onToggleFilter}
+                fontWeight="medium"
               >
                 Filter
               </Button>

--- a/src/components/Admin/WikiEditorInsight/WikiEditorsInsight.tsx
+++ b/src/components/Admin/WikiEditorInsight/WikiEditorsInsight.tsx
@@ -313,7 +313,6 @@ export const WikiEditorsInsightTable = () => {
           <TagLabel>100 Users</TagLabel>
         </Tag>
       </Flex>
-
       <Flex justifyContent={{ base: 'center', lg: 'flex-end' }} p={5}>
         <Flex gap={5} flexDir={{ base: 'column', md: 'row' }}>
           <InputGroup w="100%">

--- a/src/components/Admin/WikiEditorInsight/WikiEditorsInsight.tsx
+++ b/src/components/Admin/WikiEditorInsight/WikiEditorsInsight.tsx
@@ -25,8 +25,9 @@ import {
   VStack,
 } from '@chakra-ui/react'
 import React, { useEffect, useMemo, useState } from 'react'
-import { BiSortDown, BiSort, BiSortUp } from 'react-icons/bi'
+import { BiSortDown, BiSortUp } from 'react-icons/bi'
 
+import { RiArrowUpDownLine } from 'react-icons/ri'
 import { FiSearch } from 'react-icons/fi'
 import { MdFilterList } from 'react-icons/md'
 import { DeleteEditorModal } from './DeleteEditorModal'
@@ -84,7 +85,7 @@ export const WikiEditorsInsightTable = () => {
 
   const sortIcon = useMemo(() => {
     if (sortTableBy === 'default') {
-      return <BiSort fontSize="1.3rem" />
+      return <RiArrowUpDownLine fontSize="1.3rem" />
     }
     if (sortTableBy === 'ascending') {
       return <BiSortUp fontSize="1.3rem" />
@@ -92,7 +93,7 @@ export const WikiEditorsInsightTable = () => {
     if (sortTableBy === 'descending') {
       return <BiSortDown fontSize="1.3rem" />
     }
-    return <BiSort fontSize="1.3rem" />
+    return <RiArrowUpDownLine fontSize="1.3rem" />
   }, [editors, sortTableBy])
 
   const editorsFilteredArr = useMemo(() => {
@@ -352,12 +353,12 @@ export const WikiEditorsInsightTable = () => {
                 _expanded={{ bg: 'brand.500', color: 'white' }}
                 py={2}
                 px={10}
-                rightIcon={<MdFilterList fontSize="25px" />}
+                leftIcon={<MdFilterList fontSize="25px" />}
                 variant="outline"
                 onClick={onToggleFilter}
                 fontWeight="medium"
               >
-                Filter
+                Filters
               </Button>
             </PopoverTrigger>
             <PopoverContent w="fit-content">


### PR DESCRIPTION


- [x] Rearrange the promote and archive buttons as below (check on figma). promote should come before archive because the promote button will be used often compared to the archive button

- [x] Change All tiny help buttons (the question marks) to pink according to the figma design
- [x] remove arrow in front of the archive and ban buttons.

- [x] Implement new flow for archive/unarchive 




- [x] implement new flow for ban/unban 
closes https://github.com/EveripediaNetwork/issues/issues/689