### PR TITLE
Adds table edit options

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@rtk-query/graphql-request-base-query": "^1.0.3",
     "@svgr/webpack": "^6.2.1",
     "@toast-ui/editor": "^3.1.3",
+    "@toast-ui/editor-plugin-table-merged-cell": "^3.1.0",
     "@toast-ui/react-editor": "^3.1.3",
     "@types/gtag.js": "^0.0.10",
     "@types/remove-markdown": "^0.3.1",

--- a/src/components/Layout/Editor/Editor.tsx
+++ b/src/components/Layout/Editor/Editor.tsx
@@ -12,6 +12,7 @@ import { store } from '@/store/store'
 // eslint-disable-next-line import/no-cycle
 import media from '@/editor-plugins/media'
 import { PasteListener } from '@/utils/PasteListener'
+import tableMergedCellPlugin from '@toast-ui/editor-plugin-table-merged-cell'
 
 export const wikiEditorRef = {
   current: null as ToastUIEditor | null,
@@ -138,7 +139,7 @@ const Editor = ({ onChange, markdown = '' }: EditorType) => {
   return (
     <Box ref={containerRef} m={0} w="full" h="full">
       <ToastUIEditorJSX
-        plugins={[wikiLink, cite, media]}
+        plugins={[wikiLink, cite, media, tableMergedCellPlugin]}
         height="100%"
         theme={colorMode === 'dark' ? 'dark' : 'light'}
         ref={editorRef}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2951,6 +2951,11 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@toast-ui/editor-plugin-table-merged-cell@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@toast-ui/editor-plugin-table-merged-cell/-/editor-plugin-table-merged-cell-3.1.0.tgz#86422e2bc0dc2becf956aa7fa6cc5b45031e9611"
+  integrity sha512-9ch9h1heTs0Kkmhwpb1ef9psQSM77wvUO3J75BsHv3RO5nAug42W3HC4Y+qbX5n1z1VhOGGjuOb4GPIr8s5dRA==
+
 "@toast-ui/editor@^3.1.3":
   version "3.1.7"
   resolved "https://registry.yarnpkg.com/@toast-ui/editor/-/editor-3.1.7.tgz#6c889c8d068d7dd1c996a4a384ebb3dddd9e6b1d"


### PR DESCRIPTION
Closes https://github.com/EveripediaNetwork/issues/issues/750

# Changes
- added table merge plugin which creates context menu with various table options to add, delete and edit columns and rows of already created table

# Links
- https://iq-wiki-git-edit-table-feature-prediqt.vercel.app/create-wiki

# How to test
- create a new table
- right click on any table cell to see new context menu pop up. choose desired option for editing

# Screenshot
![image](https://user-images.githubusercontent.com/52039218/193074466-2811167a-bdc6-422b-8194-033400a276f2.png)
