### PR TITLE
Fixes weird description in the history card

### DIFF
--- a/src/components/Activity/ActivityCard.tsx
+++ b/src/components/Activity/ActivityCard.tsx
@@ -139,7 +139,15 @@ const ActivityCard = ({
           maxW={{ base: '70%', lg: '80%' }}
           overflow="hidden"
         >
-          <Text display={{ base: 'none', md: 'flex' }}>{brief}</Text>
+          <Text
+            mt="1"
+            display={{ base: 'none', md: '-webkit-box' }}
+            noOfLines={2}
+            textOverflow="ellipsis"
+            overflow="hidden"
+          >
+            {brief}
+          </Text>
         </Box>
         <Stack
           direction={{ base: 'column', md: 'row' }}

--- a/src/components/Activity/ActivityCard.tsx
+++ b/src/components/Activity/ActivityCard.tsx
@@ -138,6 +138,7 @@ const ActivityCard = ({
           mt="-2%"
           maxW={{ base: '70%', lg: '80%' }}
           overflow="hidden"
+          display={{ base: 'none', md: 'flex' }}
         >
           <Text
             mt="1"
@@ -150,6 +151,7 @@ const ActivityCard = ({
           </Text>
         </Box>
         <Stack
+          mt={{ base: '2', md: '0' }}
           direction={{ base: 'column', md: 'row' }}
           justifyContent="space-between"
           w="full"


### PR DESCRIPTION
Fixes weird description in the history card

Changes:
Added text truncate.

Before:
![Screenshot 2022-10-18 095821](https://user-images.githubusercontent.com/66301634/196387814-410069c5-4df8-4a41-ba3d-ae1cef47f326.jpg)

Now:
![Screenshot 2022-10-18 100135](https://user-images.githubusercontent.com/66301634/196387890-720eaf4b-54fa-40f9-abd1-4a3106608a03.jpg)


fixes https://github.com/EveripediaNetwork/issues/issues/829
