### PR TITLE
wiki page responsive fix

### DIFF
--- a/src/components/Landing/Hero.tsx
+++ b/src/components/Landing/Hero.tsx
@@ -51,8 +51,8 @@ const Hero = ({ wiki }: { wiki: Wiki | undefined }) => {
           Encyclopedia
         </Heading>
         <Text
-          w={{ base: '70%', md: '80%' }}
-          fontSize={{ base: 'md', lg: 'xl' }}
+          w={{ base: '70%', md: '75%', xl: '80%' }}
+          fontSize={{ base: 'md', md: 'lg', lg: 'xl' }}
           pb={10}
         >
           {description}

--- a/src/components/Layout/Navbar/MobileSubNav.tsx
+++ b/src/components/Layout/Navbar/MobileSubNav.tsx
@@ -38,7 +38,12 @@ const MobileSubNavItem = ({ item, ...rest }: { item: NavItem } & FlexProps) => (
         />
       )}
 
-      <LinkOverlay href={item.href} fontWeight={600} color="linkColor">
+      <LinkOverlay
+        href={item.href}
+        fontWeight={600}
+        target={item.target}
+        color="linkColor"
+      >
         {item.label}
       </LinkOverlay>
     </HStack>

--- a/src/components/Layout/Navbar/NavMenu.tsx
+++ b/src/components/Layout/Navbar/NavMenu.tsx
@@ -77,6 +77,7 @@ const NavMenu = ({
               }}
               color="linkColor"
               key={key}
+              target={item.target}
             >
               {item.label === 'Settings' && <Divider />}
               <MenuItem minH="48px" bg="subMenuBg">

--- a/src/components/Wiki/WikiAccordion/AccordionWidget.tsx
+++ b/src/components/Wiki/WikiAccordion/AccordionWidget.tsx
@@ -123,7 +123,7 @@ const AccordionWidget = ({ type, title, titleTag, content }: WikiInsights) => {
   return (
     <HStack
       bgColor="wikiCardItemBg"
-      borderRadius={4}
+      borderRadius={8}
       justify="space-between"
       align="center"
       p={4}

--- a/src/components/Wiki/WikiAccordion/index.tsx
+++ b/src/components/Wiki/WikiAccordion/index.tsx
@@ -38,7 +38,7 @@ const WikiAccordion = ({
         bgColor: withNoDarkBg ? 'gray.800' : 'gray.700',
       }}
       p={3}
-      borderRadius={4}
+      borderRadius={8}
     >
       <HStack cursor="pointer" onClick={onToggle} justify="start">
         <IconButton

--- a/src/components/Wiki/WikiPage/InsightComponents/CurrencyConverter.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/CurrencyConverter.tsx
@@ -97,8 +97,8 @@ const CurrencyConverter = ({ token, tokenStats }: CurrencyConverterProps) => {
   )
 
   return (
-    <VStack w="100%" spacing={4} borderWidth={1} borderRadius={2}>
-      <Box w="100%" bgColor="wikiCardBg" p={3} borderRadius={4}>
+    <VStack w="100%" spacing={4} borderWidth={1} borderRadius={8}>
+      <Box w="100%" bgColor="wikiCardBg" p={3} borderRadius={8}>
         <Text
           style={{
             userSelect: 'none',

--- a/src/components/Wiki/WikiPage/InsightComponents/RelatedMedia.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/RelatedMedia.tsx
@@ -11,7 +11,7 @@ const RelatedMediaGrid = ({ media }: { media?: Media[] }) => {
   return (
     <VStack w="100%" spacing={4} borderRadius={2}>
       <WikiAccordion title="Media">
-        <SimpleGrid columns={3} spacing={5}>
+        <SimpleGrid columns={{ base: 3, md: 4, xl: 3 }} spacing={5}>
           {media.map((m, i) => (
             <AspectRatio ratio={1} key={i}>
               <MediaPreview

--- a/src/components/Wiki/WikiPage/InsightComponents/WikiCommitMessage.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/WikiCommitMessage.tsx
@@ -21,7 +21,7 @@ const WikiCommitMessage = ({
       })
     : '-'
   return (
-    <VStack w="100%" spacing={4} borderRadius={2}>
+    <VStack w="100%" spacing={4} borderRadius={8}>
       <WikiAccordion
         display="flex"
         withNoDarkBg
@@ -35,7 +35,7 @@ const WikiCommitMessage = ({
         {commitMessage && (
           <VStack
             bgColor="wikiCardItemBg"
-            borderRadius={4}
+            borderRadius={8}
             align="left"
             p={4}
             spacing={2}

--- a/src/components/Wiki/WikiPage/InsightComponents/WikiDetails.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/WikiDetails.tsx
@@ -53,7 +53,7 @@ export const WikiDetails = ({
         fontWeight="600"
         w="100%"
         textAlign="center"
-        display={{ base: 'none', lg: 'block', md: 'block' }}
+        display={{ base: 'none', xl: 'block' }}
       >
         {title}
       </Heading>

--- a/src/components/Wiki/WikiPage/InsightComponents/WikiDetails.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/WikiDetails.tsx
@@ -8,6 +8,7 @@ import {
   Td,
   Text,
   Tr,
+  TableContainer,
   VStack,
   AspectRatio,
 } from '@chakra-ui/react'
@@ -60,118 +61,122 @@ export const WikiDetails = ({
       <AspectRatio w="100%" ratio={WIKI_IMAGE_ASPECT_RATIO}>
         <WikiImage bgColor="dimColor" priority imageURL={imgSrc} alt={title} />
       </AspectRatio>
-      <Table size="sm" variant="simple">
-        <Tbody>
-          {categories.length !== 0 && (
+      <TableContainer w="full">
+        <Table size="sm" variant="simple">
+          <Tbody>
+            {categories.length !== 0 && (
+              <Tr>
+                <Td pt={1} pb={3}>
+                  Categories
+                </Td>
+                <Td pt={1} pb={3}>
+                  <HStack flexWrap="wrap" justify="start">
+                    {categories?.map((category, i) => (
+                      <Link
+                        key={i}
+                        isExternal
+                        href={`/categories/${category.id}`}
+                        color="brandLinkColor"
+                      >
+                        {category.title}
+                      </Link>
+                    ))}
+                  </HStack>
+                </Td>
+              </Tr>
+            )}
+            {tags.length !== 0 && (
+              <Tr>
+                <Td py={1}>Tags</Td>
+                <Td py={1}>
+                  <HStack marginLeft={-2} flexWrap="wrap" justify="start">
+                    {tags?.map((tag, i) => (
+                      <Link key={i} href={`/tags/${tag.id}`} py={1}>
+                        <Tag whiteSpace="nowrap">{tag.id}</Tag>
+                      </Link>
+                    ))}
+                  </HStack>
+                </Td>
+              </Tr>
+            )}
             <Tr>
-              <Td py={1}>Categories</Td>
-              <Td py={1}>
-                <HStack flexWrap="wrap" justify="start">
-                  {categories?.map((category, i) => (
-                    <Link
-                      key={i}
-                      isExternal
-                      href={`/categories/${category.id}`}
-                      color="brandLinkColor"
-                    >
-                      {category.title}
-                    </Link>
-                  ))}
-                </HStack>
-              </Td>
-            </Tr>
-          )}
-          {tags.length !== 0 && (
-            <Tr>
-              <Td py={1}>Tags</Td>
-              <Td py={1}>
-                <HStack marginLeft={-2} flexWrap="wrap" justify="start">
-                  {tags?.map((tag, i) => (
-                    <Link key={i} href={`/tags/${tag.id}`} py={1}>
-                      <Tag whiteSpace="nowrap">{tag.id}</Tag>
-                    </Link>
-                  ))}
-                </HStack>
-              </Td>
-            </Tr>
-          )}
-          <Tr>
-            <Td>
-              <HStack spacing={3} py="2">
-                <Text>IPFS</Text>
-              </HStack>
-            </Td>
-            <Td display="flex" align="center">
-              <HStack gap={1} py="2">
-                <SiIpfs />
-                <Link
-                  target="_blank"
-                  href={`https://ipfs.everipedia.org/ipfs/${ipfsHash}`}
-                  color="brandLinkColor"
-                >
-                  <Text>{shortenAccount(ipfsHash || '')}</Text>
-                </Link>
-              </HStack>
-            </Td>
-          </Tr>
-          <Tr>
-            <Td>
-              <HStack spacing={3}>
-                <Text>TX Hash</Text>
-              </HStack>
-            </Td>
-            <Td display="flex" align="center" gap={3}>
-              <GoLink />
-              <Link
-                target="_blank"
-                href={`${config.blockExplorerUrl}/tx/${txHash}`}
-                color="brandLinkColor"
-              >
-                <Text>{shortenAccount(txHash || '')}</Text>
-              </Link>
-            </Td>
-          </Tr>
-          <Tr>
-            <Td whiteSpace="nowrap">
-              <Text py="2">Created</Text>
-            </Td>
-            <Td>
-              <Text>
-                {createdTime
-                  ? new Date(createdTime).toLocaleDateString('en-US', {
-                      year: 'numeric',
-                      month: 'long',
-                      day: 'numeric',
-                    })
-                  : '-'}
-              </Text>
-            </Td>
-          </Tr>
-          {createdBy && (
-            <Tr>
-              <Td whiteSpace="nowrap">
-                <Text py="2">Created By</Text>
-              </Td>
               <Td>
-                <HStack py="2">
-                  <DisplayAvatar
-                    alt={createdBy.profile?.username}
-                    address={createdBy.id}
-                    avatarIPFS={createdBy.profile?.avatar}
-                    size="24"
-                  />
+                <HStack spacing={3} py="2">
+                  <Text>IPFS</Text>
+                </HStack>
+              </Td>
+              <Td display="flex" align="center">
+                <HStack gap={1} py="2">
+                  <SiIpfs />
                   <Link
-                    href={`/account/${createdBy.id}`}
+                    target="_blank"
+                    href={`https://ipfs.everipedia.org/ipfs/${ipfsHash}`}
                     color="brandLinkColor"
                   >
-                    {getUsername(createdBy, username)}
+                    <Text>{shortenAccount(ipfsHash || '')}</Text>
                   </Link>
                 </HStack>
               </Td>
             </Tr>
-          )}
-        </Tbody>
-      </Table>
+            <Tr>
+              <Td>
+                <HStack spacing={3}>
+                  <Text>TX Hash</Text>
+                </HStack>
+              </Td>
+              <Td display="flex" align="center" gap={3}>
+                <GoLink />
+                <Link
+                  target="_blank"
+                  href={`${config.blockExplorerUrl}/tx/${txHash}`}
+                  color="brandLinkColor"
+                >
+                  <Text>{shortenAccount(txHash || '')}</Text>
+                </Link>
+              </Td>
+            </Tr>
+            <Tr>
+              <Td whiteSpace="nowrap">
+                <Text py="2">Created</Text>
+              </Td>
+              <Td>
+                <Text>
+                  {createdTime
+                    ? new Date(createdTime).toLocaleDateString('en-US', {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric',
+                      })
+                    : '-'}
+                </Text>
+              </Td>
+            </Tr>
+            {createdBy && (
+              <Tr>
+                <Td whiteSpace="nowrap">
+                  <Text py="2">Created By</Text>
+                </Td>
+                <Td>
+                  <HStack py="2">
+                    <DisplayAvatar
+                      alt={createdBy.profile?.username}
+                      address={createdBy.id}
+                      avatarIPFS={createdBy.profile?.avatar}
+                      size="24"
+                    />
+                    <Link
+                      href={`/account/${createdBy.id}`}
+                      color="brandLinkColor"
+                    >
+                      {getUsername(createdBy, username)}
+                    </Link>
+                  </HStack>
+                </Td>
+              </Tr>
+            )}
+          </Tbody>
+        </Table>
+      </TableContainer>
     </VStack>
   )
 }

--- a/src/components/Wiki/WikiPage/InsightComponents/WikiDetails.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/WikiDetails.tsx
@@ -43,13 +43,13 @@ export const WikiDetails = ({
   const { title, tags } = wikiTitle
   const [, username] = useENSData(createdBy?.id || '')
   return (
-    <VStack w="100%" p={4} spacing={4} borderWidth="1px" borderRadius={2}>
+    <VStack w="100%" p={4} spacing={4} borderWidth="1px" borderRadius={8}>
       <Heading
         bgColor="wikiTitleBg"
         as="h3"
         fontSize="18px"
         p={3}
-        borderRadius={4}
+        borderRadius={6}
         fontWeight="600"
         w="100%"
         textAlign="center"

--- a/src/components/Wiki/WikiPage/WikiInsights.tsx
+++ b/src/components/Wiki/WikiPage/WikiInsights.tsx
@@ -52,14 +52,15 @@ const WikiInsights = ({
 
   return (
     <VStack
-      borderLeftWidth={{ base: 0, md: '1px' }}
-      p={{ base: 0, md: 4 }}
-      pt={{ md: '24', base: '10' }}
+      borderLeftWidth={{ base: 0, xl: '1px' }}
+      p={{ base: 0, xl: 4 }}
+      pt={{ xl: '24', base: '10' }}
     >
       <Box as="aside" ref={stickyRef} w="100%">
         <VStack
-          w={{ base: '90%', md: 'clamp(300px, 25vw, 430px)' }}
-          mx={{ base: 'auto', md: 0 }}
+          w={{ base: '90%', md: '100%', xl: 'clamp(300px, 25vw, 430px)' }}
+          mx={{ base: 'auto', xl: 0 }}
+          px={{ base: '0', md: '4', xl: '0' }}
           spacing={4}
         >
           <WikiDetails
@@ -91,7 +92,7 @@ const WikiInsights = ({
 
           <Flex
             w="100%"
-            display={{ base: 'none', lg: 'block', md: 'block' }}
+            display={{ base: 'none', xl: 'block', md: 'none' }}
             gap={6}
           >
             {!!twitterLink && <TwitterTimeline url={twitterLink} />}

--- a/src/components/Wiki/WikiPage/WikiInsights.tsx
+++ b/src/components/Wiki/WikiPage/WikiInsights.tsx
@@ -53,8 +53,8 @@ const WikiInsights = ({
   return (
     <VStack
       borderLeftWidth={{ base: 0, xl: '1px' }}
-      p={{ base: 0, xl: 4 }}
-      pt={{ xl: '24', base: '10' }}
+      p={{ base: 0, md: 2, xl: 4 }}
+      pt={{ xl: '24', md: '8', base: '10' }}
     >
       <Box as="aside" ref={stickyRef} w="100%">
         <VStack

--- a/src/components/Wiki/WikiPage/WikiInsights.tsx
+++ b/src/components/Wiki/WikiPage/WikiInsights.tsx
@@ -61,7 +61,7 @@ const WikiInsights = ({
           w={{ base: '90%', md: '100%', xl: 'clamp(300px, 25vw, 430px)' }}
           mx={{ base: 'auto', xl: 0 }}
           px={{ base: '0', md: '4', xl: '0' }}
-          spacing={4}
+          spacing={6}
         >
           <WikiDetails
             wikiTitle={wiki}

--- a/src/components/Wiki/WikiPage/WikiInsights.tsx
+++ b/src/components/Wiki/WikiPage/WikiInsights.tsx
@@ -54,6 +54,7 @@ const WikiInsights = ({
     <VStack
       borderLeftWidth={{ base: 0, xl: '1px' }}
       p={{ base: 0, md: 2, xl: 4 }}
+      pr={{ md: 11, xl: 0 }}
       pt={{ xl: '24', md: '8', base: '10' }}
     >
       <Box as="aside" ref={stickyRef} w="100%">

--- a/src/components/Wiki/WikiPage/WikiMainContent.tsx
+++ b/src/components/Wiki/WikiPage/WikiMainContent.tsx
@@ -73,6 +73,7 @@ const WikiMainContent = ({ wiki }: WikiMainContentProps) => {
     <Box
       py={4}
       px={{ base: 4, md: 6, xl: 12 }}
+      pr={{ md: 15, xl: 0 }}
       maxW={{ base: '100%', xl: '900px' }}
       mx="auto"
       minH={{ base: 'unset', xl: 'calc(100vh - 70px)' }}

--- a/src/components/Wiki/WikiPage/WikiMainContent.tsx
+++ b/src/components/Wiki/WikiPage/WikiMainContent.tsx
@@ -72,12 +72,12 @@ const WikiMainContent = ({ wiki }: WikiMainContentProps) => {
   return (
     <Box
       py={4}
-      px={{ base: 4, lg: 12 }}
-      maxW="900px"
+      px={{ base: 4, xl: 12 }}
+      maxW={{ base: '100%', xl: '900px' }}
       mx="auto"
-      minH={{ base: 'unset', md: 'calc(100vh - 70px)' }}
+      minH={{ base: 'unset', xl: 'calc(100vh - 70px)' }}
       borderColor="borderColor"
-      mb={{ md: '3rem' }}
+      mb={{ xl: '3rem' }}
     >
       <Heading my={8}>{wiki?.title}</Heading>
       <Box

--- a/src/components/Wiki/WikiPage/WikiMainContent.tsx
+++ b/src/components/Wiki/WikiPage/WikiMainContent.tsx
@@ -72,7 +72,7 @@ const WikiMainContent = ({ wiki }: WikiMainContentProps) => {
   return (
     <Box
       py={4}
-      px={{ base: 4, xl: 12 }}
+      px={{ base: 4, md: 6, xl: 12 }}
       maxW={{ base: '100%', xl: '900px' }}
       mx="auto"
       minH={{ base: 'unset', xl: 'calc(100vh - 70px)' }}

--- a/src/components/Wiki/WikiPage/WikiMarkup.tsx
+++ b/src/components/Wiki/WikiPage/WikiMarkup.tsx
@@ -31,6 +31,7 @@ const MobileMeta = (wiki: {
   return (
     <VStack
       p={{ base: 4, md: 6 }}
+      pr={{ md: 15, xl: 0 }}
       mx={{ base: 'auto', md: 0 }}
       w={{ base: '100%', xl: '40%', '2xl': '50%' }}
       display={{ base: 'block', xl: 'none' }}

--- a/src/components/Wiki/WikiPage/WikiMarkup.tsx
+++ b/src/components/Wiki/WikiPage/WikiMarkup.tsx
@@ -1,6 +1,6 @@
 import { CommonMetaIds, Media, Wiki } from '@/types/Wiki'
 import { getWikiMetadataById } from '@/utils/getWikiFields'
-import { Box, Flex, HStack, chakra, Text } from '@chakra-ui/react'
+import { Box, Flex, HStack, VStack, chakra, Text } from '@chakra-ui/react'
 import React from 'react'
 import WikiNotFound from '../WIkiNotFound/WikiNotFound'
 import RelatedMediaGrid from './InsightComponents/RelatedMedia'
@@ -29,16 +29,17 @@ const MobileMeta = (wiki: {
   )?.value
 
   return (
-    <chakra.div
-      p={4}
+    <VStack
+      p={{ base: 4, md: 6 }}
       mx={{ base: 'auto', md: 0 }}
       w={{ base: '100%', xl: '40%', '2xl': '50%' }}
       display={{ base: 'block', xl: 'none' }}
+      spacing={6}
     >
       {!!twitterLink && <TwitterTimeline url={twitterLink} />}
       <RelatedWikis relatedWikis={relatedWikis} />
       {media && media.length > 0 && <RelatedMediaGrid media={media} />}
-    </chakra.div>
+    </VStack>
   )
 }
 

--- a/src/components/Wiki/WikiPage/WikiMarkup.tsx
+++ b/src/components/Wiki/WikiPage/WikiMarkup.tsx
@@ -32,8 +32,8 @@ const MobileMeta = (wiki: {
     <chakra.div
       p={4}
       mx={{ base: 'auto', md: 0 }}
-      w={{ base: '100%', md: '50%', lg: '40%', '2xl': '50%' }}
-      display={{ base: 'block', lg: 'none' }}
+      w={{ base: '100%', xl: '40%', '2xl': '50%' }}
+      display={{ base: 'block', xl: 'none' }}
     >
       {!!twitterLink && <TwitterTimeline url={twitterLink} />}
       <RelatedWikis relatedWikis={relatedWikis} />
@@ -61,7 +61,7 @@ export const WikiMarkup = ({ wiki, relatedWikis, ipfs }: WikiLayoutProps) => {
               justify="space-between"
               direction={{
                 base: 'column-reverse',
-                md: 'row',
+                xl: 'row',
               }}
             >
               <WikiMainContent wiki={wiki} />
@@ -76,9 +76,9 @@ export const WikiMarkup = ({ wiki, relatedWikis, ipfs }: WikiLayoutProps) => {
                 mt={8}
                 mb={-4}
                 display={{
-                  md: 'none',
+                  xl: 'none',
                 }}
-                textAlign="center"
+                textAlign={{ base: 'center', md: 'left' }}
                 px={4}
               >
                 {wiki?.title}
@@ -87,7 +87,7 @@ export const WikiMarkup = ({ wiki, relatedWikis, ipfs }: WikiLayoutProps) => {
             <chakra.div
               display={{
                 base: 'block',
-                md: 'none',
+                xl: 'none',
               }}
             >
               <MobileMeta

--- a/src/components/Wiki/WikiPage/WikiMarkup.tsx
+++ b/src/components/Wiki/WikiPage/WikiMarkup.tsx
@@ -79,7 +79,7 @@ export const WikiMarkup = ({ wiki, relatedWikis, ipfs }: WikiLayoutProps) => {
                   xl: 'none',
                 }}
                 textAlign={{ base: 'center', md: 'left' }}
-                px={4}
+                px={{ base: 4, md: 6 }}
               >
                 {wiki?.title}
               </Text>

--- a/src/components/Wiki/WikiPage/WikiReferences.tsx
+++ b/src/components/Wiki/WikiPage/WikiReferences.tsx
@@ -37,7 +37,7 @@ const WikiReferences = ({ references }: WikiReferencesProps) => {
       <Heading my={4} p={2} fontWeight="medium">
         REFERENCES
       </Heading>
-      <SimpleGrid mb={8} columns={[1, 2, 3]} spacing={4}>
+      <SimpleGrid mb={8} columns={[1, 2, 2, 3]} spacing={4}>
         {references.map((ref, index) => (
           <LinkBox
             display="flex"

--- a/src/components/Wiki/WikiPage/WikiTableOfContents.tsx
+++ b/src/components/Wiki/WikiPage/WikiTableOfContents.tsx
@@ -92,7 +92,7 @@ const WikiTableOfContents = ({ isAlertAtTop }: WikiTableOfContentsProps) => {
   if (isOpen === isDefaultOpen) {
     return (
       <VStack
-        display={{ base: 'none', md: 'block' }}
+        display={{ base: 'none', xl: 'block' }}
         borderLeftWidth="1px"
         w="20vw"
         px={6}

--- a/src/data/NavItemData.ts
+++ b/src/data/NavItemData.ts
@@ -86,6 +86,7 @@ export const NAV_ITEMS: NavItem[] = [
         icon: RiBook2Fill,
         href: 'https://learn.everipedia.org',
         hasImage: true,
+        target: '_blank',
       },
       {
         id: 302,

--- a/src/styles/markdown.module.css
+++ b/src/styles/markdown.module.css
@@ -579,6 +579,6 @@ html[data-theme='dark'] .markdownBody a {
 }
 
 .markdownBodyDark blockquote {
-  color: #a9b6c5;
-  border-left: 0.25em solid #4c5566;
+  color: #ffffffa3;
+  border-left: 0.25em solid #ffffffa3;
 }

--- a/src/types/NavItemType.ts
+++ b/src/types/NavItemType.ts
@@ -7,4 +7,5 @@ export interface NavItem {
   hasImage?: boolean
   icon?: IconType
   subItem?: NavItem[]
+  target?: string
 }


### PR DESCRIPTION
wiki page responsive fix

closes https://github.com/EveripediaNetwork/issues/issues/724
closes https://github.com/EveripediaNetwork/issues/issues/758
closes https://github.com/EveripediaNetwork/issues/issues/759

Changes:
Increased spacings and paddings.
IQ learn link opens a new tab on click.
Increased border radius of wiki widgets.
Fixed sub-quotes contrast issues.
Fixed the homepage sub header on md.

