### PR TITLE
Branding Link Fix

### DIFF
--- a/src/components/Layout/Footer/MenuFooter.tsx
+++ b/src/components/Layout/Footer/MenuFooter.tsx
@@ -61,7 +61,7 @@ const MenuFooter = () => {
               <Link prefetch={false} href="/static/careers">{`${t(
                 'careers',
               )}`}</Link>
-              <Link prefetch={false} href="/static/branding">{`${t(
+              <Link prefetch={false} href="/branding">{`${t(
                 'Branding',
               )}`}</Link>
               <Link target="_blank" href="https://iq.braindao.org">


### PR DESCRIPTION
# Fixed the broken branding link in iq wiki footer

_Description _

re-routed the link from "/static/branding" to "/branding"
