### PR TITLE
Fixes profile banner

### DIFF
--- a/src/components/Elements/Image/Image.tsx
+++ b/src/components/Elements/Image/Image.tsx
@@ -8,6 +8,7 @@ export type NextChakraImageProps = Omit<BoxProps, 'as'> &
     imgW?: number | string | any
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     imgH?: number | string | any
+    hideOnError?: boolean
   }
 
 export const Image = ({
@@ -18,6 +19,7 @@ export const Image = ({
   priority,
   placeholder,
   blurDataURL,
+  hideOnError,
   objectFit = 'cover',
   ...rest
 }: NextChakraImageProps) => (
@@ -29,6 +31,11 @@ export const Image = ({
       layout={imgW && imgH ? 'fixed' : 'fill'}
       src={src}
       alt={alt}
+      onError={e => {
+        if (hideOnError) {
+          e.currentTarget.style.visibility = 'hidden'
+        }
+      }}
       priority={priority}
       placeholder={placeholder}
       blurDataURL={blurDataURL}

--- a/src/components/SEO/UserProfile.tsx
+++ b/src/components/SEO/UserProfile.tsx
@@ -1,4 +1,3 @@
-import config from '@/config'
 import { UserSocialLinksData as dt } from '@/data/UserSocialLinksData'
 import { ProfileLinks } from '@/types/ProfileType'
 import { NextSeo, SocialProfileJsonLd } from 'next-seo'
@@ -6,14 +5,14 @@ import React from 'react'
 
 interface UserProfileHeaderProps {
   username: string
-  avatarIPFS?: string | null
+  avatarURL: string
   links?: ProfileLinks
   bio?: string | null
 }
 
 export const UserProfileHeader = ({
   username,
-  avatarIPFS,
+  avatarURL,
   links,
   bio,
 }: UserProfileHeaderProps) => {
@@ -45,7 +44,7 @@ export const UserProfileHeader = ({
           },
           images: [
             {
-              url: `${config.pinataBaseUrl}${avatarIPFS}`,
+              url: avatarURL,
               width: 650,
               height: 650,
               alt: 'Profile Photo',

--- a/src/pages/account/[profile].tsx
+++ b/src/pages/account/[profile].tsx
@@ -43,6 +43,7 @@ const Profile = ({ profileData }: ProfileProps) => {
             _dark={{
               backgroundImage: '/images/homepage-bg-dark.png',
             }}
+            hideOnError
             src={`${config.pinataBaseUrl}${profileData?.banner}`}
             alt={`${profileData?.username || address}-background-image`}
           />

--- a/src/pages/account/[profile].tsx
+++ b/src/pages/account/[profile].tsx
@@ -5,6 +5,8 @@ import UserInfo from '@/components/Profile/UserInfo'
 import { ProfileProvider } from '@/components/Profile/utils'
 import { UserProfileHeader } from '@/components/SEO/UserProfile'
 import config from '@/config'
+import { AvatarColorArray } from '@/data/AvatarData'
+import { useENSData } from '@/hooks/useENSData'
 import { getUserAddressFromUsername, getUserProfile } from '@/services/profile'
 import { store } from '@/store/store'
 import { ProfileData } from '@/types/ProfileType'
@@ -21,14 +23,24 @@ interface ProfileProps {
 const Profile = ({ profileData }: ProfileProps) => {
   const router = useRouter()
   const address = router.query.profile as string
+  const [avatar] = useENSData(address)
 
   const profileContext = useProfile()
+
+  let userAvatar = ''
+  if (profileData.avatar) {
+    userAvatar = `${config.pinataBaseUrl}${profileData?.avatar}`
+  } else if (avatar) {
+    userAvatar = avatar
+  } else {
+    userAvatar = `https://source.boringavatars.com/pixel/${address}?square=true?colors=${AvatarColorArray}`
+  }
 
   return (
     <Box key={address}>
       <UserProfileHeader
         username={profileData?.username || address}
-        avatarIPFS={profileData?.avatar}
+        avatarURL={userAvatar}
         links={profileData?.links[0]}
         bio={profileData?.bio}
       />


### PR DESCRIPTION
Fixes https://github.com/EveripediaNetwork/issues/issues/875

# Changes
- fixes banner image showing alt text on no image set
- fixes banner profile social image not showing in case of no profile image and ens avatar

# Screenshots

## Before 

<img width="1424" alt="CleanShot 2022-11-11 at 16 41 16@2x" src="https://user-images.githubusercontent.com/52039218/201328611-fa5d90b1-00bc-4bc7-9abb-7b392921f73a.png">

## After 

<img width="1426" alt="CleanShot 2022-11-11 at 16 39 57@2x" src="https://user-images.githubusercontent.com/52039218/201328367-08b547d9-449d-4b2c-b11a-ea5b6fad2638.png">
