### PR TITLE
fixes Incorrect background image on User Profile

### DIFF
--- a/src/pages/account/[profile].tsx
+++ b/src/pages/account/[profile].tsx
@@ -50,10 +50,10 @@ const Profile = ({ profileData }: ProfileProps) => {
             width="full"
             height="56"
             objectFit="cover"
-            bgColor="creamCardBg"
-            backgroundImage="/images/backgrounds/homepage-bg-white.png"
+            bgColor="careersBackground"
+            bgImage="/images/backgrounds/homepage-bg-white.png"
             _dark={{
-              backgroundImage: '/images/backgrounds/homepage-bg-dark.png',
+              bgImage: '/images/backgrounds/careers-background-dark.png',
             }}
             hideOnError
             src={`${config.pinataBaseUrl}${profileData?.banner}`}


### PR DESCRIPTION
fixes Incorrect background image on User Profile

BEFORE:

https://user-images.githubusercontent.com/32770520/218441644-d01a3ebf-3dad-4c49-b0dd-5283fcdd308a.png

NOW:

<img width="1440" alt="Screen Shot 2023-02-13 at 10 55 23 PM" src="https://user-images.githubusercontent.com/66301634/218583504-1f0158b2-525e-49f4-b7ca-69db427f460b.png">


fixes https://github.com/EveripediaNetwork/issues/issues/1038
