### PR TITLE
fixes  dapp icon

### DIFF
--- a/src/data/NavItemData.ts
+++ b/src/data/NavItemData.ts
@@ -15,9 +15,9 @@ import {
   RiBook2Fill,
   RiTeamFill,
   RiUserSearchFill,
-  RiAppStoreFill,
   RiNumbersFill,
   RiGroup2Fill,
+  RiCopperCoinLine,
 } from 'react-icons/ri'
 import { NavItem } from '@/types/NavItemType'
 
@@ -73,7 +73,7 @@ export const NAV_ITEMS: NavItem[] = [
       {
         id: 107,
         label: 'Dapps',
-        icon: RiAppStoreFill,
+        icon: RiCopperCoinLine,
         href: '/categories/dapps',
         hasImage: true,
       },

--- a/src/data/NavItemData.ts
+++ b/src/data/NavItemData.ts
@@ -17,7 +17,7 @@ import {
   RiUserSearchFill,
   RiNumbersFill,
   RiGroup2Fill,
-  RiCopperCoinLine,
+  RiCopperDiamondLine,
 } from 'react-icons/ri'
 import { NavItem } from '@/types/NavItemType'
 
@@ -73,7 +73,7 @@ export const NAV_ITEMS: NavItem[] = [
       {
         id: 107,
         label: 'Dapps',
-        icon: RiCopperCoinLine,
+        icon: RiCopperDiamondLine,
         href: '/categories/dapps',
         hasImage: true,
       },


### PR DESCRIPTION
fixes dapp category icon

Screenshots:

Before:

<img width="248" alt="Screen Shot 2023-02-21 at 3 56 45 PM" src="https://user-images.githubusercontent.com/66301634/220379646-addf8dc8-d061-48b8-8826-5c67ce9b9c04.png">


Now:
<img width="240" alt="Screen Shot 2023-02-21 at 3 55 30 PM" src="https://user-images.githubusercontent.com/66301634/220379481-4189d737-1c3d-424f-8ef8-84198ec5faeb.png">

closes https://github.com/EveripediaNetwork/issues/issues/1054
