### PR TITLE
Fixes related wikis showing current wiki page in some cases

### DIFF
--- a/src/components/Wiki/WikiPage/InsightComponents/RelatedWikis.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/RelatedWikis.tsx
@@ -51,7 +51,7 @@ export const RelatedWikis = ({
     <VStack w="100%" spacing={4} borderRadius={2} mb="5">
       <WikiAccordion mt="-3px" title="Related Articles">
         <VStack align="start" w="100%">
-          {relatedWikis.slice(0, 4).map(wiki => (
+          {relatedWikis.map(wiki => (
             <RelatedWikiCard key={wiki.id} wiki={wiki} />
           ))}
         </VStack>

--- a/src/pages/wiki/[slug]/index.tsx
+++ b/src/pages/wiki/[slug]/index.tsx
@@ -98,10 +98,10 @@ export const getStaticProps: GetStaticProps = async context => {
     const { data, error } = await store.dispatch(
       getWikiPreviewsByCategory.initiate({
         category: wiki.categories[0].id || '',
-        limit: 4,
+        limit: 6,
       }),
     )
-    relatedWikis = data
+    relatedWikis = data?.filter(w => w.id !== wiki.id)?.slice(0, 4)
     relatedWikisError = error
   }
   await Promise.all(getRunningOperationPromises())


### PR DESCRIPTION
Fixes https://github.com/EveripediaNetwork/issues/issues/847

# Changes
- added filter to remove the current wiki id from related wikis

# Screenshot
![CleanShot 2022-10-28 at 18 36 18@2x](https://user-images.githubusercontent.com/52039218/198598555-79d26e0a-b80d-42fa-9850-b93dedc67195.png)
