### PR TITLE
Wiki widget showing linked wikis

### DIFF
--- a/src/components/Wiki/WikiPage/InsightComponents/ProfileSummary.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/ProfileSummary.tsx
@@ -49,7 +49,6 @@ const ProfileListItem = ({ title, children }: ProfileListItemProps) => (
 )
 
 const ProfileSummary = ({ wiki }: ProfileSummaryProps) => {
-  console.log(wiki)
   const socialMetaData = wiki.metadata.filter(meta =>
     WikiPossibleSocialsList.includes(meta.id as CommonMetaIds),
   )

--- a/src/components/Wiki/WikiPage/InsightComponents/ProfileSummary.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/ProfileSummary.tsx
@@ -7,6 +7,7 @@ import {
   Icon,
   IconButton,
   Link,
+  Tag,
   Text,
   VStack,
   Wrap,
@@ -48,6 +49,7 @@ const ProfileListItem = ({ title, children }: ProfileListItemProps) => (
 )
 
 const ProfileSummary = ({ wiki }: ProfileSummaryProps) => {
+  console.log(wiki)
   const socialMetaData = wiki.metadata.filter(meta =>
     WikiPossibleSocialsList.includes(meta.id as CommonMetaIds),
   )
@@ -72,6 +74,14 @@ const ProfileSummary = ({ wiki }: ProfileSummaryProps) => {
   const websiteLink = socialMetaData.find(
     item => item.id === CommonMetaIds.WEBSITE,
   )?.value
+
+  const getFounderName = (text: string) => {
+    const names = text
+      .split('-')
+      .map(slug => slug.charAt(0).toUpperCase() + slug.slice(1))
+      .join(' ')
+    return `${names}`
+  }
 
   return (
     <VStack w="100%" spacing={4} borderRadius={2}>
@@ -171,6 +181,40 @@ const ProfileSummary = ({ wiki }: ProfileSummaryProps) => {
                   {LINK_OPTIONS.find(option => option.id === item.id)?.label}
                 </Link>
                 <Icon color="brandLinkColor" as={RiExternalLinkLine} />
+              </HStack>
+            ))}
+          </ProfileListItem>
+        )}
+
+        {wiki.linkedWikis?.founders && (
+          <ProfileListItem title="Founders">
+            {wiki.linkedWikis?.founders.map((item, i) => (
+              <VStack alignItems="start">
+                <Link
+                  color="brandLinkColor"
+                  fontSize="14px"
+                  key={i}
+                  href={`/wiki/${item}`}
+                  rel="noopener nofollow"
+                  isExternal
+                  _hover={{
+                    color: 'linkColorHover',
+                    textDecoration: 'underline',
+                  }}
+                >
+                  {getFounderName(item)}
+                </Link>
+              </VStack>
+            ))}
+          </ProfileListItem>
+        )}
+        {wiki.linkedWikis?.blockchains && (
+          <ProfileListItem title="Blockchains">
+            {wiki.linkedWikis?.blockchains.map((item, i) => (
+              <HStack spacing={2}>
+                <Link key={i} href={`/tags/${item}`} py={1}>
+                  <Tag whiteSpace="nowrap">{item}</Tag>
+                </Link>
               </HStack>
             ))}
           </ProfileListItem>


### PR DESCRIPTION
# Wiki widget showing linked wikis


Before 

![image](https://user-images.githubusercontent.com/75235148/214316210-c9c43c51-af5f-4cfa-92be-32834259be74.png)
![image](https://user-images.githubusercontent.com/75235148/214568575-e65f1d6e-8914-4adf-8976-206aa320228a.png)


After 
![image](https://user-images.githubusercontent.com/75235148/214315850-669467d7-eb32-4d5f-b1ef-cd01aa373b02.png)
![image](https://user-images.githubusercontent.com/75235148/214568426-d16b3899-9add-46a9-bfbd-d2ac21d71330.png)

Preview link : https://iq-wiki-git-wiki-widget-prediqt.vercel.app/wiki/bored-ape-yacht-club

## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/975
