### PR TITLE
Fixes youtube embeds not working around br tags

### DIFF
--- a/src/components/Wiki/WikiPage/WikiMainContent.tsx
+++ b/src/components/Wiki/WikiPage/WikiMainContent.tsx
@@ -44,7 +44,7 @@ const MarkdownRender = React.memo(
 const WikiMainContent = ({ wiki }: WikiMainContentProps) => {
   const { colorMode } = useColorMode()
 
-  let content = wiki?.content || ''
+  let content = wiki?.content.replace(/<br( )*\/?>/g, '\n') || ''
 
   const matchRegex = /\$\$widget\d(.*?\))\$\$/
   content.match(new RegExp(matchRegex, 'g'))?.forEach(match => {


### PR DESCRIPTION
Fixes https://github.com/EveripediaNetwork/issues/issues/709
# Changes
 - removes all br tags and replaces each with markdown line break `\n`

# Screenshots
![Frame 389](https://user-images.githubusercontent.com/52039218/189880963-7009508c-89e9-4192-841e-c8dacfd5e774.png)
