### PR TITLE
fixes incorrect numbering on rank page

### DIFF
--- a/src/pages/rank/index.tsx
+++ b/src/pages/rank/index.tsx
@@ -41,8 +41,8 @@ const Rank = ({
   const [nftCount, setNftCount] = useState<number>(0)
 
   useEffect(() => {
-    setTokenCount(tokensOffset * 10 - 10)
-    setNftCount(nftOffset * 10 - 10)
+    setTokenCount(tokensOffset * 20 - 20)
+    setNftCount(nftOffset * 20 - 20)
   }, [nftOffset, tokensOffset])
 
   const { data: tokensObject, isFetching } = useGetTokenRankingQuery({

--- a/src/pages/rank/index.tsx
+++ b/src/pages/rank/index.tsx
@@ -41,8 +41,8 @@ const Rank = ({
   const [nftCount, setNftCount] = useState<number>(0)
 
   useEffect(() => {
-    setTokenCount(tokensOffset * 20 - 20)
-    setNftCount(nftOffset * 20 - 20)
+    setTokenCount(tokensOffset * LISTING_LIMITS - LISTING_LIMITS)
+    setNftCount(nftOffset * LISTING_LIMITS - LISTING_LIMITS)
   }, [nftOffset, tokensOffset])
 
   const { data: tokensObject, isFetching } = useGetTokenRankingQuery({


### PR DESCRIPTION
fixes incorrect numbering on rank page

Before:

https://user-images.githubusercontent.com/32770520/215434554-2a9bd471-1f90-42c9-a2eb-0a563011a5a6.png


Now:

![localhost_4000_rank (1)](https://user-images.githubusercontent.com/66301634/215514064-ef1efa38-4ad1-4153-9ccd-23acf0249402.png)

![localhost_4000_rank (2)](https://user-images.githubusercontent.com/66301634/215514148-a2ab941f-7eb0-45d2-be78-110724dfa547.png)


fixes https://github.com/EveripediaNetwork/issues/issues/991