### PR TITLE
Fixes commit message box not showing for edited wikis

### DIFF
--- a/src/components/CreateWiki/CreateWikiTopBar/WikiPublish/WikiPublishButton.tsx
+++ b/src/components/CreateWiki/CreateWikiTopBar/WikiPublish/WikiPublishButton.tsx
@@ -225,7 +225,7 @@ export const WikiPublishButton = () => {
         label="Your address is not yet whitelisted"
         mt="3"
       >
-        {isNewCreateWiki ? (
+        {!isNewCreateWiki ? (
           <PublishWithCommitMessage
             handleWikiPublish={() => handleWikiPublish()}
             isPublishDisabled={isPublishDisabled}


### PR DESCRIPTION
<img width="956" alt="CleanShot 2023-02-14 at 20 36 52@2x" src="https://user-images.githubusercontent.com/52039218/218777325-248659d7-38f2-4e8e-9bd5-47e8b49da55d.png">
