### PR TITLE
when user isnt logged in feedback

### DIFF
--- a/src/components/Wiki/WikiPage/InsightComponents/ContentFeedback.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/ContentFeedback.tsx
@@ -13,7 +13,7 @@ const ContentFeedback = ({
 }: {
   choice: boolean
   contentId: string
-  userId: string
+  userId?: string
 }) => {
   const [feedbackVal, setFeedbackVal] = useState<boolean>(choice)
   const [contentFeedback] = useContentFeedbackMutation()

--- a/src/services/admin/queries.ts
+++ b/src/services/admin/queries.ts
@@ -239,7 +239,7 @@ export const REVALIDATE_URL = gql`
 export const CONTENT_FEEDBACK = gql`
   mutation ContentFeedback(
     $contentId: String!
-    $userId: String!
+    $userId: String
     $feedback: ContentFeedbackType
   ) {
     contentFeedback(

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -12,7 +12,7 @@ export type EditorsType = {
 
 export type ContentFeedbackArgs = {
   contentId: string
-  userId: string
+  userId?: string
   feedback: ContentFeedbackType
 }
 


### PR DESCRIPTION
# A quick fix for the iq wiki content feedback to handle when users arent logged in and they provide a fedback