### PR TITLE
Fixes bolded heading not showing up in table of contents

### DIFF
--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -296,7 +296,8 @@ const CreateWikiContent = () => {
           .replace(EditorContentOverride, '')
           .replace(/<\/?em>/gm, '*')
           .replace(/<\/?strong>/gm, '**')
-          .replace(/<\/?del>/gm, '~~'),
+          .replace(/<\/?del>/gm, '~~')
+          .replace(/^(#+\s)(\*\*)(.+)(\*\*)/gm, '$1$3'),
         metadata: [
           ...wiki.metadata.filter(
             m => m.id !== EditSpecificMetaIds.COMMIT_MESSAGE,


### PR DESCRIPTION
# Changes
- adds a new filter to remove bold tags before saving to ipfs when heading is made bold

# Screenshot
<img width="520" alt="CleanShot 2022-11-29 at 13 19 10@2x" src="https://user-images.githubusercontent.com/52039218/204469806-01c8f5ff-e767-4ff6-9d6a-43f3896f6343.png">

![79390](https://user-images.githubusercontent.com/52039218/204470000-5ef5abf1-af86-43a2-a19e-94d51e7ac5d9.png)

