### PR TITLE
Fixes fonts in local dev and reduced number of imported font weights

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -27,6 +27,8 @@ type EpAppProps = Omit<AppProps, 'Component'> & {
 
 export const montserrat = Montserrat({
   subsets: ['latin'],
+  weight: ['500', '600', '700'],
+  display: 'swap',
 })
 
 const App = ({ Component, pageProps, router }: EpAppProps) => {


### PR DESCRIPTION
# Changes
- Fixes fonts not swapping from fallback montserrat font in local dev environment with `display: swap`
- Reduces weights to 500, 600, 700 used in design
# How to test
- check out this branch on local - `git checkout font-fixes && yarn dev`
- inspect element and check if the font-family is `montserrat` in computed tab

![CleanShot 2022-11-22 at 19 53 07@2x](https://user-images.githubusercontent.com/52039218/203338393-d5ae54dc-7f6c-43e0-8e79-36b04d371819.png)
