### PR TITLE
update: ig and bonds link

### DIFF
--- a/src/components/Layout/Footer/MenuFooter.tsx
+++ b/src/components/Layout/Footer/MenuFooter.tsx
@@ -77,7 +77,7 @@ const MenuFooter = () => {
               <Link
                 textAlign={{ base: 'center', md: 'left' }}
                 target="_blank"
-                href="https://learn.everipedia.org/iq/iq/iq-bonds-guide-ethereum"
+                href="https://app.bondprotocol.finance/#/market/1/80"
               >
                 {`${t('bonds')}`}
               </Link>

--- a/src/data/SocialsData.ts
+++ b/src/data/SocialsData.ts
@@ -37,7 +37,7 @@ export const Socials: Social[] = [
   },
   {
     id: 4,
-    href: 'https://instagram.com/everipedia',
+    href: 'https://www.instagram.com/iqwiki_/',
     name: 'instagram',
     icon: RiInstagramFill,
   },

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -177,7 +177,6 @@ export interface EditorsTable {
     ipfs: string
     wikiId: string
   }[]
-  // rome-ignore lint/suspicious/noExplicitAny: <explanation>
   lastCreatedWiki: any
   editorAvatar: string
   latestActivity: string


### PR DESCRIPTION
# Fixing Routing Bond Link and Instagram Link

This PR fixes the footer links for both Instagram (IG) and Bond on our website. Previously, the links were not redirecting to the correct pages. The issue has been resolved by updating the URLs in the code.

The changes have been thoroughly tested and verified on various devices and browsers.

Thank you for reviewing this PR.

## How should this be tested?

1. Go to footer.
2. Click the bond link, this will open the bond page on a new tab.
3. Click the ig logo, this will open a new tab of the iq-wiki Instagram page.

## Linked issues

https://github.com/EveripediaNetwork/issues/issues/1196
