### PR TITLE
Add api call for address conversion

### DIFF
--- a/src/pages/api/address-to-wiki.ts
+++ b/src/pages/api/address-to-wiki.ts
@@ -1,0 +1,25 @@
+/* eslint-disable consistent-return */
+import { addressToWiki } from '@/services/address-to-wiki'
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+interface AddressToWikiRes {
+  addressToWiki: {
+    wiki: string
+  }[]
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const { address } = req.query
+
+  try {
+    const ress = (await addressToWiki(address as string)) as AddressToWikiRes
+    if (ress) {
+      return res.status(200).json(ress.addressToWiki.map(w => w.wiki))
+    }
+  } catch (e) {
+    return res.status(500).json({ error: 'an error occurred' })
+  }
+}

--- a/src/services/address-to-wiki/index.ts
+++ b/src/services/address-to-wiki/index.ts
@@ -1,0 +1,7 @@
+import { request } from 'graphql-request'
+import { GET_ADDRESS_TO_WIKI } from './queries'
+
+const link = process.env.NEXT_PUBLIC_EP_API || ''
+
+export const addressToWiki = async (arg: string) =>
+  request(link, GET_ADDRESS_TO_WIKI, { address: arg })

--- a/src/services/address-to-wiki/queries.ts
+++ b/src/services/address-to-wiki/queries.ts
@@ -1,0 +1,9 @@
+import { gql } from 'graphql-request'
+
+export const GET_ADDRESS_TO_WIKI = gql`
+  query addressToWiki($address: String!) {
+    addressToWiki(address: $address) {
+      wiki
+    }
+  }
+`


### PR DESCRIPTION
# Get wiki link of address

_A crypto address are passed as a a param into the UI `api/address-to-wiki` like`/api/address-to-wiki?address=0x1f9840a85d5af5bf1d1762f925bdaddc4201f984` and then the request scans for wikis that have the contract/token address, builds a wiki link to that address and returns it JSON format_

## How should this be tested?

1. <img width="916" alt="image" src="https://user-images.githubusercontent.com/67957533/219649876-2a4a4bd3-a40b-4787-9b2c-a8d0be9788f6.png">


## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/1039
