### PR TITLE
Small Alignment fixes

### DIFF
--- a/src/components/Elements/Carousel/Carousel.tsx
+++ b/src/components/Elements/Carousel/Carousel.tsx
@@ -22,7 +22,7 @@ const ArrowBtn = ({ ArrowIcon, onClick, top, isNext }: ArrowProps) => (
   <Box
     top={top}
     position="absolute"
-    transform="translate(0, -50%)"
+    transform="translate(0, 150%)"
     display="grid"
     placeItems="center"
     onClick={onClick}

--- a/src/components/Landing/TrendingWikis.tsx
+++ b/src/components/Landing/TrendingWikis.tsx
@@ -91,7 +91,7 @@ const TrendingWikiCard = ({ wiki }: { wiki: Wiki }) => {
             </Text>
 
             <HStack justify="space-between">
-              <Flex gap={3} width="50%">
+              <Flex alignItems="center" gap={3} width="50%">
                 <Link href={`/account/${wiki?.user?.id}`}>
                   <DisplayAvatar
                     alt={getUsername(wiki?.user, ensName)}


### PR DESCRIPTION
# Changes
-  fixes editor avatar alignment on trending wikis card
-  carousel arrows alignment to be around vertically center in all places

# Screenshots

### Before
<img width="1329" alt="CleanShot 2022-11-29 at 17 02 37@2x" src="https://user-images.githubusercontent.com/52039218/204518346-e3f5093c-eb63-4ccd-9073-60e48fad388e.png">

### After
<img width="1289" alt="CleanShot 2022-11-29 at 17 02 59@2x" src="https://user-images.githubusercontent.com/52039218/204518442-2524a5b6-0137-4e22-975d-007bc67f587d.png">
