### PR TITLE
Redirect users on archived wiki

### DIFF
--- a/src/pages/wiki/[slug]/index.tsx
+++ b/src/pages/wiki/[slug]/index.tsx
@@ -85,7 +85,7 @@ export const getStaticProps: GetStaticProps = async context => {
   if (wiki?.hidden) {
     return {
       redirect: {
-        destination: `/404`,
+        destination: `/404/?wiki=${wiki.title}`,
         permanent: false,
       },
     }

--- a/src/pages/wiki/[slug]/index.tsx
+++ b/src/pages/wiki/[slug]/index.tsx
@@ -82,6 +82,14 @@ export const getStaticProps: GetStaticProps = async context => {
     getWikisByCategory.initiate({ category: category.id }),
   )
 
+  if (wiki?.hidden) {
+    return {
+      redirect: {
+        destination: `/404`,
+        permanent: false,
+      },
+    }
+  }
   await Promise.all(getRunningOperationPromises())
   return {
     props: { wiki: wiki || null },

--- a/src/services/wikis/queries.ts
+++ b/src/services/wikis/queries.ts
@@ -19,6 +19,7 @@ export const GET_WIKI_BY_ID = gql`
   query GetWiki($id: String!) {
     wiki(id: $id) {
       id
+      hidden
       ipfs
       transactionHash
       created

--- a/src/store/slices/wiki.slice.ts
+++ b/src/store/slices/wiki.slice.ts
@@ -55,6 +55,7 @@ const initialState: Wiki = {
   version: 1,
   language: LanguagesISOEnum.EN,
   title: '',
+  hidden: true,
   content: '',
   summary: '',
   categories: [],

--- a/src/types/Wiki.ts
+++ b/src/types/Wiki.ts
@@ -174,6 +174,7 @@ export interface Wiki {
 export type WikiPreview = Pick<
   Wiki,
   | 'id'
+  | 'hidden'
   | 'title'
   | 'summary'
   | 'tags'

--- a/src/types/Wiki.ts
+++ b/src/types/Wiki.ts
@@ -168,6 +168,7 @@ export interface Wiki {
   updated?: string
   created?: string
   author: Author
+  hidden: boolean
 }
 
 export type WikiPreview = Pick<


### PR DESCRIPTION
This PR is to redirect users when they visit an archived wiki. 

[Click this to test: ](https://iq-wiki-git-688-archived-wiki-should-not-be-rendered-prediqt.vercel.app/wiki/wiki-title-testing-event)
## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/688
