### PR TITLE
Fixes typo on faq

### DIFF
--- a/src/components/Faq/CreateWikisFAQ.tsx
+++ b/src/components/Faq/CreateWikisFAQ.tsx
@@ -134,7 +134,7 @@ const CreateWikisFAQ = () => {
                     To add or update a featured image, click on the placeholder
                     image. You can easily add a photo by dragging and dropping
                     it or clicking to select an image from your PC. You can also
-                    clicking Image URL and paste in a link to the image and the
+                    click on Image URL and paste in a link to the image and the
                     system will fetch it automatically.{' '}
                     <iframe
                       title="Adding a featured image"


### PR DESCRIPTION
Fixes typo on faq

Before:

![PHOTO-2022-11-25-17-03-46](https://user-images.githubusercontent.com/66301634/204025370-4a554d02-1957-4231-9a98-db3a001528a3.jpg)

Now:

<img width="1440" alt="Screen Shot 2022-11-25 at 5 28 35 PM" src="https://user-images.githubusercontent.com/66301634/204025440-81120cf1-de75-4718-b16b-170dbb48bc9e.png">
