### PR TITLE
Us career page

### DIFF
--- a/src/components/Careers/CareersCard.tsx
+++ b/src/components/Careers/CareersCard.tsx
@@ -41,11 +41,13 @@ const CareerCard = ({
       >
         {description}
       </Text>
-      <Flex mt={{ base: '4', md: '6' }} justifyContent="flex-end">
-        <Button as="a" href={link} target="_blank" size="lg" variant="solid">
-          Apply now
-        </Button>
-      </Flex>
+      {link && (
+        <Flex mt={{ base: '4', md: '6' }} justifyContent="flex-end">
+          <Button as="a" href={link} target="_blank" size="lg" variant="solid">
+            Apply now
+          </Button>
+        </Flex>
+      )}
     </Box>
   )
 }

--- a/src/components/Careers/CareersHero.tsx
+++ b/src/components/Careers/CareersHero.tsx
@@ -1,7 +1,13 @@
 import React from 'react'
 import { Box, Flex, Heading, Text } from '@chakra-ui/react'
 
-const CareersHero = ({title, description}: {title: string, description?: string}) => {
+const CareersHero = ({
+  title,
+  description,
+}: {
+  title: string
+  description?: string
+}) => {
   return (
     <Box
       my={-2}
@@ -24,19 +30,19 @@ const CareersHero = ({title, description}: {title: string, description?: string}
         >
           {title}
         </Heading>
-        {
-          description && <Text
-          color="careersTextColor"
-          textAlign="center"
-          mt={{ md: 3 }}
-          fontSize={{ '2xl': '2xl', md: 'xl', base: 'md' }}
-          px={{ base: '3', md: 0 }}
-        >
-          Do you wish to join our great team? we&apos;re looking for
-          Intellectual Individuals who are committed to doing well by doing
-          good. here is the list of our open positions.
-        </Text>
-        }
+        {description && (
+          <Text
+            color="careersTextColor"
+            textAlign="center"
+            mt={{ md: 3 }}
+            fontSize={{ '2xl': '2xl', md: 'xl', base: 'md' }}
+            px={{ base: '3', md: 0 }}
+          >
+            Do you wish to join our great team? we&apos;re looking for
+            Intellectual Individuals who are committed to doing well by doing
+            good. here is the list of our open positions.
+          </Text>
+        )}
       </Flex>
     </Box>
   )

--- a/src/components/Careers/CareersHero.tsx
+++ b/src/components/Careers/CareersHero.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Box, Flex, Heading, Text } from '@chakra-ui/react'
 
-const CareersHero = () => {
+const CareersHero = ({title, description}: {title: string, description?: string}) => {
   return (
     <Box
       my={-2}
@@ -22,9 +22,10 @@ const CareersHero = () => {
           fontSize={{ lg: '6xl', md: '4xl', base: '2xl', '2xl': '7xl' }}
           mb={{ base: 6, md: 0 }}
         >
-          IQ.Wiki Careers
+          {title}
         </Heading>
-        <Text
+        {
+          description && <Text
           color="careersTextColor"
           textAlign="center"
           mt={{ md: 3 }}
@@ -35,6 +36,7 @@ const CareersHero = () => {
           Intellectual Individuals who are committed to doing well by doing
           good. here is the list of our open positions.
         </Text>
+        }
       </Flex>
     </Box>
   )

--- a/src/components/Layout/Footer/MenuFooter.tsx
+++ b/src/components/Layout/Footer/MenuFooter.tsx
@@ -5,12 +5,10 @@ import {
   Heading,
   SimpleGrid,
   Stack,
-  Tag,
   Text,
 } from '@chakra-ui/react'
 import { Logo, Link } from '@/components/Elements'
 import { useTranslation } from 'react-i18next'
-import { AllCareers } from '@/data/CareersData'
 
 const MenuFooter = () => {
   const { t } = useTranslation()

--- a/src/components/Layout/Footer/MenuFooter.tsx
+++ b/src/components/Layout/Footer/MenuFooter.tsx
@@ -99,9 +99,9 @@ const MenuFooter = () => {
                   prefetch={false}
                   href="/careers"
                 >
-                  <Box as="span">{`${t('careers')}`}</Box>
+                  {`${t('careers')}`}
                 </Link>
-                {AllCareers.length !== 0 && (
+                {/* {AllCareers.length !== 0 && (
                   <Tag
                     ml="2"
                     size="sm"
@@ -111,8 +111,13 @@ const MenuFooter = () => {
                   >
                     We&apos;re hiring
                   </Tag>
-                )}
+                )} */}
               </Box>
+              <Link
+                textAlign={{ base: 'center', md: 'left' }}
+                prefetch={false}
+                href="/us-careers"
+              >{`${t('usCareers')}`}</Link>
               <Link
                 textAlign={{ base: 'center', md: 'left' }}
                 prefetch={false}

--- a/src/data/CareersData.ts
+++ b/src/data/CareersData.ts
@@ -1,7 +1,7 @@
 export type CareersDatatype = {
   title: string
   description: string
-  link: string
+  link?: string
   location: string
 }
 

--- a/src/pages/careers/index.tsx
+++ b/src/pages/careers/index.tsx
@@ -9,7 +9,12 @@ import CareerCard from '@/components/Careers/CareersCard'
 const OurCareers = () => {
   return (
     <main>
-      <CareersHero />
+      <CareersHero
+        title="IQ.Wiki Careers"
+        description="Do you wish to join our great team? we're looking for
+          Intellectual Individuals who are committed to doing well by doing
+          good. here is the list of our open positions."
+      />
       <SimpleGrid
         maxW={{ base: '100%', md: '95%', '2xl': '1280px' }}
         py={{ base: 8, lg: 16 }}

--- a/src/pages/us-careers.tsx
+++ b/src/pages/us-careers.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const USCareers = () => {
+  return (
+    <div>us-careers</div>
+  )
+}
+
+export default USCareers

--- a/src/pages/us-careers.tsx
+++ b/src/pages/us-careers.tsx
@@ -1,8 +1,41 @@
 import React from 'react'
+import CareersHero from '@/components/Careers/CareersHero'
+import { CareersHeader } from '@/components/SEO/Static'
+import { SimpleGrid } from '@chakra-ui/react'
+import CareerCard from '@/components/Careers/CareersCard'
+
+const OurCareers = () => {
+  return (
+    <main>
+      <CareersHero
+        title="IQ.Wiki US Careers"
+        description="Do you wish to join our great team? we're looking for
+          Intellectual Individuals who are committed to doing well by doing
+          good. here is the list of our open positions."
+      />
+      <SimpleGrid
+        maxW={{ base: '100%', md: '95%', '2xl': '1280px' }}
+        py={{ base: 8, lg: 16 }}
+        mx="auto"
+        px={{ base: '5', md: 0 }}
+        gap={{ base: 10, md: '15' }}
+      >
+        <CareerCard
+          title="Manager, Web Traffic"
+          location="Las Vegas, US"
+          description="Distributed Machines, Inc., d/b/a Everipedia, seeks a Manager, Web Traffic, for our Las Vegas, NV office. May work from home from any location in the U.S. Requires a Bach. of Bus. Admin. & 2 years experience as a Management Analyst working in the blockchain technology industry for companies with their own cryptocurrency, including experience with knowledge projects such as Wikipedia, Quora, etc. Please submit your resume to jobs@everipedia.com."
+        />
+      </SimpleGrid>
+    </main>
+  )
+}
 
 const USCareers = () => {
   return (
-    <div>us-careers</div>
+    <>
+      <CareersHeader />
+      <OurCareers />
+    </>
   )
 }
 

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -39,6 +39,7 @@ export const resources = {
       bonds: 'Bonds',
       aboutUs: 'About us',
       careers: 'Careers',
+      usCareers: 'US Careers',
       brainies: 'brainies',
       resources: 'Resources',
       glossary: 'Glossary',


### PR DESCRIPTION
# US Careers Page

_create a new page on the IQ.wiki website called "US Careers". The page should have a URL of iq.wiki/us-careers and should be added to the footer menu in a manner similar to the "Careers" page.

Result

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/70170061/230217864-cd68293c-9834-4330-9d63-3af61a42c7c8.png">


fixes https://github.com/EveripediaNetwork/issues/issues/1181