### PR TITLE
Adds Media Categorisation 

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@ethersproject/contracts": "^5.6.2",
     "@ethersproject/providers": "^5.6.8",
     "@ethersproject/units": "^5.6.1",
-    "@everipedia/iq-utils": "^0.0.1",
+    "@everipedia/iq-utils": "^0.0.3",
     "@everipedia/wagmi-magic-connector": "^0.7.0",
     "@metamask/detect-provider": "^1.2.0",
     "@next/font": "^13.0.3",

--- a/src/components/Elements/Dropzone/Dropzone.tsx
+++ b/src/components/Elements/Dropzone/Dropzone.tsx
@@ -169,14 +169,14 @@ const Dropzone = ({
                       <Text
                         textAlign="center"
                         color="wikiDropzoneText"
-                        fontWeight="bold"
+                        fontSize="md"
                       >
                         {dropzonePlaceHolderTitle}
                       </Text>
                       <Text
                         textAlign="center"
+                        fontSize="sm"
                         color="wikiDropzoneText"
-                        fontWeight="bold"
                       >
                         {dropzonePlaceHolderSize}
                       </Text>

--- a/src/components/Layout/Editor/Highlights/MediaModal/MediaModal.tsx
+++ b/src/components/Layout/Editor/Highlights/MediaModal/MediaModal.tsx
@@ -24,7 +24,7 @@ import { shortenText } from '@/utils/shortenText'
 import shortenBalance from '@/utils/shortenBallance'
 import { v4 as uuidv4 } from 'uuid'
 import { saveImage } from '@/utils/create-wiki'
-import { Image } from '@everipedia/iq-utils'
+import { Image, MediaType } from '@everipedia/iq-utils'
 import { WikiImage } from '@/components/WikiImage'
 import { MEDIA_POST_DEFAULT_ID } from '@/data/Constants'
 import { checkMediaDefaultId, constructMediaUrl } from '@/utils/mediaUtils'
@@ -88,10 +88,22 @@ const MediaModal = ({
         name,
         size: shortenBalance(fileSize),
         id,
+        type: MediaType.DEFAULT,
         source: 'IPFS_IMG',
       },
     })
     uploadImageToIPFS({ id, type: value })
+  }
+
+  const handleSetType = (mediaId: string, type: MediaType) => {
+    dispatch({
+      type: 'wiki/updateMediaDetails',
+      payload: {
+        id: mediaId,
+        hash: mediaId,
+        type,
+      },
+    })
   }
 
   const dropZoneActions = {
@@ -192,9 +204,26 @@ const MediaModal = ({
                         justifyContent="space-between"
                         alignItems="center"
                       >
-                        <Select size="xs" maxW="28" variant="outline">
-                          <option value="image">Image</option>
-                          <option value="video">Token Icon</option>
+                        <Select
+                          size="xs"
+                          maxW="28"
+                          variant="outline"
+                          value={media.type}
+                          onChange={e =>
+                            handleSetType(media.id, e.target.value as MediaType)
+                          }
+                        >
+                          <option value={MediaType.DEFAULT}>Default</option>
+                          <option
+                            disabled={
+                              wiki.media?.find(
+                                m => m.type === MediaType.ICON,
+                              ) !== undefined
+                            }
+                            value={MediaType.ICON}
+                          >
+                            Token Icon
+                          </option>
                         </Select>
                         <Text textAlign="right" flex="1">
                           {media.size}mb

--- a/src/components/Layout/Editor/Highlights/MediaModal/MediaModal.tsx
+++ b/src/components/Layout/Editor/Highlights/MediaModal/MediaModal.tsx
@@ -16,6 +16,7 @@ import {
   Progress,
   Stack,
   useToast,
+  Select,
 } from '@chakra-ui/react'
 import { RiCloseLine, RiImageLine } from 'react-icons/ri'
 import { useAppDispatch, useAppSelector } from '@/store/hook'
@@ -126,7 +127,7 @@ const MediaModal = ({
             {wiki.media !== undefined && wiki.media?.length > 0 && (
               <SimpleGrid
                 mt={4}
-                maxH="162px"
+                maxH="240px"
                 borderWidth="1px"
                 p={3}
                 borderRadius={8}
@@ -185,12 +186,18 @@ const MediaModal = ({
                           isIndeterminate
                         />
                       )}
-                      <Flex w="full" fontSize="xs" gap={16}>
-                        <Text flex="1">{media.size}mb</Text>
-                        <Text flex="1">
-                          {checkMediaDefaultId(media.id)
-                            ? 'uploading'
-                            : 'uploaded'}
+                      <Flex
+                        w="full"
+                        fontSize="xs"
+                        justifyContent="space-between"
+                        alignItems="center"
+                      >
+                        <Select size="xs" maxW="28" variant="outline">
+                          <option value="image">Image</option>
+                          <option value="video">Token Icon</option>
+                        </Select>
+                        <Text textAlign="right" flex="1">
+                          {media.size}mb
                         </Text>
                       </Flex>
                     </VStack>
@@ -198,7 +205,6 @@ const MediaModal = ({
                 ))}
               </SimpleGrid>
             )}
-
             <Flex direction="column" gap={5} w="full" borderRadius="7px" py={3}>
               <Dropzone
                 dropZoneActions={dropZoneActions}

--- a/src/components/Layout/Editor/Highlights/MediaModal/MediaModal.tsx
+++ b/src/components/Layout/Editor/Highlights/MediaModal/MediaModal.tsx
@@ -124,98 +124,87 @@ const MediaModal = ({
           <Box mt="3">
             <Text fontWeight="bold">Uploads</Text>
             {wiki.media !== undefined && wiki.media?.length > 0 && (
-              <Box
-                my={4}
-                display="flex"
-                justifyContent={{ base: 'center', md: 'left' }}
+              <SimpleGrid
+                mt={4}
                 maxH="162px"
                 borderWidth="1px"
-                p={5}
+                p={3}
                 borderRadius={8}
-                overflow="auto"
+                overflowY="scroll"
+                columns={{ base: 1, md: 2 }}
+                spacing={4}
               >
-                <SimpleGrid
-                  columns={{ base: 1, md: 2 }}
-                  spacingY={6}
-                  spacingX={12}
-                >
-                  {wiki.media.map(media => (
-                    <Flex key={media.id} gap={4} color="linkColor">
-                      <Box mt={1}>
-                        {!checkMediaDefaultId(media.id) ? (
-                          <WikiImage
+                {wiki.media.map(media => (
+                  <Flex
+                    key={media.id}
+                    gap={4}
+                    w="100%"
+                    alignItems="center"
+                    color="linkColor"
+                  >
+                    {!checkMediaDefaultId(media.id) ? (
+                      <WikiImage
+                        cursor="pointer"
+                        alt="media"
+                        flexShrink={0}
+                        imageURL={
+                          media.source !== 'YOUTUBE'
+                            ? constructMediaUrl(media)
+                            : `https://i3.ytimg.com/vi/${media.name}/maxresdefault.jpg`
+                        }
+                        boxSize="42"
+                        borderRadius="lg"
+                        overflow="hidden"
+                        mt="1"
+                      />
+                    ) : (
+                      <RiImageLine size="42" />
+                    )}
+                    <VStack spacing={1} w="full">
+                      <Flex w="full">
+                        <Text fontSize="sm" flex="1">
+                          {media.name
+                            ? shortenText(media.name, 15)
+                            : 'untitled'}
+                        </Text>
+                        <Box mt={1}>
+                          <RiCloseLine
                             cursor="pointer"
-                            alt="media"
-                            flexShrink={0}
-                            imageURL={
-                              media.source !== 'YOUTUBE'
-                                ? constructMediaUrl(media)
-                                : `https://i3.ytimg.com/vi/${media.name}/maxresdefault.jpg`
-                            }
-                            h={{ base: '30px', lg: '40px' }}
-                            w={{ base: '30px', lg: '40px' }}
-                            borderRadius="lg"
-                            overflow="hidden"
-                            mt="1"
-                          />
-                        ) : (
-                          <RiImageLine size="40" />
-                        )}
-                      </Box>
-                      <VStack>
-                        <Flex w="full">
-                          {media.name && (
-                            <Box flex="1">
-                              <Text fontSize="sm">
-                                {shortenText(media.name, 15)}
-                              </Text>
-                            </Box>
-                          )}
-                          <Box mt={1}>
-                            <RiCloseLine
-                              cursor="pointer"
-                              onClick={() => deleteMedia(media.id)}
-                              color="red"
-                              size="14"
-                            />
-                          </Box>
-                        </Flex>
-                        <Box w="full">
-                          <Progress
-                            value={checkMediaDefaultId(media.id) ? 50 : 100}
-                            h="3px"
-                            colorScheme="green"
-                            size="sm"
+                            onClick={() => deleteMedia(media.id)}
+                            color="red"
+                            size="14"
                           />
                         </Box>
-                        <Flex w="full" fontSize="xs" gap={16}>
-                          <Text flex="1">{media.size}mb</Text>
-                          <Text flex="1">
-                            {checkMediaDefaultId(media.id)
-                              ? 'uploading'
-                              : 'uploaded'}
-                          </Text>
-                        </Flex>
-                      </VStack>
-                    </Flex>
-                  ))}
-                </SimpleGrid>
-              </Box>
+                      </Flex>
+                      {checkMediaDefaultId(media.id) && (
+                        <Progress
+                          w="full"
+                          h="3px"
+                          colorScheme="green"
+                          size="sm"
+                          isIndeterminate
+                        />
+                      )}
+                      <Flex w="full" fontSize="xs" gap={16}>
+                        <Text flex="1">{media.size}mb</Text>
+                        <Text flex="1">
+                          {checkMediaDefaultId(media.id)
+                            ? 'uploading'
+                            : 'uploaded'}
+                        </Text>
+                      </Flex>
+                    </VStack>
+                  </Flex>
+                ))}
+              </SimpleGrid>
             )}
 
-            <Flex
-              direction="column"
-              gap={5}
-              w="full"
-              borderRadius="7px"
-              py={5}
-              mb={3}
-            >
+            <Flex direction="column" gap={5} w="full" borderRadius="7px" py={3}>
               <Dropzone
                 dropZoneActions={dropZoneActions}
                 dropzonePlaceHolderTitle={`Drag and drop an ${dropZoneActions.textType} or click to select.`}
                 dropzonePlaceHolderSize="(10mb max)"
-                aspectRatio={8 / 3}
+                aspectRatio={11 / 3}
                 mediaModal
               />
               <ImageInput
@@ -225,7 +214,7 @@ const MediaModal = ({
               />
             </Flex>
             {wiki.media !== undefined && wiki.media?.length > 0 && (
-              <Box mb={8} justifyContent="center" display="flex">
+              <Box mb={4} justifyContent="center" display="flex">
                 <Stack spacing={4} direction="row" align="center">
                   <Button size="md" onClick={onClose}>
                     <Text fontSize="xs">Save</Text>

--- a/src/components/Wiki/WikiPage/InsightComponents/CurrencyConverter.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/CurrencyConverter.tsx
@@ -3,18 +3,24 @@ import { Box, HStack, IconButton, Input, Text, VStack } from '@chakra-ui/react'
 import { RiArrowLeftRightLine } from 'react-icons/ri'
 import { TokenStats } from '@/services/token-stats'
 import { Image } from '@/components/Elements/Image/Image'
+import config from '@/config'
 
 const CurrencyBox = ({
   token,
+  tokenImage,
   tokenSymbol,
   value,
   setValue,
 }: {
   token?: string
   tokenSymbol: string
+  tokenImage?: string
   value: number
   setValue: (value: string) => void
 }) => {
+  const tokenImageSrc = tokenImage
+    ? `${config.pinataBaseUrl}${tokenImage}`
+    : `https://icons.iq.wiki/128/${token}.png`
   return (
     <HStack
       zIndex={2}
@@ -26,7 +32,7 @@ const CurrencyBox = ({
       <HStack align="center">
         {token ? (
           <Image
-            src={`https://icons.iq.wiki/128/${token}.png`}
+            src={tokenImageSrc}
             imgH={18}
             imgW={18}
             alt={token}
@@ -61,14 +67,19 @@ const CurrencyBox = ({
 interface CurrencyConverterProps {
   token: string
   tokenStats: TokenStats
+  tokenImage?: string
 }
 
-const CurrencyConverter = ({ token, tokenStats }: CurrencyConverterProps) => {
+const CurrencyConverter = ({
+  token,
+  tokenStats,
+  tokenImage,
+}: CurrencyConverterProps) => {
   const conversionRate = tokenStats?.token_price_in_usd
   const tokenSymbol = tokenStats.symbol
   const [fromCurrency, setFromCurrency] = useState<number>(0)
   const [toCurrency, setToCurrency] = useState<number>(0)
-  const [isTokenLeft, setisTokenLeft] = useState(true)
+  const [isTokenLeft, setIsTokenLeft] = useState(true)
 
   // function for updating the from currency
   const updateValues = useCallback(
@@ -134,6 +145,7 @@ const CurrencyConverter = ({ token, tokenStats }: CurrencyConverterProps) => {
             <CurrencyBox
               token={token}
               tokenSymbol={tokenSymbol}
+              tokenImage={tokenImage}
               value={fromCurrency}
               setValue={e => updateValues(e, true)}
             />
@@ -155,7 +167,7 @@ const CurrencyConverter = ({ token, tokenStats }: CurrencyConverterProps) => {
               p={2}
               zIndex={2}
               m="2px 7px !important"
-              onClick={() => setisTokenLeft(!isTokenLeft)}
+              onClick={() => setIsTokenLeft(!isTokenLeft)}
               transform="scale(0.8)"
             />
             <CurrencyBox

--- a/src/components/Wiki/WikiPage/WikiInsights.tsx
+++ b/src/components/Wiki/WikiPage/WikiInsights.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect, useState } from 'react'
 import { Box, Flex, VStack } from '@chakra-ui/react'
-import { CommonMetaIds, EditSpecificMetaIds, Wiki } from '@everipedia/iq-utils'
+import {
+  CommonMetaIds,
+  EditSpecificMetaIds,
+  MediaType,
+  Wiki,
+} from '@everipedia/iq-utils'
 import { getWikiImageUrl } from '@/utils/getWikiImageUrl'
 import { TokenStats } from '@/services/token-stats'
 import { NFTStats } from '@/services/nft-stats'
@@ -100,6 +105,9 @@ const WikiInsights = ({
               {wikiIsNFT && <NFTStatistics nftStats={nftStats} />}
               {tokenStats && (
                 <CurrencyConverter
+                  tokenImage={
+                    wiki.media?.find(m => m.type === MediaType.ICON)?.id
+                  }
                   token={getTokenFromURI(coingeckoLink)}
                   tokenStats={tokenStats}
                 />

--- a/src/services/wikis/queries.ts
+++ b/src/services/wikis/queries.ts
@@ -72,6 +72,7 @@ export const GET_WIKI_BY_ID = gql`
         name
         id
         size
+        type
         source
       }
       metadata {

--- a/src/store/slices/wiki.slice.ts
+++ b/src/store/slices/wiki.slice.ts
@@ -186,6 +186,7 @@ const wikiSlice = createSlice({
         const updatedMedia = [...state.media]
         updatedMedia[findMediaIndex] = {
           ...updatedMedia[findMediaIndex],
+          ...action.payload,
           ...{ id: action.payload.hash },
         }
         const newState = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2747,10 +2747,10 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.1"
 
-"@everipedia/iq-utils@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@everipedia/iq-utils/-/iq-utils-0.0.1.tgz#fc984b938ef0aa5e73b6896f393ab357e25c7993"
-  integrity sha512-DNQaymc9m7lSyRkuYQbAB2Xb0thw6RA6S9vKRR2cHBmWmVumKAIXDR7CP6f8hm4JSX37lVhCqsl8Knj5tJICbA==
+"@everipedia/iq-utils@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@everipedia/iq-utils/-/iq-utils-0.0.3.tgz#e1de97acbc6b35ce25998735f2929bb9627907cb"
+  integrity sha512-kCmvo7rhD5KNWO4xwXr0D/sL0vzD3AtDK4nRFynDGKG3ZULF3yzkBq1oV4DQtDARJZHRvCeIUZ4n1jMDkaFulg==
 
 "@everipedia/wagmi-magic-connector@^0.7.0":
   version "0.7.0"


### PR DESCRIPTION
Closes https://github.com/EveripediaNetwork/issues/issues/930

# Changes
- made media modal more compact
- added select fields to media cards for selecting which category/type the media is.
- restricted media cards to only select `ICON` media type once.
- modifies wiki queries to get media type information 
- enables **currency calculator widget** to use media image with type `ICON` if present (fallbacks to icons.iq.wiki if not)

# Screenshots
![CleanShot 2022-12-21 at 21 34 20@2x](https://user-images.githubusercontent.com/52039218/208949516-d71b82e7-0fec-4ead-aaca-5def874d681f.png)
fixes: https://github.com/EveripediaNetwork/issues/issues/953 
