### PR TITLE
Fixes resize image based on placeholder

### DIFF
--- a/src/components/About/AboutHero.tsx
+++ b/src/components/About/AboutHero.tsx
@@ -41,8 +41,7 @@ const AboutHero = () => {
       <Box>
         <Image
           objectFit="contain"
-          imgH={450}
-          imgW={450}
+          imgBoxSize={450}
           maxW="90vw"
           className="teamMember__image"
           src={`/images/${aboutHeroSrc}`}

--- a/src/components/About/BlogCard.tsx
+++ b/src/components/About/BlogCard.tsx
@@ -27,6 +27,7 @@ const BlogCard = ({
       >
         <Box h="210px" mt={-6} mx={-6} mb={6} pos="relative">
           <Image
+            w="full"
             src={image}
             alt={title}
             layout="fill"

--- a/src/components/About/BlogCard.tsx
+++ b/src/components/About/BlogCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import Image from 'next/image'
+import { IMAGE_BOX_SIZE } from '@/data/Constants'
 import { Box, Center, Text, Stack } from '@chakra-ui/react'
+import { Image } from '../Elements/Image/Image'
 
 const BlogCard = ({
   image,
@@ -25,7 +26,13 @@ const BlogCard = ({
         overflow="hidden"
       >
         <Box h="210px" mt={-6} mx={-6} mb={6} pos="relative">
-          <Image src={image} alt={title} layout="fill" />
+          <Image
+            src={image}
+            alt={title}
+            layout="fill"
+            imgH={IMAGE_BOX_SIZE}
+            imgW={IMAGE_BOX_SIZE}
+          />
         </Box>
         <Stack>
           <Text color="gray.400" fontSize="sm">

--- a/src/components/About/BlogCard.tsx
+++ b/src/components/About/BlogCard.tsx
@@ -30,8 +30,7 @@ const BlogCard = ({
             src={image}
             alt={title}
             layout="fill"
-            imgH={IMAGE_BOX_SIZE}
-            imgW={IMAGE_BOX_SIZE}
+            imgBoxSize={IMAGE_BOX_SIZE}
           />
         </Box>
         <Stack>

--- a/src/components/About/BlogCard.tsx
+++ b/src/components/About/BlogCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { IMAGE_BOX_SIZE } from '@/data/Constants'
+import { IMAGE_BOX_SIZE, WIKI_IMAGE_ASPECT_RATIO } from '@/data/Constants'
 import { Box, Center, Text, Stack } from '@chakra-ui/react'
 import { Image } from '../Elements/Image/Image'
 
@@ -31,7 +31,8 @@ const BlogCard = ({
             src={image}
             alt={title}
             layout="fill"
-            imgBoxSize={IMAGE_BOX_SIZE}
+            imgH={IMAGE_BOX_SIZE}
+            imgW={IMAGE_BOX_SIZE * WIKI_IMAGE_ASPECT_RATIO}
           />
         </Box>
         <Stack>

--- a/src/components/Activity/ActivityCard.tsx
+++ b/src/components/Activity/ActivityCard.tsx
@@ -85,8 +85,7 @@ const ActivityCard = ({
             borderRadius="lg"
             overflow="hidden"
             alt={title}
-            imgW={IMAGE_BOX_SIZE}
-            imgH={IMAGE_BOX_SIZE}
+            imgBoxSize={IMAGE_BOX_SIZE}
           />
         </AspectRatio>
       </Link>

--- a/src/components/Activity/ActivityCard.tsx
+++ b/src/components/Activity/ActivityCard.tsx
@@ -10,7 +10,6 @@ import {
   AspectRatio,
   Wrap,
 } from '@chakra-ui/react'
-import { WikiImage } from '@/components/WikiImage'
 import { getWikiImageUrl } from '@/utils/getWikiImageUrl'
 import { BaseCategory, BaseTag, Image, User } from '@everipedia/iq-utils'
 import { getReadableDate } from '@/utils/getFormattedDate'
@@ -20,6 +19,7 @@ import { WIKI_IMAGE_ASPECT_RATIO } from '@/data/Constants'
 import DisplayAvatar from '../Elements/Avatar/DisplayAvatar'
 import { Link } from '../Elements'
 import { LinkWrapper } from '../Elements/LinkElements/LinkWrapper'
+import { Image as ActivityImage } from '../Elements/Image/Image'
 
 interface ActivityCardProps {
   title: string
@@ -76,10 +76,10 @@ const ActivityCard = ({
             lg: '156px',
           }}
         >
-          <WikiImage
+          <ActivityImage
             cursor="pointer"
             flexShrink={0}
-            imageURL={getWikiImageUrl(WikiImgObj)}
+            src={getWikiImageUrl(WikiImgObj)}
             borderRadius="lg"
             overflow="hidden"
             alt={title}

--- a/src/components/Activity/ActivityCard.tsx
+++ b/src/components/Activity/ActivityCard.tsx
@@ -15,13 +15,11 @@ import { BaseCategory, BaseTag, Image, User } from '@everipedia/iq-utils'
 import { getReadableDate } from '@/utils/getFormattedDate'
 import { useRouter } from 'next/router'
 import { getUsername } from '@/utils/getUsername'
-import { WIKI_IMAGE_ASPECT_RATIO } from '@/data/Constants'
+import { IMAGE_BOX_SIZE, WIKI_IMAGE_ASPECT_RATIO } from '@/data/Constants'
 import DisplayAvatar from '../Elements/Avatar/DisplayAvatar'
 import { Link } from '../Elements'
 import { LinkWrapper } from '../Elements/LinkElements/LinkWrapper'
 import { Image as ActivityImage } from '../Elements/Image/Image'
-
-const ACTIVITY_IMAGE_BOX_SIZE = 156
 
 interface ActivityCardProps {
   title: string
@@ -86,8 +84,8 @@ const ActivityCard = ({
             borderRadius="lg"
             overflow="hidden"
             alt={title}
-            imgW={ACTIVITY_IMAGE_BOX_SIZE}
-            imgH={ACTIVITY_IMAGE_BOX_SIZE}
+            imgW={IMAGE_BOX_SIZE}
+            imgH={IMAGE_BOX_SIZE}
           />
         </AspectRatio>
       </Link>

--- a/src/components/Activity/ActivityCard.tsx
+++ b/src/components/Activity/ActivityCard.tsx
@@ -21,6 +21,8 @@ import { Link } from '../Elements'
 import { LinkWrapper } from '../Elements/LinkElements/LinkWrapper'
 import { Image as ActivityImage } from '../Elements/Image/Image'
 
+const ACTIVITY_IMAGE_BOX_SIZE = 156
+
 interface ActivityCardProps {
   title: string
   brief: string
@@ -77,12 +79,15 @@ const ActivityCard = ({
           }}
         >
           <ActivityImage
+            boxSize="100%"
             cursor="pointer"
             flexShrink={0}
             src={getWikiImageUrl(WikiImgObj)}
             borderRadius="lg"
             overflow="hidden"
             alt={title}
+            imgW={ACTIVITY_IMAGE_BOX_SIZE}
+            imgH={ACTIVITY_IMAGE_BOX_SIZE}
           />
         </AspectRatio>
       </Link>

--- a/src/components/Blog/BlogPost.tsx
+++ b/src/components/Blog/BlogPost.tsx
@@ -4,6 +4,7 @@ import { Image } from '@/components/Elements/Image/Image'
 import { Blog } from '@/types/Blog'
 import { Avatar } from '@/components/Elements'
 import { useENSData } from '@/hooks/useENSData'
+import { IMAGE_BOX_SIZE } from '@/data/Constants'
 import LinkOverlay from '../Elements/LinkElements/LinkOverlay'
 
 type BlogPostType = {
@@ -27,7 +28,13 @@ export const BlogPost = ({ post, ...rest }: BlogPostType) => {
       {...rest}
     >
       {post.cover_image ? (
-        <Image h="52" src={post.cover_image} loading="lazy" alt={post.title} />
+        <Image
+          h="52"
+          src={post.cover_image}
+          loading="lazy"
+          alt={post.title}
+          imgBoxSize={IMAGE_BOX_SIZE}
+        />
       ) : null}
       <Flex h="fit-content" p="4" flexDir="column" flex="auto">
         <Flex flex="auto" align="center">

--- a/src/components/Blog/BlogPost.tsx
+++ b/src/components/Blog/BlogPost.tsx
@@ -33,6 +33,7 @@ export const BlogPost = ({ post, ...rest }: BlogPostType) => {
           src={post.cover_image}
           loading="lazy"
           alt={post.title}
+          width="full"
           imgBoxSize={IMAGE_BOX_SIZE}
         />
       ) : null}

--- a/src/components/Blog/BlogPost.tsx
+++ b/src/components/Blog/BlogPost.tsx
@@ -4,7 +4,7 @@ import { Image } from '@/components/Elements/Image/Image'
 import { Blog } from '@/types/Blog'
 import { Avatar } from '@/components/Elements'
 import { useENSData } from '@/hooks/useENSData'
-import { IMAGE_BOX_SIZE } from '@/data/Constants'
+import { IMAGE_BOX_SIZE, WIKI_IMAGE_ASPECT_RATIO } from '@/data/Constants'
 import LinkOverlay from '../Elements/LinkElements/LinkOverlay'
 
 type BlogPostType = {
@@ -34,7 +34,8 @@ export const BlogPost = ({ post, ...rest }: BlogPostType) => {
           loading="lazy"
           alt={post.title}
           width="full"
-          imgBoxSize={IMAGE_BOX_SIZE}
+          imgH={IMAGE_BOX_SIZE}
+          imgW={IMAGE_BOX_SIZE * WIKI_IMAGE_ASPECT_RATIO}
         />
       ) : null}
       <Flex h="fit-content" p="4" flexDir="column" flex="auto">

--- a/src/components/Categories/CategoryCard.tsx
+++ b/src/components/Categories/CategoryCard.tsx
@@ -8,7 +8,10 @@ import {
   LinkOverlay,
   Icon,
 } from '@chakra-ui/react'
-import { CATEGORY_DESCRIPTION_WORD_LIMIT } from '@/data/Constants'
+import {
+  CATEGORY_DESCRIPTION_WORD_LIMIT,
+  IMAGE_BOX_SIZE,
+} from '@/data/Constants'
 import { IconType } from 'react-icons'
 import { Image } from '../Elements/Image/Image'
 
@@ -45,6 +48,8 @@ const CategoryCard = ({
             height="150px"
             alt={title}
             loading="lazy"
+            imgH={IMAGE_BOX_SIZE}
+            imgW={IMAGE_BOX_SIZE}
           />
           <Box position="absolute" bottom="0" left="50%">
             <Icon
@@ -62,7 +67,6 @@ const CategoryCard = ({
             />
           </Box>
         </Box>
-
         <Box p={5}>
           <LinkOverlay href={`/categories/${categoryId}`}>
             <Heading textAlign="center" size="sm" my="10px">

--- a/src/components/Categories/CategoryCard.tsx
+++ b/src/components/Categories/CategoryCard.tsx
@@ -11,6 +11,7 @@ import {
 import {
   CATEGORY_DESCRIPTION_WORD_LIMIT,
   IMAGE_BOX_SIZE,
+  WIKI_IMAGE_ASPECT_RATIO,
 } from '@/data/Constants'
 import { IconType } from 'react-icons'
 import { Image } from '../Elements/Image/Image'
@@ -48,7 +49,8 @@ const CategoryCard = ({
             height="150px"
             alt={title}
             loading="lazy"
-            imgBoxSize={IMAGE_BOX_SIZE}
+            imgW={IMAGE_BOX_SIZE * WIKI_IMAGE_ASPECT_RATIO}
+            imgH={IMAGE_BOX_SIZE}
           />
           <Box position="absolute" bottom="0" left="50%">
             <Icon

--- a/src/components/Categories/CategoryCard.tsx
+++ b/src/components/Categories/CategoryCard.tsx
@@ -48,8 +48,7 @@ const CategoryCard = ({
             height="150px"
             alt={title}
             loading="lazy"
-            imgH={IMAGE_BOX_SIZE}
-            imgW={IMAGE_BOX_SIZE}
+            imgBoxSize={IMAGE_BOX_SIZE}
           />
           <Box position="absolute" bottom="0" left="50%">
             <Icon

--- a/src/components/Elements/Avatar/DisplayAvatar.tsx
+++ b/src/components/Elements/Avatar/DisplayAvatar.tsx
@@ -51,8 +51,7 @@ const DisplayAvatar = ({
   if (avatarIPFS || fetchedAvatarIPFS) {
     content = (
       <Image
-        imgH={size}
-        imgW={size}
+        imgBoxSize={size}
         src={`${config.pinataBaseUrl}${avatarIPFS || fetchedAvatarIPFS}`}
         borderRadius="full"
         {...(rest as Omit<NextChakraImageProps, 'src'>)}

--- a/src/components/Elements/Image/Image.tsx
+++ b/src/components/Elements/Image/Image.tsx
@@ -4,8 +4,7 @@ import NextImage, { ImageProps } from 'next/image'
 
 export type NextChakraImageProps = Omit<Omit<BoxProps, 'as'>, 'objectFit'> &
   Omit<Omit<ImageProps, 'width'>, 'height'> & {
-    imgW?: number
-    imgH?: number
+    imgBoxSize?: number
     hideOnError?: boolean
     objectFit?: 'cover' | 'contain' | 'fill' | 'none' | 'scale-down'
   }
@@ -13,19 +12,18 @@ export type NextChakraImageProps = Omit<Omit<BoxProps, 'as'>, 'objectFit'> &
 export const Image = ({
   src,
   alt,
-  imgW,
-  imgH,
   priority,
   placeholder,
   blurDataURL,
   hideOnError,
   sizes,
   objectFit = 'cover',
+  imgBoxSize,
   ...rest
 }: NextChakraImageProps) => (
   <Box
-    h={`${imgH}px`}
-    w={`${imgW}px`}
+    h={`${imgBoxSize}px`}
+    w={`${imgBoxSize}px`}
     {...rest}
     overflow="hidden"
     position="relative"
@@ -38,7 +36,7 @@ export const Image = ({
         width: '100%',
         height: '100%',
       }}
-      fill={!(imgW && imgH)}
+      fill={!imgBoxSize}
       src={src}
       alt={alt}
       onError={e => {
@@ -51,8 +49,8 @@ export const Image = ({
       placeholder={placeholder}
       blurDataURL={blurDataURL}
       loading={priority ? 'eager' : 'lazy'}
-      width={imgW}
-      height={imgH}
+      width={imgBoxSize}
+      height={imgBoxSize}
     />
   </Box>
 )

--- a/src/components/Elements/Image/Image.tsx
+++ b/src/components/Elements/Image/Image.tsx
@@ -4,6 +4,8 @@ import NextImage, { ImageProps } from 'next/image'
 
 export type NextChakraImageProps = Omit<Omit<BoxProps, 'as'>, 'objectFit'> &
   Omit<Omit<ImageProps, 'width'>, 'height'> & {
+    imgW?: number
+    imgH?: number
     imgBoxSize?: number
     hideOnError?: boolean
     objectFit?: 'cover' | 'contain' | 'fill' | 'none' | 'scale-down'
@@ -19,11 +21,13 @@ export const Image = ({
   sizes,
   objectFit = 'cover',
   imgBoxSize,
+  imgW,
+  imgH,
   ...rest
 }: NextChakraImageProps) => (
   <Box
-    h={`${imgBoxSize}px`}
-    w={`${imgBoxSize}px`}
+    h={`${imgBoxSize || imgH}px`}
+    w={`${imgBoxSize || imgW}px`}
     {...rest}
     overflow="hidden"
     position="relative"
@@ -36,7 +40,7 @@ export const Image = ({
         width: '100%',
         height: '100%',
       }}
-      fill={!imgBoxSize}
+      fill={!(imgW && imgH) || !imgBoxSize}
       src={src}
       alt={alt}
       onError={e => {
@@ -49,8 +53,8 @@ export const Image = ({
       placeholder={placeholder}
       blurDataURL={blurDataURL}
       loading={priority ? 'eager' : 'lazy'}
-      width={imgBoxSize}
-      height={imgBoxSize}
+      width={imgBoxSize || imgW}
+      height={imgBoxSize || imgH}
     />
   </Box>
 )

--- a/src/components/Landing/CategoriesList.tsx
+++ b/src/components/Landing/CategoriesList.tsx
@@ -13,6 +13,8 @@ import { useTranslation } from 'react-i18next'
 import { Category } from '@/types/CategoryDataTypes'
 import LinkOverlay from '../Elements/LinkElements/LinkOverlay'
 
+const CATEGORY_IMAGE_BOX_SIZE = 300
+
 interface CategoriesListProps {
   categories: Category[]
 }
@@ -66,8 +68,9 @@ const CategoriesList = ({ categories }: CategoriesListProps) => {
                   h="200px"
                   w="100%"
                   alt={category.title}
+                  imgH={CATEGORY_IMAGE_BOX_SIZE}
+                  imgW={CATEGORY_IMAGE_BOX_SIZE}
                 />
-
                 <Text
                   py="4"
                   w="100%"

--- a/src/components/Landing/CategoriesList.tsx
+++ b/src/components/Landing/CategoriesList.tsx
@@ -11,6 +11,7 @@ import {
 import { Image } from '@/components/Elements/Image/Image'
 import { useTranslation } from 'react-i18next'
 import { Category } from '@/types/CategoryDataTypes'
+import { WIKI_IMAGE_ASPECT_RATIO } from '@/data/Constants'
 import LinkOverlay from '../Elements/LinkElements/LinkOverlay'
 
 const CATEGORY_IMAGE_BOX_SIZE = 300
@@ -68,7 +69,8 @@ const CategoriesList = ({ categories }: CategoriesListProps) => {
                   h="200px"
                   w="100%"
                   alt={category.title}
-                  imgBoxSize={CATEGORY_IMAGE_BOX_SIZE}
+                  imgW={CATEGORY_IMAGE_BOX_SIZE * WIKI_IMAGE_ASPECT_RATIO}
+                  imgH={CATEGORY_IMAGE_BOX_SIZE}
                 />
                 <Text
                   py="4"

--- a/src/components/Landing/CategoriesList.tsx
+++ b/src/components/Landing/CategoriesList.tsx
@@ -68,8 +68,7 @@ const CategoriesList = ({ categories }: CategoriesListProps) => {
                   h="200px"
                   w="100%"
                   alt={category.title}
-                  imgH={CATEGORY_IMAGE_BOX_SIZE}
-                  imgW={CATEGORY_IMAGE_BOX_SIZE}
+                  imgBoxSize={CATEGORY_IMAGE_BOX_SIZE}
                 />
                 <Text
                   py="4"

--- a/src/components/Landing/HeroCard.tsx
+++ b/src/components/Landing/HeroCard.tsx
@@ -39,8 +39,7 @@ export const HeroCard = ({ wiki }: { wiki: Wiki | undefined }) => {
             borderRadius="none"
             roundedTop="lg"
             overflow="hidden"
-            imgH={HERO_WIKI_IMG_WIDTH}
-            imgW={WIKI_IMAGE_ASPECT_RATIO * HERO_WIKI_IMG_WIDTH}
+            imgBoxSize={HERO_WIKI_IMG_WIDTH}
             priority
             alt={wiki?.title || 'wiki'}
           />

--- a/src/components/Landing/TrendingCard.tsx
+++ b/src/components/Landing/TrendingCard.tsx
@@ -77,8 +77,7 @@ const TrendingCard = ({
                         alt={wiki.title}
                         borderRadius="md"
                         overflow="hidden"
-                        imgH={IMAGE_BOX_SIZE}
-                        imgW={IMAGE_BOX_SIZE}
+                        imgBoxSize={IMAGE_BOX_SIZE}
                       />
                     </AspectRatio>
                   </Link>

--- a/src/components/Landing/TrendingCard.tsx
+++ b/src/components/Landing/TrendingCard.tsx
@@ -13,11 +13,11 @@ import { Wiki } from '@everipedia/iq-utils'
 import { getWikiImageUrl } from '@/utils/getWikiImageUrl'
 import router from 'next/router'
 import { IconType } from 'react-icons/lib'
-import { WIKI_IMAGE_ASPECT_RATIO } from '@/data/Constants'
+import { IMAGE_BOX_SIZE, WIKI_IMAGE_ASPECT_RATIO } from '@/data/Constants'
 import { shortenText } from '@/utils/shortenText'
 import { Link } from '../Elements'
 import { TrendingSkeleton } from './LoadingTrendingWikis'
-import { WikiImage } from '../WikiImage'
+import { Image } from '../Elements/Image/Image'
 
 const TrendingCard = ({
   wikis = [],
@@ -72,11 +72,13 @@ const TrendingCard = ({
                         lg: '70px',
                       }}
                     >
-                      <WikiImage
-                        imageURL={getWikiImageUrl(wiki.images)}
+                      <Image
+                        src={getWikiImageUrl(wiki.images)}
                         alt={wiki.title}
                         borderRadius="md"
                         overflow="hidden"
+                        imgH={IMAGE_BOX_SIZE}
+                        imgW={IMAGE_BOX_SIZE}
                       />
                     </AspectRatio>
                   </Link>

--- a/src/components/Landing/TrendingCard.tsx
+++ b/src/components/Landing/TrendingCard.tsx
@@ -29,15 +29,12 @@ const TrendingCard = ({
   icon: IconType
 }) => {
   return (
-    <Flex
-      py="1"
-      minH={{ md: '400px', xl: '440px' }}
-      maxW={{ base: 'min(90vw, 400px)', md: '96', lg: '392' }}
-    >
+    <Flex py="1" maxW={{ base: 'min(90vw, 400px)', md: '96', lg: '392' }}>
       <Box
         w="full"
         rounded="lg"
         shadow="lg"
+        minH="500px"
         py={3}
         bg="white"
         _dark={{ bgColor: 'gray.700', color: 'white' }}
@@ -55,7 +52,7 @@ const TrendingCard = ({
           </Text>
         </chakra.div>
         {wikis ? (
-          <VStack w="full" pt="2" px="2" gap="5" overflow="hidden">
+          <VStack w="full" pt="2" px="2" gap="4" overflow="hidden">
             {wikis.map((wiki, i) => (
               <HStack w="full" key={i}>
                 <chakra.span minW="2" alignSelf="center">
@@ -98,7 +95,6 @@ const TrendingCard = ({
                     >
                       {shortenText(wiki.title, 24)}
                     </Text>
-
                     <Text
                       display={{ base: 'none', md: '-webkit-box' }}
                       noOfLines={2}

--- a/src/components/Landing/TrendingCard.tsx
+++ b/src/components/Landing/TrendingCard.tsx
@@ -77,7 +77,8 @@ const TrendingCard = ({
                         alt={wiki.title}
                         borderRadius="md"
                         overflow="hidden"
-                        imgBoxSize={IMAGE_BOX_SIZE}
+                        imgW={IMAGE_BOX_SIZE * WIKI_IMAGE_ASPECT_RATIO}
+                        imgH={IMAGE_BOX_SIZE}
                       />
                     </AspectRatio>
                   </Link>

--- a/src/components/Landing/TrendingWikis.tsx
+++ b/src/components/Landing/TrendingWikis.tsx
@@ -54,7 +54,7 @@ const TrendingWikiCard = ({ wiki }: { wiki: Wiki }) => {
         >
           <AspectRatio
             ratio={WIKI_IMAGE_ASPECT_RATIO}
-            h={{ base: '205px', md: '200px' }}
+            h={{ base: '250px', md: '250px' }}
           >
             <Image
               src={getWikiImageUrl(wiki.images)}
@@ -163,6 +163,7 @@ const TrendingWikis = ({
         mx="auto"
         flexWrap="wrap"
         gap={4}
+        minH="500px"
       >
         <TrendingCard
           title="Trending Wikis"
@@ -170,7 +171,7 @@ const TrendingWikis = ({
           wikis={drops}
         />
         <TrendingCard title="Recent Edits" icon={RiTimeFill} wikis={recent} />
-        <Flex pt="1" minH={{ base: '418px', lg: '425px', xl: '440px' }}>
+        <Flex pt="1" minH="500px">
           <Box
             maxW={{ base: 'min(90vw, 400px)', md: '96', lg: '392' }}
             w="full"
@@ -210,7 +211,6 @@ const TrendingWikis = ({
                   speed: 500,
                   slidesToShow: 1,
                   slidesToScroll: 1,
-
                   responsive: [
                     {
                       breakpoint: 1000,
@@ -236,7 +236,7 @@ const TrendingWikis = ({
                 }}
               >
                 {featuredWikis.map(wiki => (
-                  <Box px="3" pt="3" pb={{ md: '0', xl: '3' }}>
+                  <Box px="3" pt="3" pb="3">
                     <TrendingWikiCard key={`wiki-${wiki.id}`} wiki={wiki} />
                   </Box>
                 ))}

--- a/src/components/Landing/TrendingWikis.tsx
+++ b/src/components/Landing/TrendingWikis.tsx
@@ -18,12 +18,12 @@ import { useENSData } from '@/hooks/useENSData'
 import { getReadableDate } from '@/utils/getFormattedDate'
 import { getUsername } from '@/utils/getUsername'
 import { WikiSummarySize, getWikiSummary } from '@/utils/getWikiSummary'
-import { WIKI_IMAGE_ASPECT_RATIO } from '@/data/Constants'
+import { IMAGE_BOX_SIZE, WIKI_IMAGE_ASPECT_RATIO } from '@/data/Constants'
 import { Carousel, Link } from '../Elements'
 import TrendingCard from './TrendingCard'
 import DisplayAvatar from '../Elements/Avatar/DisplayAvatar'
 import { LoadingTrendingWikiCard } from './LoadingTrendingWikis'
-import { WikiImage } from '../WikiImage'
+import { Image } from '../Elements/Image/Image'
 
 const TrendingWikiCard = ({ wiki }: { wiki: Wiki }) => {
   const [, ensName] = useENSData(wiki.user.id)
@@ -56,12 +56,14 @@ const TrendingWikiCard = ({ wiki }: { wiki: Wiki }) => {
             ratio={WIKI_IMAGE_ASPECT_RATIO}
             h={{ base: '205px', md: '200px' }}
           >
-            <WikiImage
-              imageURL={getWikiImageUrl(wiki.images)}
+            <Image
+              src={getWikiImageUrl(wiki.images)}
               alt={wiki.title}
               borderTopRadius="md"
               overflow="hidden"
               objectFit="cover"
+              imgH={IMAGE_BOX_SIZE}
+              imgW={IMAGE_BOX_SIZE}
             />
           </AspectRatio>
           <Flex

--- a/src/components/Landing/TrendingWikis.tsx
+++ b/src/components/Landing/TrendingWikis.tsx
@@ -62,8 +62,7 @@ const TrendingWikiCard = ({ wiki }: { wiki: Wiki }) => {
               borderTopRadius="md"
               overflow="hidden"
               objectFit="cover"
-              imgH={IMAGE_BOX_SIZE}
-              imgW={IMAGE_BOX_SIZE}
+              imgBoxSize={IMAGE_BOX_SIZE}
             />
           </AspectRatio>
           <Flex

--- a/src/components/Landing/TrendingWikis.tsx
+++ b/src/components/Landing/TrendingWikis.tsx
@@ -62,7 +62,8 @@ const TrendingWikiCard = ({ wiki }: { wiki: Wiki }) => {
               borderTopRadius="md"
               overflow="hidden"
               objectFit="cover"
-              imgBoxSize={IMAGE_BOX_SIZE}
+              imgW={IMAGE_BOX_SIZE * WIKI_IMAGE_ASPECT_RATIO}
+              imgH={IMAGE_BOX_SIZE}
             />
           </AspectRatio>
           <Flex

--- a/src/components/Layout/Navbar/NavSearch/index.tsx
+++ b/src/components/Layout/Navbar/NavSearch/index.tsx
@@ -160,8 +160,7 @@ const NavSearch = (props: NavSearchProps) => {
             <WikiImage
               src={wikiImage}
               alt={wiki.title}
-              imgH={40}
-              imgW={WIKI_IMAGE_ASPECT_RATIO * 40}
+              imgBoxSize={WIKI_IMAGE_ASPECT_RATIO * 40}
               flexShrink={0}
               borderRadius={5}
               overflow="hidden"

--- a/src/components/Settings/ImageUpload.tsx
+++ b/src/components/Settings/ImageUpload.tsx
@@ -1,4 +1,5 @@
 import config from '@/config'
+import { IMAGE_BOX_SIZE } from '@/data/Constants'
 import { saveImage } from '@/utils/create-wiki'
 import { Box, Spinner, useToast } from '@chakra-ui/react'
 import React, { memo, useRef } from 'react'
@@ -78,6 +79,8 @@ const ImageUpload = ({
           overflow="hidden"
           bgColor="rgba(130, 130, 130, 0.49)"
           position="relative"
+          imgH={IMAGE_BOX_SIZE}
+          imgW={IMAGE_BOX_SIZE}
           _hover={
             isLoading
               ? { cursor: 'not-allowed' }

--- a/src/components/Settings/ImageUpload.tsx
+++ b/src/components/Settings/ImageUpload.tsx
@@ -79,8 +79,7 @@ const ImageUpload = ({
           overflow="hidden"
           bgColor="rgba(130, 130, 130, 0.49)"
           position="relative"
-          imgH={IMAGE_BOX_SIZE}
-          imgW={IMAGE_BOX_SIZE}
+          imgBoxSize={IMAGE_BOX_SIZE}
           _hover={
             isLoading
               ? { cursor: 'not-allowed' }

--- a/src/components/Settings/Notification/SearchWikiNotifications.tsx
+++ b/src/components/Settings/Notification/SearchWikiNotifications.tsx
@@ -184,8 +184,7 @@ const SearchWikiNotifications = () => {
           <WikiImage
             src={articleImage}
             alt={wiki.title}
-            imgH={40}
-            imgW={40 * WIKI_IMAGE_ASPECT_RATIO}
+            imgBoxSize={40 * WIKI_IMAGE_ASPECT_RATIO}
             flexShrink={0}
             borderRadius={5}
             overflow="hidden"

--- a/src/components/Wiki/WikiPage/InsightComponents/CurrencyConverter.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/CurrencyConverter.tsx
@@ -5,6 +5,8 @@ import { TokenStats } from '@/services/token-stats'
 import { Image } from '@/components/Elements/Image/Image'
 import config from '@/config'
 
+const CURRENCY_BOX_SIZE = 18
+
 const CurrencyBox = ({
   token,
   tokenImage,
@@ -33,20 +35,17 @@ const CurrencyBox = ({
         {token ? (
           <Image
             src={tokenImageSrc}
-            imgH={18}
-            imgW={18}
+            imgBoxSize={CURRENCY_BOX_SIZE}
             alt={token}
             borderRadius="100px"
           />
         ) : (
           <Image
             src="/images/usd-logo.svg"
-            imgH={18}
-            imgW={18}
+            imgBoxSize={CURRENCY_BOX_SIZE}
             alt={tokenSymbol}
           />
         )}
-
         <Text fontSize="14px">{tokenSymbol}</Text>
       </HStack>
       <Input

--- a/src/components/Wiki/WikiPage/InsightComponents/RelatedMedia.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/RelatedMedia.tsx
@@ -37,8 +37,7 @@ const RelatedMediaGrid = ({ media }: { media?: Media[] }) => {
                       : `https://i3.ytimg.com/vi/${m.name}/maxresdefault.jpg`
                   }
                   alt="related media"
-                  imgH={RELATED_MEDIA_IMAGE_BOX_SIZE}
-                  imgW={RELATED_MEDIA_IMAGE_BOX_SIZE}
+                  imgBoxSize={RELATED_MEDIA_IMAGE_BOX_SIZE}
                   hideOnError
                   objectFit="cover"
                   bgColor="fadedText2"

--- a/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
+++ b/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
@@ -11,7 +11,6 @@ import {
 } from '@chakra-ui/react'
 import { Wiki } from '@everipedia/iq-utils'
 import { getReadableDate } from '@/utils/getFormattedDate'
-import { WikiImage } from '@/components/WikiImage'
 import { getWikiImageUrl } from '@/utils/getWikiImageUrl'
 import DisplayAvatar from '@/components/Elements/Avatar/DisplayAvatar'
 import { useENSData } from '@/hooks/useENSData'
@@ -19,7 +18,8 @@ import { shortenText } from '@/utils/shortenText'
 import { getUsername } from '@/utils/getUsername'
 import { Link } from '@/components/Elements'
 import LinkOverlay from '@/components/Elements/LinkElements/LinkOverlay'
-import { WIKI_IMAGE_ASPECT_RATIO } from '@/data/Constants'
+import { IMAGE_BOX_SIZE, WIKI_IMAGE_ASPECT_RATIO } from '@/data/Constants'
+import { Image } from '@/components/Elements/Image/Image'
 
 const WikiPreviewCard = ({
   wiki,
@@ -52,7 +52,13 @@ const WikiPreviewCard = ({
       cursor="pointer"
     >
       <AspectRatio w="100%" ratio={WIKI_IMAGE_ASPECT_RATIO}>
-        <WikiImage imageURL={getWikiImageUrl(wiki.images)} alt={wiki.title} />
+        <Image
+          src={getWikiImageUrl(wiki.images)}
+          alt={wiki.title}
+          boxSize="100%"
+          imgH={IMAGE_BOX_SIZE}
+          imgW={IMAGE_BOX_SIZE}
+        />
       </AspectRatio>
       <Stack spacing={3} p={4}>
         <LinkOverlay href={`/wiki/${id}`}>

--- a/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
+++ b/src/components/Wiki/WikiPreviewCard/WikiPreviewCard.tsx
@@ -56,8 +56,7 @@ const WikiPreviewCard = ({
           src={getWikiImageUrl(wiki.images)}
           alt={wiki.title}
           boxSize="100%"
-          imgH={IMAGE_BOX_SIZE}
-          imgW={IMAGE_BOX_SIZE}
+          imgBoxSize={IMAGE_BOX_SIZE}
         />
       </AspectRatio>
       <Stack spacing={3} p={4}>

--- a/src/data/Constants.ts
+++ b/src/data/Constants.ts
@@ -9,3 +9,4 @@ export const WIKI_SUMMARY_GEN_RATE_LIMIT_INTERVAL = 30 * 60 * 1000 // 30 Mins
 export const WIKI_SUMMARY_GEN_RATE_LIMIT_MAX_REQUESTS = 5
 export const GPT3_COST_PER_1K_TOKENS = 0.02
 export const GPT3_MAX_TRIES = 3
+export const IMAGE_BOX_SIZE = 150

--- a/src/pages/branding/index.tsx
+++ b/src/pages/branding/index.tsx
@@ -150,8 +150,7 @@ const BrandingPage = () => {
           </Box>
           <Image
             objectFit="contain"
-            imgH={500}
-            imgW={500}
+            imgBoxSize={500}
             maxW="80vw"
             src={heroImg}
             alt="Bringing knowledge to the blockchain."
@@ -159,7 +158,6 @@ const BrandingPage = () => {
             mt={10}
           />
         </Flex>
-
         <Flex mt={{ base: '16', lg: '10' }} mx="auto" justifyContent="center">
           <Text
             position="relative"

--- a/src/pages/categories/index.tsx
+++ b/src/pages/categories/index.tsx
@@ -3,7 +3,6 @@ import { NextPage } from 'next'
 import { NextSeo } from 'next-seo'
 import { Divider, Box, Heading, SimpleGrid, Flex, Text } from '@chakra-ui/react'
 import CategoryCard from '@/components/Categories/CategoryCard'
-
 import { useTranslation } from 'react-i18next'
 import { AllCategoriesData } from '@/data/AllCategoriesData'
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -65,8 +65,8 @@ export const Index = ({
         bgImage="/images/homepage-bg-white.png"
       >
         <TrendingWikis
-          drops={promotedWikis && promotedWikis.slice(0, 4)}
-          recent={recentWikis && recentWikis.slice(0, 4)}
+          drops={promotedWikis && promotedWikis.slice(0, 5)}
+          recent={recentWikis && recentWikis.slice(0, 5)}
           featuredWikis={promotedWikis && promotedWikis}
         />
         <RankingList rankings={rankings} />


### PR DESCRIPTION
Fixes resize image based on placeholder

Changes:

Reduced image sizes on server.

Media:

<img width="1440" alt="Screen Shot 2023-02-01 at 1 32 40 PM" src="https://user-images.githubusercontent.com/66301634/216044894-ac432e5f-f8ff-404b-b8d6-e220a2526a3d.png">


fixes https://github.com/EveripediaNetwork/issues/issues/998
fixes https://github.com/EveripediaNetwork/issues/issues/1002