### PR TITLE
Fix glossary scroll issue

### DIFF
--- a/src/components/Glossary/GlossaryItems.tsx
+++ b/src/components/Glossary/GlossaryItems.tsx
@@ -6,13 +6,13 @@ import GlossaryWikiCard from './GlossaryWikiCard'
 
 interface GlossaryItemProps {
   highlightText: string
-  wikis: Wiki[]
+  glossary: Wiki[]
   glossaryAlphabets: string[]
 }
 
 const GlossaryItem = ({
   highlightText,
-  wikis,
+  glossary,
   glossaryAlphabets,
 }: GlossaryItemProps) => {
   const lettersIdentifier = /^[a-zA-Z]+$/
@@ -57,7 +57,7 @@ const GlossaryItem = ({
             direction="column"
             gap="14"
           >
-            {wikis?.map(ob => (
+            {glossary?.map(ob => (
               <>
                 {cardOrder(ob.title, item) === 1 && (
                   <GlossaryWikiCard

--- a/src/pages/glossary/index.tsx
+++ b/src/pages/glossary/index.tsx
@@ -60,7 +60,7 @@ const GlossaryFilterSection = ({
             <Search2Icon
               color="gray.300"
               fontSize={{ base: 'sm', lg: 'auto' }}
-              ml={{ base: '-8', md: '0' }}
+              ml={{ base: '-8', lg: 0 }}
             />
           </InputLeftElement>
           <Input

--- a/src/pages/glossary/index.tsx
+++ b/src/pages/glossary/index.tsx
@@ -317,7 +317,7 @@ const Glossary: NextPage = () => {
 
       <GlossaryItem
         highlightText={searchText}
-        wikis={glossary ?? []}
+        glossary={glossary ?? []}
         glossaryAlphabets={alphabet}
       />
     </Stack>

--- a/src/pages/glossary/index.tsx
+++ b/src/pages/glossary/index.tsx
@@ -228,7 +228,7 @@ const Glossary: NextPage = () => {
         <Box mx="auto" w="full" justifyContent="center" alignItems="center">
           <Grid
             templateColumns={{
-              base: 'repeat(14,1fr)',
+              base: 'repeat(9,1fr)',
               md: 'repeat(20,1fr)',
               lg: 'repeat(27,1fr)',
             }}

--- a/src/pages/glossary/index.tsx
+++ b/src/pages/glossary/index.tsx
@@ -182,8 +182,6 @@ const Glossary: NextPage = () => {
     filterGlossaryBySearchQuery(input)
   }
 
-
-
   return (
     <Stack direction="column" w="full" pb="56">
       <Flex


### PR DESCRIPTION
# scroll issue on the Glossary page

we have to change the feature of searching while scrolling the page down to the letter. if a user types one letter and the search bar disappears. not a good experience.


## Linked issues
fixes https://github.com/EveripediaNetwork/issues/issues/890