### PR TITLE
Fix disabled color on leaderboard tab

### DIFF
--- a/src/components/Landing/Leaderboard.tsx
+++ b/src/components/Landing/Leaderboard.tsx
@@ -126,6 +126,9 @@ const LeaderBoard = ({ leaderboards }: { leaderboards: LeaderBoardType[] }) => {
                     background: 'brandLinkColor !important',
                   },
                 }}
+                _disabled={{
+                  color: 'thirdRankColor'
+                }}
                 key={sid}
                 fontWeight="semibold"
                 p={tabPadding}

--- a/src/components/Landing/Leaderboard.tsx
+++ b/src/components/Landing/Leaderboard.tsx
@@ -127,7 +127,7 @@ const LeaderBoard = ({ leaderboards }: { leaderboards: LeaderBoardType[] }) => {
                   },
                 }}
                 _disabled={{
-                  color: 'thirdRankColor'
+                  color: 'thirdRankColor',
                 }}
                 key={sid}
                 fontWeight="semibold"


### PR DESCRIPTION
Currently, the disabled tabs don't look disabled. so, ensure they all look disabled.

Before 

<img width="1368" alt="image" src="https://user-images.githubusercontent.com/70170061/197183339-3abc1be5-7a15-42b3-8a0a-bb2c65b1662c.png">

After

<img width="1417" alt="image" src="https://user-images.githubusercontent.com/70170061/197183411-bb740b31-78bc-4aa6-8d7e-b87d96ab72b8.png">


fixes https://github.com/EveripediaNetwork/issues/issues/835
