### PR TITLE
Edited wiki empty page

### DIFF
--- a/src/components/Profile/EmptyState.tsx
+++ b/src/components/Profile/EmptyState.tsx
@@ -3,15 +3,15 @@ import { Button, Flex, Text } from '@chakra-ui/react'
 import React from 'react'
 import { Link } from '../Elements'
 
-export const EmptyState = () => {
+export const EmptyState = ({title, body}: {title: string, body: string}) => {
   return (
     <Flex flexDir="column" textAlign="center" align="center">
       <ProfileEmptyState maxBlockSize="40vw" />
       <Text fontWeight="bold" fontSize="3xl" mt="8">
-        Create your first Wiki
+        {title}
       </Text>
       <Text color="fadedText2">
-        Start creating your own wiki . When you do, they will appear here!
+        {body}
       </Text>
 
       <Link href="/create-wiki" passHref>

--- a/src/components/Profile/EmptyState.tsx
+++ b/src/components/Profile/EmptyState.tsx
@@ -3,16 +3,20 @@ import { Button, Flex, Text } from '@chakra-ui/react'
 import React from 'react'
 import { Link } from '../Elements'
 
-export const EmptyState = ({title, body}: {title: string, body: string}) => {
+export const EmptyState = ({
+  title,
+  body,
+}: {
+  title: string
+  body: string
+}) => {
   return (
     <Flex flexDir="column" textAlign="center" align="center">
       <ProfileEmptyState maxBlockSize="40vw" />
       <Text fontWeight="bold" fontSize="3xl" mt="8">
         {title}
       </Text>
-      <Text color="fadedText2">
-        {body}
-      </Text>
+      <Text color="fadedText2">{body}</Text>
 
       <Link href="/create-wiki" passHref>
         <Button px="16" w="fit-content" mt="16" as="a">

--- a/src/components/Profile/UserWikis/UserCreatedWikis.tsx
+++ b/src/components/Profile/UserWikis/UserCreatedWikis.tsx
@@ -44,7 +44,7 @@ const UserCreatedWikis = () => {
     <Box py="10" px={{ base: 6, lg: 0 }}>
       {wikis.length < 1 && !hasMore && (
         <Center>
-          <EmptyState />
+          <EmptyState title="Create your first Wiki" body="Start creating your own wiki . When you do, they will appear here!"/>
         </Center>
       )}
       <Collected wikis={wikis} />

--- a/src/components/Profile/UserWikis/UserCreatedWikis.tsx
+++ b/src/components/Profile/UserWikis/UserCreatedWikis.tsx
@@ -44,7 +44,10 @@ const UserCreatedWikis = () => {
     <Box py="10" px={{ base: 6, lg: 0 }}>
       {wikis.length < 1 && !hasMore && (
         <Center>
-          <EmptyState title="Create your first Wiki" body="Start creating your own wiki . When you do, they will appear here!"/>
+          <EmptyState
+            title="Create your first Wiki"
+            body="Start creating your own wiki . When you do, they will appear here!"
+          />
         </Center>
       )}
       <Collected wikis={wikis} />

--- a/src/components/Profile/UserWikis/UserEditedWikis.tsx
+++ b/src/components/Profile/UserWikis/UserEditedWikis.tsx
@@ -45,7 +45,7 @@ const UserEditedWikis = () => {
     <Box py="10" px={{ base: 6, lg: 0 }}>
       {wikis.length < 1 && !hasMore && (
         <Center>
-          <EmptyState />
+          <EmptyState title="Edit your first Wiki" body="You are yet to make any edits, once you edit a wiki, they will appear here."/>
         </Center>
       )}
       <Collected wikis={wikis} />

--- a/src/components/Profile/UserWikis/UserEditedWikis.tsx
+++ b/src/components/Profile/UserWikis/UserEditedWikis.tsx
@@ -45,7 +45,10 @@ const UserEditedWikis = () => {
     <Box py="10" px={{ base: 6, lg: 0 }}>
       {wikis.length < 1 && !hasMore && (
         <Center>
-          <EmptyState title="Edit your first Wiki" body="You are yet to make any edits, once you edit a wiki, they will appear here."/>
+          <EmptyState
+            title="Edit your first Wiki"
+            body="You are yet to make any edits, once you edit a wiki, they will appear here."
+          />
         </Center>
       )}
       <Collected wikis={wikis} />


### PR DESCRIPTION
I realized that we don't have an empty page for the 'edits' tab on the user profile and it's just the same as the one for wikis.
But that might be confusing.
So an empty page that describes what is supposed to be there would be appropriate 

fixes https://github.com/EveripediaNetwork/issues/issues/806