### PR TITLE
Removes background color behind token image on calculator widget

### DIFF
--- a/src/components/Wiki/WikiPage/InsightComponents/CurrencyConverter.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/CurrencyConverter.tsx
@@ -36,7 +36,6 @@ const CurrencyBox = ({
             imgH={18}
             imgW={18}
             alt={token}
-            bgColor={`hsl(${Math.floor(Math.random() * 360)}, 70%, 80%)`}
             borderRadius="100px"
           />
         ) : (


### PR DESCRIPTION
# Changes
- Removes background color behind token image on calculator widget

# Screenshot
### Before
![CleanShot 2023-01-28 at 07 35 09@2x](https://user-images.githubusercontent.com/52039218/215236549-1a3c3120-801d-44f7-bc7f-67e0f39b1311.png)

### After
![CleanShot 2023-01-28 at 07 34 49@2x](https://user-images.githubusercontent.com/52039218/215236596-c7d46f18-d12e-4304-92af-ce63206df0b2.png)

