### PR TITLE
fix bonds and instagram footer links

### DIFF
--- a/src/components/Layout/Footer/MenuFooter.tsx
+++ b/src/components/Layout/Footer/MenuFooter.tsx
@@ -77,7 +77,7 @@ const MenuFooter = () => {
               <Link
                 textAlign={{ base: 'center', md: 'left' }}
                 target="_blank"
-                href="https://learn.everipedia.org/iq/iq/iq-bonds-guide-ethereum"
+                href="https://app.bondprotocol.finance/#/market/1/80"
               >
                 {`${t('bonds')}`}
               </Link>

--- a/src/data/SocialsData.ts
+++ b/src/data/SocialsData.ts
@@ -37,7 +37,7 @@ export const Socials: Social[] = [
   },
   {
     id: 4,
-    href: 'https://instagram.com/everipedia',
+    href: 'https://www.instagram.com/iqwiki_/',
     name: 'instagram',
     icon: RiInstagramFill,
   },


### PR DESCRIPTION
# Summary

This pr addresses [#1196](https://github.com/EveripediaNetwork/issues/issues/1196). It updates  the bonds and instagram links with the right urls.

## How should this be tested?

1. Scroll to footer
2. Click the 'bonds' link (It should take you to the correct url)
3. Click the instagram icon link (It should take you IQ wiki instagram page)

