### PR TITLE
Reduce width of Network Error UI. 

### DIFF
--- a/src/components/Layout/Network/NetworkErrorNotification.tsx
+++ b/src/components/Layout/Network/NetworkErrorNotification.tsx
@@ -113,7 +113,7 @@ const NetworkErrorNotification = () => {
       size="lg"
     >
       <AlertDialogOverlay />
-      <AlertDialogContent>
+      <AlertDialogContent width={{ base: '90%', lg: '100%' }}>
         <Box p={8}>
           <Flex>
             <Icon


### PR DESCRIPTION
<img width="341" alt="image" src="https://user-images.githubusercontent.com/30846348/194715183-086c13f0-62e6-4f85-a08e-153027c446d5.png">
Before. 

<img width="318" alt="image" src="https://user-images.githubusercontent.com/30846348/194715157-50e7f405-dc69-4380-bb95-6f3af0561501.png">
After

- -------

Closes https://github.com/EveripediaNetwork/issues/issues/795
