### PR TITLE
Adds errors to getStaticProps so pages fallback to previous versions

### DIFF
--- a/src/data/NetworkData.ts
+++ b/src/data/NetworkData.ts
@@ -1,5 +1,3 @@
-import { utils } from 'ethers'
-
 export type Network = {
   id: number
   image: string
@@ -14,20 +12,20 @@ export const Networks: Network[] = [
     image: '/images/polygon.svg',
     name: 'Polygon',
     isActive: true,
-    chainId: utils.hexValue(80001),
+    chainId: '0x13881',
   },
   {
     id: 2,
     image: '/images/ethereum2.svg',
     name: 'Ethereum',
     isActive: false,
-    chainId: utils.hexValue(1),
+    chainId: '0x1',
   },
   {
     id: 3,
     image: '/images/bsc.svg',
     name: 'Bsc',
     isActive: false,
-    chainId: utils.hexValue(56),
+    chainId: '0x38',
   },
 ]

--- a/src/pages/activity/index.tsx
+++ b/src/pages/activity/index.tsx
@@ -110,13 +110,18 @@ const Activity = ({ activities }: { activities: ActivityType[] }) => {
 }
 
 export const getStaticProps: GetStaticProps = async () => {
-  const activities = await store.dispatch(
+  const { data: activities, error: activitiesError } = await store.dispatch(
     getLatestActivities.initiate({ offset: 0, limit: ITEM_PER_PAGE }),
   )
   await Promise.all(getRunningOperationPromises())
+
+  if (activitiesError) {
+    throw new Error(`Error fetching activities: ${activitiesError}`)
+  }
+
   return {
     props: {
-      activities: activities.status !== 'fulfilled' ? [] : activities.data,
+      activities: activities || [],
     },
   }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -49,11 +49,12 @@ export const Index = ({
 }
 
 export async function getStaticProps() {
-  const { data: promotedWikis } = await store.dispatch(
-    getPromotedWikis.initiate(),
+  const { data: promotedWikis, error: promotedWikisError } =
+    await store.dispatch(getPromotedWikis.initiate())
+  const { data: categories, error: categoriesError } = await store.dispatch(
+    getCategories.initiate(),
   )
-  const { data: categories } = await store.dispatch(getCategories.initiate())
-  const { data: tagsData } = await store.dispatch(
+  const { data: tagsData, error: tagsDataError } = await store.dispatch(
     getTags.initiate({
       startDate: Math.floor(Date.now() / 1000) - 60 * 60 * 24 * 30,
       endDate: Math.floor(Date.now() / 1000),
@@ -62,6 +63,16 @@ export async function getStaticProps() {
   await Promise.all(getWikisRunningOperationPromises())
   await Promise.all(getCategoriesRunningOperationPromises())
   await Promise.all(getTagsRunningOperationPromises())
+
+  if (promotedWikisError || categoriesError || tagsDataError) {
+    throw new Error(
+      `Error fetching data. the error is: ${{
+        promotedWikisError,
+        categoriesError,
+        tagsDataError,
+      }}`,
+    )
+  }
 
   return {
     props: {

--- a/src/pages/revision/[id].tsx
+++ b/src/pages/revision/[id].tsx
@@ -154,7 +154,7 @@ export const getStaticProps: GetStaticProps = async context => {
     }
   }
 
-  const { data: activityData, error } = await store.dispatch(
+  const { data: activityData, error: activityError } = await store.dispatch(
     getActivityById.initiate(id),
   )
 
@@ -171,13 +171,17 @@ export const getStaticProps: GetStaticProps = async context => {
 
   await Promise.all(getRunningOperationPromises())
 
-  if (activityData && !error)
+  if (activityData && !activityError)
     return {
       props: {
         wiki: activityData,
         relatedWikis,
       },
     }
+
+  if (activityError) {
+    throw new Error(`Error fetching activity: ${activityError}`)
+  }
 
   return {
     notFound: true,

--- a/src/pages/wiki/[slug]/history.tsx
+++ b/src/pages/wiki/[slug]/history.tsx
@@ -115,10 +115,20 @@ const History = ({ wikiHistory, wiki }: HistoryPageProps) => {
 export const getStaticProps: GetStaticProps = async context => {
   const slug = context.params?.slug
   if (typeof slug !== 'string') return { notFound: true }
-  const { data: wikiHistory } = await store.dispatch(
+  const { data: wikiHistory, error: wikiHistoryError } = await store.dispatch(
     getActivityByWiki.initiate(slug),
   )
-  const { data: wiki } = await store.dispatch(getWiki.initiate(slug))
+
+  if (wikiHistoryError)
+    throw new Error(`Error fetching wiki history: ${wikiHistoryError}`)
+
+  const { data: wiki, error: wikiError } = await store.dispatch(
+    getWiki.initiate(slug),
+  )
+
+  if (wikiError)
+    throw new Error(`Error fetching latest wiki for history: ${wikiError}`)
+
   return {
     props: {
       wikiHistory,


### PR DESCRIPTION
# Changes
- implements throwing errors when there is a error from a request in getStaticProps to fallback to previous version instead of sending the error to cache