### PR TITLE
Terms of service update

### DIFF
--- a/src/components/Layout/Footer/MenuFooter.tsx
+++ b/src/components/Layout/Footer/MenuFooter.tsx
@@ -94,6 +94,10 @@ const MenuFooter = () => {
               <Link prefetch={false} href="/static/terms">{`${t(
                 'termsOfService',
               )}`}</Link>
+              <Link
+                prefetch={false}
+                href="https://docs.google.com/document/d/11ZxSfCegdvKr3k9QjqzoZXliwyh1ytUx29IVz7LPVCs/edit?usp=sharing"
+              >{`${t('privacyRights')}`}</Link>
             </Stack>
           </GridItem>
         </SimpleGrid>

--- a/src/pages/static/terms.tsx
+++ b/src/pages/static/terms.tsx
@@ -150,7 +150,7 @@ const Terms = () => (
             infringes someone else&rsquo;s intellectual property rights, such as
             copyrights or trademarks, your IP address may be banned and your
             page removed under IQ.wiki&apos;s repeat infringer policy. If you
-            believe your IP address was banned by mistake, please contact us
+            believe your IP address was banned by mistake, please contact us.
           </Text>
           <Heading as="h2" size="md">
             Designated Agent

--- a/src/pages/static/terms.tsx
+++ b/src/pages/static/terms.tsx
@@ -17,12 +17,12 @@ const Terms = () => (
       <Flex gap={10} flexDirection={{ base: 'column', lg: 'row' }}>
         <Flex gap={5} flex="3" flexDirection="column">
           <Text>
-            Welcome to IQ.Wiki, the website and online service of Everipedia
-            Inc. (&quot;Everipedia,&quot; &quot;we,&quot; &quot;us&quot; or
-            &quot;our&quot;). This page explains the terms by which you may use
-            our online and/or mobile services, web site, and software provided
-            on or in connection with the IQ.Wiki service (collectively the
-            &quot;Service&quot;). By accessing or using the Service, you
+            Welcome to IQ.Wiki, the website and online service of Distributed
+            Machines Inc. (&quot;IQ.wiki,&quot; &quot;we,&quot; &quot;us&quot;
+            or &quot;our&quot;). This page explains the terms by which you may
+            use our online and/or mobile services, website, and software
+            provided on or in connection with the IQ.Wiki service (collectively
+            the &quot;Service&quot;). By accessing or using the Service, you
             (&quot;you&quot; or &quot;your&quot;), signify that you have read,
             understand and agree to be bound by the terms of service and
             conditions set forth below (as amended from time to time,
@@ -43,16 +43,16 @@ const Terms = () => (
             bound. We will indicate at the top of this page the date these terms
             were last revised. If you do not agree to abide by these or any
             future Terms, do not use or access (or continue to use or access)
-            the Service. Everipedia allows you to upload images, files, and
-            other media. You agree to only upload images that you have the
-            necessary licenses, and permissions, and rights, or that are in the
-            public domain, or that you own. You must agree not to upload any
+            the Service. IQ.wiki allows you to upload images, files, and other
+            media. You agree to only upload images that you have the necessary
+            licenses, and permissions, and rights, or that are in the public
+            domain, or that you own. You must agree not to upload any
             copyrighted image unless you were permitted by the owner of the
             image or you are legally otherwise entitled to upload the image.
-            Everipedia takes no responsibility for any liability you may or may
-            not incur from uploading images for which you do not have the
-            necessary licenses, permissions, and/or rights. Additional terms and
-            conditions may apply to certain services provided by Everipedia, and
+            IQ.wiki takes no responsibility for any liability you may or may not
+            incur from uploading images for which you do not have the necessary
+            licenses, permissions, and/or rights. Additional terms and
+            conditions may apply to certain services provided by IQ.wiki, and
             you agree that you shall be subject to any additional terms
             applicable to such services that may be posted on the Website or
             otherwise made available to you from time to time. All such terms
@@ -63,10 +63,9 @@ const Terms = () => (
             ARBITRATION ON AN INDIVIDUAL BASIS TO RESOLVE DISPUTES, RATHER THAN
             JURY TRIALS OR CLASS ACTIONS. THE SERVICE MAY CONTAIN CONTENT THAT
             IS INACCURATE, OBJECTIONABLE, INAPPROPRIATE FOR CHILDREN, OR
-            OTHERWISE UNSUITED TO YOUR PURPOSE, AND YOU AGREE THAT EVERIPEDIA
-            SHALL NOT BE LIABLE FOR ANY DAMAGES YOU ALLEGE IN INCUR AS A RESULT
-            OF ANY EXPOSURE TO SUCH CONTENT. YOU USE THE SERVICE AT YOUR OWN
-            RISK.
+            OTHERWISE UNSUITED TO YOUR PURPOSE, AND YOU AGREE THAT IQ.wiki SHALL
+            NOT BE LIABLE FOR ANY DAMAGES YOU ALLEGE IN INCUR AS A RESULT OF ANY
+            EXPOSURE TO SUCH CONTENT. YOU USE THE SERVICE AT YOUR OWN RISK.
           </Text>
           <Heading as="h2" size="md">
             Eligibility
@@ -82,115 +81,103 @@ const Terms = () => (
             Access and Use of the Service
           </Heading>
           <Text>
-            Everipedia is an encyclopedia of the internet, aiming to categorize
-            and comment every single link on the internet. We welcome your
+            IQ.wiki is a cryptocurrency encyclopedia. We welcome your
             participation in this quest subject to these Terms. Registration may
             not be required to view content on the Service, but even
             unregistered Users are bound by these Terms. Subject to the terms
             and conditions of these Terms, you are hereby granted a
             non-exclusive, limited, non-transferable, freely revocable license
             to use the Service as permitted by the features of the Service.
-            Everipedia reserves all rights not expressly granted herein in the
-            Service and the Everipedia Content (as defined below). Everipedia
-            may terminate this license at any time for any reason or no reason.
+            IQ.wiki reserves all rights not expressly granted herein in the
+            Service and the IQ.wiki Content (as defined below). IQ.wiki may
+            terminate this license at any time for any reason or no reason.
           </Text>
           <Text>
-            <b>Your Registration Obligations:</b> Your Everipedia account gives
-            you access to the services and functionality that we may establish
-            and maintain from time to time and in our sole discretion. We may
+            <b>Your Registration Obligations:</b> Your IQ.wiki account gives you
+            access to the services and functionality that we may establish and
+            maintain from time to time and in our sole discretion. We may
             maintain different types of accounts for different types of Users.
-            If you open an Everipedia account on behalf of a company,
-            organization, school, or other entity, then (i) &quot;you&quot;
-            includes you and that entity, and (ii) you represent and warrant
-            that you are an authorized representative of the entity with the
-            authority to bind the entity to this Agreement, and that you agree
-            to this Agreement on the entity&apos;s behalf. Without limiting the
-            generality of the foregoing, if you are a teacher or other
-            representative of a school and/or district, you represent and
-            warrant that you have permission from your school and/or district to
-            enter into these Terms and to use the Service as part of your
-            curriculum. If you choose to register for an account, you agree to
-            provide and maintain true, accurate, current and complete
-            information about yourself as prompted by our registration form. The
-            information you submit to us when you register (&quot;Registration
-            Data&quot;) and certain other information about you are governed by
-            our Privacy Policy as well as these Terms, as discussed above. By
-            using the Service you consent to having Registration Data and other
-            data you submit transferred to and processed within the United
-            States.
+            If you open an IQ.wiki account on behalf of a company, organization,
+            school, or other entity, then (i) &quot;you&quot; includes you and
+            that entity, and (ii) you represent and warrant that you are an
+            authorized representative of the entity with the authority to bind
+            the entity to this Agreement, and that you agree to this Agreement
+            on the entity&apos;s behalf. Without limiting the generality of the
+            foregoing, if you are a teacher or other representative of a school
+            and/or district, you represent and warrant that you have permission
+            from your school and/or district to enter into these Terms and to
+            use the Service as part of your curriculum. If you choose to
+            register for an account, you agree to provide and maintain true,
+            accurate, current and complete information about yourself as
+            prompted by our registration form. The information you submit to us
+            when you register (&quot;Registration Data&quot;) and certain other
+            information about you are governed by our Privacy Policy as well as
+            these Terms, as discussed above. By using the Service you consent to
+            having Registration Data and other data you submit transferred to
+            and processed within the United States.
           </Text>
           <Text>
             <b>Member Account, Password and Security:</b> You are responsible
             for maintaining the confidentiality of your password and account, if
             any, and are fully responsible for any and all activities that occur
             under your password or account. You agree to (a) immediately notify
-            Everipedia of any unauthorized use of your password or account or
-            any other breach of security, and (b) ensure that you exit from your
+            IQ.wiki of any unauthorized use of your password or account or any
+            other breach of security, and (b) ensure that you exit from your
             account at the end of each session when accessing the Service.
-            Everipedia will not be liable for any loss or damage arising from
-            your failure to comply with this Section.
+            IQ.wiki will not be liable for any loss or damage arising from your
+            failure to comply with this Section.
           </Text>
           <Heading as="h2" size="md">
             Copyright / Repeat Infringement
           </Heading>
           <Text>
-            Everipedia responds to copyright complaints submitted under the
-            Digital Millennium Copyright Act (&ldquo;DMCA&rdquo;). Section 512
-            of the DMCA outlines the statutory requirements needed for the
-            formal reporting of copyright infringement, as well as providing
+            IQ.wiki responds to copyright complaints submitted under the Digital
+            Millennium Copyright Act (&ldquo;DMCA&rdquo;). Section 512 of the
+            DMCA outlines the statutory requirements needed for the formal
+            reporting of copyright infringement, as well as providing
             instructions on how an affected party can appeal a removal by
-            submitting a compliant counter-notice. Everipedia will respond to
+            submitting a compliant counter-notice. IQ.wiki will respond to
             reports of copyright infringement, allegations concerning the
             unauthorized use of a copyrighted video, image, or other file
             uploaded through our media hosting services, or pages containing
             links to allegedly infringing materials.
           </Text>
           <Text>
-            By using Everipedia, you have agreed to our Terms of Service, which
-            prohibit people from taking any action on Everipedia that infringes
-            or violates someone else&apos;s intellectual property rights or
+            By using IQ.wiki, you have agreed to our Terms of Service, which
+            prohibit people from taking any action on IQ.wiki that infringes or
+            violates someone else&apos;s intellectual property rights or
             otherwise violates the law. If you repeatedly post content that
             infringes someone else&rsquo;s intellectual property rights, such as
             copyrights or trademarks, your IP address may be banned and your
-            page removed under Everipedia&apos;s repeat infringer policy. If you
-            believe your IP address was banned by mistake, please contact us.
+            page removed under IQ.wiki&apos;s repeat infringer policy. If you
+            believe your IP address was banned by mistake, please contact us
           </Text>
           <Heading as="h2" size="md">
             Designated Agent
           </Heading>
           <Text>
             You can mail copyright complaints to: <br />
-            201 Wilshire Boulevard <br />
-            Everipedia - Suite 300 <br />
-            Santa Monica, California, 90401 <br />
-            United States of America <br />
+            2300 West Sahara Ave., Suite 800 <br />
+            PMB 214 <br />
+            Las Vegas, NV 89102 <br /> <br />
             or via email: webmaster@everipedia.org <br />
             or submit them via the{' '}
             <Link
               color="brandLinkColor"
-              href="https://everipedia.org/contact-us"
+              href="https://forms.gle/WivCngAngW19kGMn9"
             >
-              Contact Us
-            </Link>{' '}
-            submission form:{' '}
-            <Link
-              color="brandLinkColor"
-              href="https://everipedia.org/contact-us"
-            >
-              https://everipedia.org/contact-us
+              IQ.wiki Content Removal form
             </Link>
           </Text>
           <Text>
-            <b>Modifications to Service:</b> Everipedia reserves the right to
+            <b>Modifications to Service:</b> IQ.wiki reserves the right to
             modify or discontinue, temporarily or permanently, the Service (or
             any part thereof) or any User account with or without notice. You
-            agree that Everipedia shall not be liable to you or to any third
-            party for any modification, suspension or discontinuance of the
-            Service.
+            agree that IQ.wiki shall not be liable to you or to any third party
+            for any modification, suspension or discontinuance of the Service.
           </Text>
           <Text>
-            Everipedia&apos;s Content: Everipedia&apos;s articles are licensed
-            under a{' '}
+            IQ.wiki&apos;s Content: IQ.wiki&apos;s articles are licensed under a{' '}
             <Link
               color="brandLinkColor"
               href="https://creativecommons.org/licenses/by/4.0/"

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -46,6 +46,7 @@ export const resources = {
       guideLines: 'Guidelines',
       privacyPolicy: 'Privacy Policy',
       termsOfService: 'Terms of service',
+      privacyRights: 'Your CA Privacy Rights',
       copyRight: '© 2022 IQ.Wiki Powered By IQ',
 
       //Desktop Nav


### PR DESCRIPTION
# Terms of service update and Privacy Rights Link added

Before
![Screenshot 2022-12-21 115752](https://user-images.githubusercontent.com/75235148/208889662-003a879f-8a39-47a3-ae95-701de34a12d3.png)

After 
![Screenshot 2022-12-21 115832](https://user-images.githubusercontent.com/75235148/208889841-5ff82705-8866-4737-9099-cc738622eeee.png)

Also the Terms of service page is updated, example wordings like Everipedia is changed to IQ.wiki and many more
