### PR TITLE
Adds stopping wiki to publish while media are uploading

### DIFF
--- a/src/data/Constants.ts
+++ b/src/data/Constants.ts
@@ -1,5 +1,5 @@
 export const ITEM_PER_PAGE = 12
 export const FETCH_DELAY_TIME = 3000
 export const CATEGORY_DESCRIPTION_WORD_LIMIT = 200
-export const MEDIA_POST_DEFAULT_ID = 'DEFAULT_ID'
+export const MEDIA_POST_DEFAULT_ID = 'UPLOADING_ID'
 export const WIKI_IMAGE_ASPECT_RATIO = 4 / 3

--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -85,6 +85,7 @@ import {
 } from '@/store/slices/wiki.slice'
 import useConfetti from '@/hooks/useConfetti'
 import WikiScoreIndicator from '@/components/Layout/Editor/WikiScoreIndicator'
+import { MEDIA_POST_DEFAULT_ID } from '@/data/Constants'
 
 type PageWithoutFooter = NextPage & {
   noFooter?: boolean
@@ -220,6 +221,14 @@ const CreateWikiContent = () => {
       return false
     }
 
+    if (!wiki.media?.every(m => !m.id.endsWith(MEDIA_POST_DEFAULT_ID))) {
+      toast({
+        title: 'Some of media are still uploading, please wait',
+        status: 'error',
+        duration: 3000,
+      })
+      return false
+    }
     return true
   }
 


### PR DESCRIPTION
Fixes https://github.com/EveripediaNetwork/issues/issues/728

# Changes
- added new validation function to trigger a toast and return valid wiki false when any media has uploading tag to its id

# Screenshots
https://user-images.githubusercontent.com/52039218/191497771-835a9084-e534-4bc9-8521-9b78cc20ae6e.mp4

