### PR TITLE
Use react routing

### DIFF
--- a/src/components/Categories/CategoryCard.tsx
+++ b/src/components/Categories/CategoryCard.tsx
@@ -1,13 +1,5 @@
 import React from 'react'
-import {
-  VStack,
-  Heading,
-  Text,
-  Box,
-  LinkBox,
-  LinkOverlay,
-  Icon,
-} from '@chakra-ui/react'
+import { VStack, Heading, Text, Box, LinkBox, Icon } from '@chakra-ui/react'
 import {
   CATEGORY_DESCRIPTION_WORD_LIMIT,
   IMAGE_BOX_SIZE,
@@ -15,8 +7,7 @@ import {
 } from '@/data/Constants'
 import { IconType } from 'react-icons'
 import { Image } from '../Elements/Image/Image'
-import Link from 'next/link'
-
+import LinkOverlay from '@/components/Elements/LinkElements/LinkOverlay'
 interface CategoryCardProps {
   imageCard: string
   coverIcon: IconType
@@ -74,7 +65,7 @@ const CategoryCard = ({
           <Heading textAlign="center" size="sm" my="10px">
             {title}
           </Heading>
-          <LinkOverlay as={Link} href={`/categories/${categoryId}`}>
+          <LinkOverlay href={`/categories/${categoryId}`}>
             <Text
               maxWidth="300px"
               fontSize="xs"

--- a/src/components/Categories/CategoryCard.tsx
+++ b/src/components/Categories/CategoryCard.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/data/Constants'
 import { IconType } from 'react-icons'
 import { Image } from '../Elements/Image/Image'
+import Link from 'next/link'
 
 interface CategoryCardProps {
   imageCard: string
@@ -33,13 +34,13 @@ const CategoryCard = ({
 }: CategoryCardProps) => {
   return (
     <LinkBox
-      as="article"
       bgColor="cardBg"
       borderWidth="1px"
       borderColor="dimColor"
       _hover={{ boxShadow: '0px 0px 10px rgba(0, 0, 0, 0.1)' }}
       overflow="hidden"
       borderRadius="12px"
+      key={categoryId}
     >
       <VStack cursor="pointer">
         <Box w="100%" position="relative">
@@ -68,12 +69,12 @@ const CategoryCard = ({
             />
           </Box>
         </Box>
-        <LinkOverlay href={`/categories/${categoryId}`}>
-          <Box p={5}>
-            <Heading textAlign="center" size="sm" my="10px">
-              {title}
-            </Heading>
 
+        <Box p={5}>
+          <Heading textAlign="center" size="sm" my="10px">
+            {title}
+          </Heading>
+          <LinkOverlay as={Link} href={`/categories/${categoryId}`}>
             <Text
               maxWidth="300px"
               fontSize="xs"
@@ -84,8 +85,8 @@ const CategoryCard = ({
                 ? brief.slice(0, CATEGORY_DESCRIPTION_WORD_LIMIT).concat('...')
                 : brief}
             </Text>
-          </Box>
-        </LinkOverlay>
+          </LinkOverlay>
+        </Box>
       </VStack>
     </LinkBox>
   )

--- a/src/components/Categories/CategoryCard.tsx
+++ b/src/components/Categories/CategoryCard.tsx
@@ -68,18 +68,24 @@ const CategoryCard = ({
             />
           </Box>
         </Box>
-        <Box p={5}>
-          <LinkOverlay href={`/categories/${categoryId}`}>
+        <LinkOverlay href={`/categories/${categoryId}`}>
+          <Box p={5}>
             <Heading textAlign="center" size="sm" my="10px">
               {title}
             </Heading>
-          </LinkOverlay>
-          <Text maxWidth="300px" fontSize="xs" textAlign="center" opacity="0.6">
-            {brief.length > CATEGORY_DESCRIPTION_WORD_LIMIT
-              ? brief.slice(0, CATEGORY_DESCRIPTION_WORD_LIMIT).concat('...')
-              : brief}
-          </Text>
-        </Box>
+
+            <Text
+              maxWidth="300px"
+              fontSize="xs"
+              textAlign="center"
+              opacity="0.6"
+            >
+              {brief.length > CATEGORY_DESCRIPTION_WORD_LIMIT
+                ? brief.slice(0, CATEGORY_DESCRIPTION_WORD_LIMIT).concat('...')
+                : brief}
+            </Text>
+          </Box>
+        </LinkOverlay>
       </VStack>
     </LinkBox>
   )

--- a/src/components/Categories/TrendingCategoryItem.tsx
+++ b/src/components/Categories/TrendingCategoryItem.tsx
@@ -1,14 +1,11 @@
 import React from 'react'
 import { useRouter } from 'next/router'
-import Link from 'next/link'
 import {
   AspectRatio,
   Box,
   Flex,
   Heading,
-  // Link,
   LinkBox,
-  LinkOverlay,
   Text,
 } from '@chakra-ui/react'
 import { IMAGE_BOX_SIZE, WIKI_IMAGE_ASPECT_RATIO } from '@/data/Constants'
@@ -18,6 +15,7 @@ import { Image as ImageType, User } from '@everipedia/iq-utils'
 import { getWikiImageUrl } from '@/utils/WikiUtils/getWikiImageUrl'
 import { Image } from '../Elements/Image/Image'
 import DisplayAvatar from '../Elements/Avatar/DisplayAvatar'
+import LinkOverlay from '@/components/Elements/LinkElements/LinkOverlay'
 
 interface TrendingCategoryItemProps {
   title: string
@@ -99,7 +97,6 @@ const TrendingCategoryItem = ({
                 href={`/account/${editor.id}`}
                 color="brandLinkColor"
                 fontWeight="bold"
-                as={Link}
               >
                 {getUsername(editor)}
               </LinkOverlay>

--- a/src/components/Categories/TrendingCategoryItem.tsx
+++ b/src/components/Categories/TrendingCategoryItem.tsx
@@ -1,12 +1,14 @@
 import React from 'react'
 import { useRouter } from 'next/router'
+import Link from 'next/link'
 import {
   AspectRatio,
   Box,
   Flex,
   Heading,
-  Link,
+  // Link,
   LinkBox,
+  LinkOverlay,
   Text,
 } from '@chakra-ui/react'
 import { IMAGE_BOX_SIZE, WIKI_IMAGE_ASPECT_RATIO } from '@/data/Constants'
@@ -93,13 +95,14 @@ const TrendingCategoryItem = ({
               alt={editor.profile?.username}
             />
             <Text fontSize={{ base: '10px', md: '14px' }} color="linkColor">
-              <Link
+              <LinkOverlay
                 href={`/account/${editor.id}`}
                 color="brandLinkColor"
                 fontWeight="bold"
+                as={Link}
               >
                 {getUsername(editor)}
-              </Link>
+              </LinkOverlay>
             </Text>
           </Flex>
           <Text

--- a/src/components/Glossary/GlossaryWikiCard.tsx
+++ b/src/components/Glossary/GlossaryWikiCard.tsx
@@ -5,10 +5,10 @@ import {
   Text,
   Box,
   LinkBox,
-  LinkOverlay,
   Highlight,
 } from '@chakra-ui/react'
 import { WIKI_SUMMARY_LIMIT } from '@/data/Constants'
+import LinkOverlay from '@/components/Elements/LinkElements/LinkOverlay'
 
 interface GlossaryWikiCardProps {
   highlightText: string

--- a/src/components/Landing/FeaturedWikiCard.tsx
+++ b/src/components/Landing/FeaturedWikiCard.tsx
@@ -4,9 +4,7 @@ import {
   Flex,
   Heading,
   HStack,
-  Link,
   LinkBox,
-  LinkOverlay,
   Text,
   chakra,
 } from '@chakra-ui/react'
@@ -22,7 +20,8 @@ import {
 } from '@/utils/WikiUtils/getWikiSummary'
 import DisplayAvatar from '../Elements/Avatar/DisplayAvatar'
 import { Image } from '../Elements/Image/Image'
-import NextLink from 'next/link'
+import LinkOverlay from '@/components/Elements/LinkElements/LinkOverlay'
+import Link from '@/components/Elements/LinkElements/Link'
 
 export const FeaturedWikiCard = ({ wiki }: { wiki: Wiki }) => {
   const [, ensName] = useENSData(wiki.user.id)
@@ -71,7 +70,7 @@ export const FeaturedWikiCard = ({ wiki }: { wiki: Wiki }) => {
             fontWeight="semibold"
             p={4}
           >
-            <LinkOverlay as={NextLink} href={`/wiki/${wiki?.id}`}>
+            <LinkOverlay href={`/wiki/${wiki?.id}`}>
               <Heading
                 width="90%"
                 overflow="hidden"

--- a/src/components/Landing/FeaturedWikiCard.tsx
+++ b/src/components/Landing/FeaturedWikiCard.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/utils/WikiUtils/getWikiSummary'
 import DisplayAvatar from '../Elements/Avatar/DisplayAvatar'
 import { Image } from '../Elements/Image/Image'
+import NextLink from 'next/link'
 
 export const FeaturedWikiCard = ({ wiki }: { wiki: Wiki }) => {
   const [, ensName] = useENSData(wiki.user.id)
@@ -70,7 +71,7 @@ export const FeaturedWikiCard = ({ wiki }: { wiki: Wiki }) => {
             fontWeight="semibold"
             p={4}
           >
-            <LinkOverlay href={`/wiki/${wiki?.id}`}>
+            <LinkOverlay as={NextLink} href={`/wiki/${wiki?.id}`}>
               <Heading
                 width="90%"
                 overflow="hidden"

--- a/src/components/Layout/Footer/Footer.tsx
+++ b/src/components/Layout/Footer/Footer.tsx
@@ -30,7 +30,7 @@ import { ChevronDownIcon } from '@chakra-ui/icons'
 import { languageData } from '@/data/LanguageData'
 import { useTranslation } from 'react-i18next'
 import { logEvent } from '@/utils/googleAnalytics'
-import Link from 'next/link'
+import Link from '@/components/Elements/LinkElements/Link'
 
 const Footer = () => {
   const { t, i18n } = useTranslation()

--- a/src/components/Wiki/WikiPage/CustomModals/ShareWikiModal.tsx
+++ b/src/components/Wiki/WikiPage/CustomModals/ShareWikiModal.tsx
@@ -32,7 +32,7 @@ import EmailIconColor from '@/components/Icons/emailIconColor'
 import config from '@/config'
 import { Modal } from '@/components/Elements'
 import { logEvent } from '@/utils/googleAnalytics'
-import Link from 'next/link'
+import Link from '@/components/Elements/LinkElements/Link'
 
 const SHARING_OPTIONS = [
   {

--- a/src/components/Wiki/WikiPage/InsightComponents/WikiDetails.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/WikiDetails.tsx
@@ -110,7 +110,6 @@ export const WikiDetails = ({
                         {categories?.map((category, i) => (
                           <Link
                             key={i}
-                            isExternal
                             href={`/categories/${category.id}`}
                             color="brandLinkColor"
                           >


### PR DESCRIPTION
# React Routing

_There are several links on our website that are loading a new page instead of utilizing React routing. I propose reviewing the entire site for instances where links are not utilizing React routing. In particular, I suggest focusing on the homepage where users may click on "Users", "Featured Wikis", or "Categories".


fixes https://github.com/EveripediaNetwork/issues/issues/1247