### PR TITLE
overlapped tag issue fixed 

### DIFF
--- a/src/components/Wiki/WikiPage/CustomRenderers/LinkRenderers/WikiLinkRender.tsx
+++ b/src/components/Wiki/WikiPage/CustomRenderers/LinkRenderers/WikiLinkRender.tsx
@@ -83,7 +83,7 @@ const WikiLinkPreview = ({ wikiId }: { wikiId: string }) => {
           </PopoverBody>
           {wiki?.tags?.length !== 0 && (
             <PopoverFooter>
-              <HStack spacing={2} align="center" flexWrap="wrap">
+              <HStack gap="1" align="center" flexWrap="wrap">
                 <Tag variant="outline">
                   <TagLeftIcon mr={1} boxSize="12px" as={RiPriceTagLine} />
                   <TagLabel ml={0} fontSize="12px">


### PR DESCRIPTION
# Overlapping tags in wiki page



# Before
![image](https://user-images.githubusercontent.com/75235148/213862608-2535ade9-7365-49a6-82ae-51cb754d5368.png)

# After
![image](https://user-images.githubusercontent.com/75235148/213862600-1dca1852-a55e-4b86-a181-0ec6c3f5fb4c.png)


 closes https://github.com/EveripediaNetwork/issues/issues/974
