### PR TITLE
Fixes citaiton delete not removing opening square bracket

### DIFF
--- a/src/editor-plugins/cite/frame/ReferenceCard.tsx
+++ b/src/editor-plugins/cite/frame/ReferenceCard.tsx
@@ -57,7 +57,7 @@ export const ReferenceCard = ({
     newContent = newContent.replace(
       new RegExp(
         // eslint-disable-next-line no-useless-escape
-        ` *\[\\\\[[0-9]{0,5}\\]\]\\(#cite-id-${reference.id}\\) *`,
+        `\[\\\\[[0-9]+\\]\]\\(#cite-id-${reference.id}\\)`,
         'g',
       ),
       '',


### PR DESCRIPTION
Fixes https://github.com/EveripediaNetwork/issues/issues/846

# Changes
- changed delete regex to correctly match the cite number