### PR TITLE
Fix handling of null value keys from linked wikis

### DIFF
--- a/src/store/slices/wiki.slice.ts
+++ b/src/store/slices/wiki.slice.ts
@@ -243,9 +243,12 @@ const wikiSlice = createSlice({
       }
       if (!newLinkedWikis[linkType] || newLinkedWikis[linkType]?.length === 0)
         delete newLinkedWikis[linkType]
-      const newState = {
+      const newState: Wiki = {
         ...state,
         linkedWikis: newLinkedWikis,
+      }
+      if (Object.keys(newLinkedWikis).length === 0) {
+        delete newState.linkedWikis
       }
       saveDraftInLocalStorage(newState)
       return newState

--- a/src/store/slices/wiki.slice.ts
+++ b/src/store/slices/wiki.slice.ts
@@ -233,16 +233,19 @@ const wikiSlice = createSlice({
         linkType: LinkedWikiKey
         wikiId: string
       }
+      const newLinkedWikis = {
+        ...state.linkedWikis,
+        [linkType]: state.linkedWikis
+          ? (state.linkedWikis[linkType] || []).filter(
+              (id: string) => id !== wikiId,
+            )
+          : [],
+      }
+      if (!newLinkedWikis[linkType] || newLinkedWikis[linkType]?.length === 0)
+        delete newLinkedWikis[linkType]
       const newState = {
         ...state,
-        linkedWikis: {
-          ...state.linkedWikis,
-          [linkType]: state.linkedWikis
-            ? (state.linkedWikis[linkType] || []).filter(
-                (id: string) => id !== wikiId,
-              )
-            : [],
-        },
+        linkedWikis: newLinkedWikis,
       }
       saveDraftInLocalStorage(newState)
       return newState

--- a/src/utils/create-wiki.ts
+++ b/src/utils/create-wiki.ts
@@ -10,6 +10,8 @@ import {
   EditSpecificMetaIds,
   whiteListedLinkNames,
   CreateNewWikiSlug,
+  LinkedWikiKey,
+  LinkedWikis,
 } from '@everipedia/iq-utils'
 import { useAppDispatch } from '@/store/hook'
 import { createContext } from '@chakra-ui/react-utils'
@@ -348,7 +350,27 @@ export const useCreateWikiState = (router: NextRouter) => {
     )
 
   const isLoadingWiki = isLoadingLatestWiki || isLoadingRevisionWiki
-  const wikiData = revisionWikiData || latestWikiData
+
+  const wikiData = useMemo(() => {
+    const data = revisionWikiData || latestWikiData
+
+    if (data?.linkedWikis) {
+      // remove null values from linked wikis
+      const newLinkedWikis = {} as LinkedWikis
+      Object.entries(data.linkedWikis).forEach(([key, value]) => {
+        if (value !== null) {
+          newLinkedWikis[key as LinkedWikiKey] = value
+        }
+      })
+      return {
+        ...data,
+        linkedWikis: newLinkedWikis,
+      }
+    }
+
+    return data
+  }, [latestWikiData, revisionWikiData])
+
   const [commitMessage, setCommitMessage] = useState('')
   const [openTxDetailsDialog, setOpenTxDetailsDialog] = useState<boolean>(false)
   const [isWritingCommitMsg, setIsWritingCommitMsg] = useState<boolean>(false)


### PR DESCRIPTION
closes https://github.com/EveripediaNetwork/issues/issues/957

# Changes
- added transformation to remove linkedWiki keys on create wiki page
- made removeLinkedWiki action to remove keys from linkedWikis object if it is empty and remove linkedWiki key from wiki object if it is empty object