### PR TITLE
fixes divider on categories from gray 300 to gray 500

### DIFF
--- a/src/pages/categories/[category].tsx
+++ b/src/pages/categories/[category].tsx
@@ -103,9 +103,9 @@ const CategoryPage = ({
           newWikis={newWikis}
         />
         <Divider
-          opacity="1 !important"
-          bgColor="gray.500"
-          _dark={{ bgColor: 'whiteAlpha.200' }}
+          opacity="1"
+          borderColor="gray.300"
+          _dark={{ boderColor: 'whiteAlpha.200' }}
         />
         <Box mt={10}>
           {wikisInCategory.length > 0 ? (

--- a/src/pages/categories/[category].tsx
+++ b/src/pages/categories/[category].tsx
@@ -102,7 +102,11 @@ const CategoryPage = ({
           trending={trending}
           newWikis={newWikis}
         />
-        <Divider bgColor="gray.300" _dark={{ bgColor: 'whiteAlpha.200' }} />
+        <Divider
+          opacity="1 !important"
+          bgColor="gray.500"
+          _dark={{ bgColor: 'whiteAlpha.200' }}
+        />
         <Box mt={10}>
           {wikisInCategory.length > 0 ? (
             <>


### PR DESCRIPTION
Before:

<img width="1440" alt="Screen Shot 2023-02-21 at 7 34 04 PM" src="https://user-images.githubusercontent.com/66301634/220430135-a0242246-e365-49a2-a3ab-dba013ffc968.png">

Now:

<img width="1440" alt="Screen Shot 2023-02-21 at 7 25 34 PM" src="https://user-images.githubusercontent.com/66301634/220430018-894e0597-badb-4431-9834-de9eb7dc60b9.png">

