### PR TITLE
Fixes overlay tags

### DIFF
--- a/src/components/Editor/EditorModals/EditWikiDetailsModal/TagsInput.tsx
+++ b/src/components/Editor/EditorModals/EditWikiDetailsModal/TagsInput.tsx
@@ -35,6 +35,7 @@ const TagsInput = ({ wiki }: { wiki: Wiki }) => {
         borderWidth={1}
         p={2}
         pos="relative"
+        maxH="max-content"
       >
         <Select
           isOptionDisabled={() => value.length >= 5}

--- a/src/components/Editor/EditorModals/EditWikiDetailsModal/index.tsx
+++ b/src/components/Editor/EditorModals/EditWikiDetailsModal/index.tsx
@@ -50,8 +50,9 @@ const HighlightsModal = ({
             mt={-2}
             py={4}
             px={6}
-            maxH="min(64vh, 500px)"
+            maxH="max-content"
             overflowY="auto"
+            zIndex="4"
           >
             <CategoryInput wiki={currentWiki} />
             <TagsInput wiki={currentWiki} />

--- a/src/components/Editor/EditorModals/EditWikiDetailsModal/index.tsx
+++ b/src/components/Editor/EditorModals/EditWikiDetailsModal/index.tsx
@@ -50,7 +50,7 @@ const HighlightsModal = ({
             mt={-2}
             py={4}
             px={6}
-            maxH="max-content"
+            maxH="min(64vh, 500px)"
             overflowY="auto"
             zIndex="4"
           >


### PR DESCRIPTION
Fixes overlay tags

Before:

<img width="582" alt="before-choosing-tag" src="https://user-images.githubusercontent.com/66301634/213816689-28a4b666-7579-40e4-a498-442ff5e33c6d.png">


Now:

<img width="1440" alt="Screen Shot 2023-01-20 at 11 45 06 PM" src="https://user-images.githubusercontent.com/66301634/213818554-1118caaa-eba0-427c-aae2-cd68ebc343ed.png">


fixes https://github.com/EveripediaNetwork/issues/issues/973
