### PR TITLE
Adds hideOnError on related media images

### DIFF
--- a/src/components/Wiki/WikiPage/InsightComponents/RelatedMedia.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/RelatedMedia.tsx
@@ -33,6 +33,7 @@ const RelatedMediaGrid = ({ media }: { media?: Media[] }) => {
                   h="100%"
                   w="100%"
                   alt="related media"
+                  hideOnError
                   objectFit="cover"
                   bgColor="fadedText2"
                 />


### PR DESCRIPTION
# Changes
- Removes broken image preview on related media widget if the image is not available in some cases

# Links
- before: https://iq.wiki/wiki/upbit
- after: https://iq-wiki-git-media-plugin-fixes-prediqt.vercel.app/wiki/upbit

# Screenshots
![Frame 395](https://user-images.githubusercontent.com/52039218/203987114-c0812727-942e-44c5-8ef7-30fad61303cb.png)
