### PR TITLE
Updating regex for coingecko url test

### DIFF
--- a/src/data/WikiLinks.ts
+++ b/src/data/WikiLinks.ts
@@ -96,7 +96,7 @@ export const LINK_OPTIONS = [
     type: LinkType.SOCIAL,
     label: 'Coingecko',
     icon: CoinGeckoIcon,
-    tests: [/https:\/\/(www.)?coingecko.com\/en\/(nft|coins)\//],
+    tests: [/https:\/\/(www.)?coingecko.com\/en\/(nft|coins)\/(.+)/],
   },
   {
     id: CommonMetaIds.COIN_MARKET_CAP,

--- a/src/data/WikiLinks.ts
+++ b/src/data/WikiLinks.ts
@@ -96,7 +96,7 @@ export const LINK_OPTIONS = [
     type: LinkType.SOCIAL,
     label: 'Coingecko',
     icon: CoinGeckoIcon,
-    tests: [/https:\/\/(www.)?coingecko.com\/en\/(nft|coin)\/(.+)/],
+    tests: [/https:\/\/(www.)?coingecko.com\/en\/(nft|coins)\//],
   },
   {
     id: CommonMetaIds.COIN_MARKET_CAP,


### PR DESCRIPTION
To test, edit a wiki and paste a valid Coingecko URL and you shouldn't get the "Invalid URL" error. 
closes https://github.com/EveripediaNetwork/issues/issues/855
