### PR TITLE
Manual mapping for token stats

### DIFF
--- a/src/services/token-stats/index.ts
+++ b/src/services/token-stats/index.ts
@@ -33,8 +33,17 @@ export const tokenStatsApi = createApi({
   },
   baseQuery: graphqlRequestBaseQuery({ url: config.graphqlUrl }),
   endpoints: builder => ({
-    getTokenStats: builder.query<TokenStats, {tokenName:string, cmcTokenName?:string}>({
-      query: ({tokenName, cmcTokenName}:{tokenName: string, cmcTokenName?:string}) => ({
+    getTokenStats: builder.query<
+      TokenStats,
+      { tokenName: string, cmcTokenName?: string }
+    >({
+      query: ({
+        tokenName,
+        cmcTokenName,
+      }: {
+        tokenName: string
+        cmcTokenName?: string
+      }) => ({
         document: GET_TOKEN_STATS,
         variables: { tokenName, cmcTokenName },
       }),

--- a/src/services/token-stats/index.ts
+++ b/src/services/token-stats/index.ts
@@ -33,10 +33,10 @@ export const tokenStatsApi = createApi({
   },
   baseQuery: graphqlRequestBaseQuery({ url: config.graphqlUrl }),
   endpoints: builder => ({
-    getTokenStats: builder.query<TokenStats, string>({
-      query: (tokenName: string) => ({
+    getTokenStats: builder.query<TokenStats, {tokenName:string, cmcTokenName?:string}>({
+      query: ({tokenName, cmcTokenName}:{tokenName: string, cmcTokenName?:string}) => ({
         document: GET_TOKEN_STATS,
-        variables: { tokenName },
+        variables: { tokenName, cmcTokenName },
       }),
       transformResponse: (response: GetTokenStatsResponse) =>
         response.tokenStats,

--- a/src/services/token-stats/index.ts
+++ b/src/services/token-stats/index.ts
@@ -35,7 +35,7 @@ export const tokenStatsApi = createApi({
   endpoints: builder => ({
     getTokenStats: builder.query<
       TokenStats,
-      { tokenName: string, cmcTokenName?: string }
+      { tokenName: string; cmcTokenName?: string }
     >({
       query: ({
         tokenName,

--- a/src/services/token-stats/queries.ts
+++ b/src/services/token-stats/queries.ts
@@ -1,8 +1,8 @@
 import { gql } from 'graphql-request'
 
 export const GET_TOKEN_STATS = gql`
-  query tokenStats($tokenName: String!) {
-    tokenStats(tokenName: $tokenName) {
+  query tokenStats($tokenName: String!, $cmcTokenName: String) {
+    tokenStats(tokenName: $tokenName, cmcTokenName: $cmcTokenName) {
       id
       symbol
       name

--- a/src/services/token-stats/utils.ts
+++ b/src/services/token-stats/utils.ts
@@ -23,7 +23,7 @@ export const fetchTokenStats = async (coingeckoUrl?: string) => {
   const token = getTokenFromURI(coingeckoUrl)
   if (!token) return undefined
   const { data } = await store.dispatch(
-    getTokenStats.initiate({tokenName: remappingTokenIds(token)}),
+    getTokenStats.initiate({ tokenName: remappingTokenIds(token) }),
   )
 
   return data

--- a/src/services/token-stats/utils.ts
+++ b/src/services/token-stats/utils.ts
@@ -4,11 +4,11 @@ import { store } from '@/store/store'
 const remappingTokenIds = (token: string) => {
   switch (token) {
     case 'polygon':
-      return 'matic-network'
+      return {tokenName: 'matic-network', cmcTokenName: "polygon"}
     case 'bnb':
-      return 'binancecoin'
+      return {tokenName: 'binancecoin',  cmcTokenName: 'bnb'}
     default:
-      return token
+      return {tokenName: token}
   }
 }
 
@@ -22,8 +22,9 @@ export const fetchTokenStats = async (coingeckoUrl?: string) => {
   if (!coingeckoUrl) return undefined
   const token = getTokenFromURI(coingeckoUrl)
   if (!token) return undefined
+  const tokenDetails = remappingTokenIds(token)
   const { data } = await store.dispatch(
-    getTokenStats.initiate({ tokenName: remappingTokenIds(token) }),
+    getTokenStats.initiate(tokenDetails),
   )
 
   return data

--- a/src/services/token-stats/utils.ts
+++ b/src/services/token-stats/utils.ts
@@ -2,13 +2,12 @@ import { getTokenStats } from '@/services/token-stats'
 import { store } from '@/store/store'
 
 const remappingTokenIds = (token: string) => {
+  console.log(token)
   switch (token) {
     case 'polygon':
       return { tokenName: 'matic-network', cmcTokenName: 'polygon' }
     case 'bnb':
       return { tokenName: 'binancecoin', cmcTokenName: 'bnb' }
-    case 'frax-price-index':
-      return { tokenName: 'frax', cmcTokenName: 'frax' }
     default:
       return { tokenName: token }
   }

--- a/src/services/token-stats/utils.ts
+++ b/src/services/token-stats/utils.ts
@@ -2,7 +2,6 @@ import { getTokenStats } from '@/services/token-stats'
 import { store } from '@/store/store'
 
 const remappingTokenIds = (token: string) => {
-  console.log(token)
   switch (token) {
     case 'polygon':
       return { tokenName: 'matic-network', cmcTokenName: 'polygon' }

--- a/src/services/token-stats/utils.ts
+++ b/src/services/token-stats/utils.ts
@@ -7,6 +7,8 @@ const remappingTokenIds = (token: string) => {
       return { tokenName: 'matic-network', cmcTokenName: 'polygon' }
     case 'bnb':
       return { tokenName: 'binancecoin', cmcTokenName: 'bnb' }
+    case 'frax-price-index': 
+      return { tokenName: 'frax', cmcTokenName: 'frax' }
     default:
       return { tokenName: token }
   }

--- a/src/services/token-stats/utils.ts
+++ b/src/services/token-stats/utils.ts
@@ -23,7 +23,7 @@ export const fetchTokenStats = async (coingeckoUrl?: string) => {
   const token = getTokenFromURI(coingeckoUrl)
   if (!token) return undefined
   const { data } = await store.dispatch(
-    getTokenStats.initiate(remappingTokenIds(token)),
+    getTokenStats.initiate({tokenName: remappingTokenIds(token)}),
   )
 
   return data

--- a/src/services/token-stats/utils.ts
+++ b/src/services/token-stats/utils.ts
@@ -7,7 +7,7 @@ const remappingTokenIds = (token: string) => {
       return { tokenName: 'matic-network', cmcTokenName: 'polygon' }
     case 'bnb':
       return { tokenName: 'binancecoin', cmcTokenName: 'bnb' }
-    case 'frax-price-index': 
+    case 'frax-price-index':
       return { tokenName: 'frax', cmcTokenName: 'frax' }
     default:
       return { tokenName: token }

--- a/src/services/token-stats/utils.ts
+++ b/src/services/token-stats/utils.ts
@@ -4,11 +4,11 @@ import { store } from '@/store/store'
 const remappingTokenIds = (token: string) => {
   switch (token) {
     case 'polygon':
-      return {tokenName: 'matic-network', cmcTokenName: "polygon"}
+      return { tokenName: 'matic-network', cmcTokenName: 'polygon' }
     case 'bnb':
-      return {tokenName: 'binancecoin',  cmcTokenName: 'bnb'}
+      return { tokenName: 'binancecoin', cmcTokenName: 'bnb' }
     default:
-      return {tokenName: token}
+      return { tokenName: token }
   }
 }
 
@@ -23,9 +23,7 @@ export const fetchTokenStats = async (coingeckoUrl?: string) => {
   const token = getTokenFromURI(coingeckoUrl)
   if (!token) return undefined
   const tokenDetails = remappingTokenIds(token)
-  const { data } = await store.dispatch(
-    getTokenStats.initiate(tokenDetails),
-  )
+  const { data } = await store.dispatch(getTokenStats.initiate(tokenDetails))
 
   return data
 }


### PR DESCRIPTION
we will need a manual mapping for some specific cases where coingecko and cmc have not same ids. An example its in binance coin page.

id for coingecko is binancecoin
id for cmc is bnb

so we need a mapping somewhere for these special cases and we need to call tokenStats w a second param

implement https://github.com/EveripediaNetwork/ep-api/pull/238 in UI <- this will get merged later today

https://github.com/EveripediaNetwork/ep-ui/blob/main/src/services/token-stats/utils.ts#L4

fixes https://github.com/EveripediaNetwork/issues/issues/832
