### PR TITLE
Wikis naming error in search bar

### DIFF
--- a/src/components/Layout/Navbar/NavSearch/index.tsx
+++ b/src/components/Layout/Navbar/NavSearch/index.tsx
@@ -47,12 +47,12 @@ export type NavSearchProps = {
 }
 
 const ItemPaths = {
-  [SEARCH_TYPES.ARTICLE]: '/wiki/',
+  [SEARCH_TYPES.WIKI]: '/wiki/',
   [SEARCH_TYPES.CATEGORY]: '/categories/',
   [SEARCH_TYPES.ACCOUNT]: '/account/',
 }
 
-const ARTICLES_LIMIT = 5
+const WIKIS_LIMIT = 5
 const CATEGORIES_LIMIT = 2
 const ACCOUNTS_LIMIT = 4
 
@@ -61,22 +61,21 @@ const NavSearch = (props: NavSearchProps) => {
   const { query, setQuery, isLoading, results } = useNavSearch()
   const router = useRouter()
 
-  const unrenderedArticles = results.articles.length - ARTICLES_LIMIT
+  const unrenderedWikis = results.wikis.length - WIKIS_LIMIT
   const unrenderedCategories = results.categories.length - CATEGORIES_LIMIT
   const unrenderedAccounts = results.accounts.length - ACCOUNTS_LIMIT
   const noResults =
-    results.articles.length === 0 &&
+    results.wikis.length === 0 &&
     results.categories.length === 0 &&
     results.accounts.length === 0
 
-  const resolvedUnrenderedArticles =
-    unrenderedArticles > 0 ? unrenderedArticles : 0
+  const resolvedUnrenderedWikis = unrenderedWikis > 0 ? unrenderedWikis : 0
   const resolvedUnrenderedCategories =
     unrenderedCategories > 0 ? unrenderedCategories : 0
   const resolvedUnrenderedAccounts =
     unrenderedAccounts > 0 ? unrenderedAccounts : 0
   const totalUnrendered =
-    resolvedUnrenderedArticles +
+    resolvedUnrenderedWikis +
     resolvedUnrenderedCategories +
     resolvedUnrenderedAccounts
 
@@ -143,27 +142,27 @@ const NavSearch = (props: NavSearchProps) => {
     },
   }
 
-  const articlesSearchList = (
+  const wikisSearchList = (
     <>
-      {results.articles?.slice(0, ARTICLES_LIMIT).map(article => {
-        const articleImage = `${config.pinataBaseUrl}${
-          article.images && article.images[0].id
+      {results.wikis?.slice(0, WIKIS_LIMIT).map(wiki => {
+        const wikiImage = `${config.pinataBaseUrl}${
+          wiki.images && wiki.images[0].id
         }`
-        const value = fillType(article, SEARCH_TYPES.ARTICLE)
+        const value = fillType(wiki, SEARCH_TYPES.WIKI)
         // This negates the bug that is caused by two wikis with the same title.
         // value.title = `${article.title}${article.id}`
         return (
           <AutoCompleteItem
-            key={article.id}
+            key={wiki.id}
             value={value}
             getValue={art => art.title}
-            label={article.title}
+            label={wiki.title}
             onClick={() => setHamburger(false)}
             {...generalItemStyles}
           >
             <WikiImage
-              src={articleImage}
-              alt={article.title}
+              src={wikiImage}
+              alt={wiki.title}
               imgH={40}
               imgW={WIKI_IMAGE_ASPECT_RATIO * 40}
               flexShrink={0}
@@ -172,10 +171,10 @@ const NavSearch = (props: NavSearchProps) => {
             />
             <Flex direction="column" w={{ lg: '100%' }}>
               <chakra.span fontWeight="semibold" fontSize="sm">
-                {article.title}
+                {wiki.title}
               </chakra.span>
               <Text noOfLines={{ base: 2, lg: 1 }} maxW="full" fontSize="xs">
-                {getWikiSummary(article, WikiSummarySize.Big)}
+                {getWikiSummary(wiki, WikiSummarySize.Big)}
               </Text>
             </Flex>
             <Wrap
@@ -184,11 +183,11 @@ const NavSearch = (props: NavSearchProps) => {
               gap="1"
               ml="auto"
               maxWidth="fit-content"
-              display={article.tags.length > 0 ? 'flex' : 'none'}
+              display={wiki.tags.length > 0 ? 'flex' : 'none'}
             >
-              {article.tags?.map(tag => (
+              {wiki.tags?.map(tag => (
                 <chakra.div
-                  key={`${article.id}-${tag.id}`}
+                  key={`${wiki.id}-${tag.id}`}
                   fontWeight="medium"
                   fontSize="xs"
                   alignSelf="center"
@@ -270,10 +269,8 @@ const NavSearch = (props: NavSearchProps) => {
   const searchList = (
     <>
       <AutoCompleteGroup>
-        <AutoCompleteGroupTitle {...titleStyles}>
-          Articles
-        </AutoCompleteGroupTitle>
-        {articlesSearchList}
+        <AutoCompleteGroupTitle {...titleStyles}>Wikis</AutoCompleteGroupTitle>
+        {wikisSearchList}
       </AutoCompleteGroup>
       <AutoCompleteGroup>
         <AutoCompleteGroupTitle {...titleStyles}>

--- a/src/pages/search/[query].tsx
+++ b/src/pages/search/[query].tsx
@@ -24,37 +24,37 @@ interface SearchQueryProps {
 const SearchQuery = ({ query }: SearchQueryProps) => {
   const [isLoading, setIsLoading] = useState(false)
   const [results, setResults] = useState<{
-    articles: WikiPreview[]
+    wikis: WikiPreview[]
     categories: Category[]
   }>({
-    articles: [],
+    wikis: [],
     categories: [],
   })
   useEffect(() => {
     setIsLoading(true)
     Promise.all([fetchWikisList(query), fetchCategoriesList(query)]).then(
       res => {
-        const [articles = [], categories = []] = res
-        if (articles.length || categories.length) {
-          setResults({ articles, categories })
+        const [wikis = [], categories = []] = res
+        if (wikis.length || categories.length) {
+          setResults({ wikis, categories })
           setIsLoading(false)
         }
       },
     )
   }, [query])
-  const { articles, categories } = results
-  const totalResults = articles.length + categories.length
+  const { wikis, categories } = results
+  const totalResults = wikis.length + categories.length
 
-  const articleList = articles.map(article => {
+  const wikiList = wikis.map(wiki => {
     return (
       <ActivityCard
-        key={article.id}
-        title={article.title}
-        brief={article.summary}
-        editor={article.user}
-        wiki={article}
-        wikiId={article.id}
-        lastModTimeStamp={article.updated}
+        key={wiki.id}
+        title={wiki.title}
+        brief={wiki.summary}
+        editor={wiki.user}
+        wiki={wiki}
+        wikiId={wiki.id}
+        lastModTimeStamp={wiki.updated}
       />
     )
   })
@@ -102,13 +102,13 @@ const SearchQuery = ({ query }: SearchQueryProps) => {
           Results for {query}
         </Heading>
 
-        {!isLoading && articles.length !== 0 && (
+        {!isLoading && wikis.length !== 0 && (
           <Stack spacing="4">
             <Text>Showing {totalResults} results </Text>
 
-            <Heading fontSize="2xl">Articles</Heading>
+            <Heading fontSize="2xl">Wikis</Heading>
             <Flex direction="column" gap="4">
-              {articleList}
+              {wikiList}
             </Flex>
             {categories.length !== 0 && (
               <>

--- a/src/services/search/utils.ts
+++ b/src/services/search/utils.ts
@@ -23,7 +23,7 @@ type AccountArgs = {
   username: string
 }
 type Results = {
-  articles: WikiPreview[]
+  wikis: WikiPreview[]
   categories: Category[]
   accounts: Account[]
 }
@@ -31,7 +31,7 @@ type Results = {
 export type SearchItem = keyof typeof SEARCH_TYPES
 
 export const SEARCH_TYPES = {
-  ARTICLE: 'ARTICLE',
+  WIKI: 'WIKI',
   CATEGORY: 'CATEGORY',
   ACCOUNT: 'ACCOUNT',
 } as const
@@ -67,8 +67,8 @@ const debouncedFetchResults = debounce(
       fetchCategoriesList(query),
       fetchAccountsList({ id: query, username: query }),
     ]).then(res => {
-      const [articles = [], categories = [], accounts = []] = res
-      cb({ articles, categories, accounts })
+      const [wikis = [], categories = [], accounts = []] = res
+      cb({ wikis, categories, accounts })
     })
   },
   500,
@@ -79,7 +79,7 @@ export const useNavSearch = () => {
   const [isLoading, setIsLoading] = useState(false)
 
   const [results, setResults] = useState<Results>({
-    articles: [],
+    wikis: [],
     categories: [],
     accounts: [],
   })
@@ -88,7 +88,7 @@ export const useNavSearch = () => {
     if (query && query.length >= 3) {
       setIsLoading(true)
       debouncedFetchResults(query, res => {
-        if (!res.accounts && !res.articles && !res.categories) {
+        if (!res.accounts && !res.wikis && !res.categories) {
           logEvent({
             action: 'SEARCH_NO_RESULTS',
             label: query,


### PR DESCRIPTION
# Changing Articles in the IQ wiki search bar to Wiki  

_PR description goes here_

_Before_
The wiki section is titled Articles 
![image](https://user-images.githubusercontent.com/75235148/202869339-9057c5e0-a51c-4876-8ccc-089f62526f85.png)

_Now_
![image](https://user-images.githubusercontent.com/75235148/202869449-a98a9934-1135-42e7-8536-5f6bc2530145.png)

closes https://github.com/EveripediaNetwork/issues/issues/884
