### PR TITLE
Weird Zero in new wikis solved

### DIFF
--- a/src/components/Wiki/WikiPage/InsightComponents/WikiDetails.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/WikiDetails.tsx
@@ -48,6 +48,7 @@ export const WikiDetails = ({
 }) => {
   const { title, tags } = wikiTitle
   const [, username] = useENSData(createdBy?.id || '')
+  const wikiViews = views !== undefined && views > 250 ? views : undefined
   return (
     <Box borderWidth="1px" p={4} borderRadius={8} w="full">
       <Stack
@@ -133,6 +134,7 @@ export const WikiDetails = ({
                     </Td>
                   </Tr>
                 )}
+
                 <Tr>
                   <Td>
                     <HStack spacing={3} py="2">
@@ -201,6 +203,7 @@ export const WikiDetails = ({
                         <Link
                           href={`/account/${createdBy.id}`}
                           color="brandLinkColor"
+                          prefetch={false}
                         >
                           {getUsername(createdBy, username)}
                         </Link>
@@ -208,7 +211,7 @@ export const WikiDetails = ({
                     </Td>
                   </Tr>
                 )}
-                {views && views > 250 && (
+                {wikiViews && (
                   <Tr>
                     <Td whiteSpace="nowrap">
                       <Text py="2">Views</Text>


### PR DESCRIPTION
# Weird Zero in new wikis solved

## How should this be tested?

This can be tested by creating new wikis 

After checking the code well i noticed that using **'views && views > 250 && (<>...</> )'**  gives a type of boolean| 0 | undefined and since new wikis have 0 views then it shows 0,

![image](https://user-images.githubusercontent.com/75235148/215692527-41fcfab3-9012-4966-b7ae-e79a0e7923fe.png)


## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/988
