### PR TITLE
Fix wallet bug

### DIFF
--- a/src/components/Layout/WalletDrawer/Connectors.tsx
+++ b/src/components/Layout/WalletDrawer/Connectors.tsx
@@ -30,7 +30,6 @@ import {
 } from '@/utils/WalletUtils/fetchWalletBalance'
 import { shortenBalance } from '@/utils/textUtils'
 
-
 interface ConnectorsProps {
   openWalletDrawer?: () => void
 }
@@ -151,10 +150,7 @@ const Connectors = ({ openWalletDrawer }: ConnectorsProps) => {
                   <Spinner color="color" mt="1" />
                 ) : (
                   <Text fontWeight="bold" fontSize="xl">
-                    $
-                    {totalBalance &&
-                      shortenBalance(totalBalance)}{' '}
-                    USD
+                    ${totalBalance && shortenBalance(totalBalance)} USD
                   </Text>
                 )}
               </Flex>

--- a/src/components/Layout/WalletDrawer/Connectors.tsx
+++ b/src/components/Layout/WalletDrawer/Connectors.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/utils/WalletUtils/fetchWalletBalance'
 import { shortenBalance } from '@/utils/textUtils'
 
+
 interface ConnectorsProps {
   openWalletDrawer?: () => void
 }
@@ -73,7 +74,6 @@ const Connectors = ({ openWalletDrawer }: ConnectorsProps) => {
     },
   })
 
-  const dollarUSLocale = Intl.NumberFormat('en-US')
   const [totalBalanceIsLoading, setTotalBalanceIsLoading] =
     useState<boolean>(true)
   const hiIQData = {
@@ -153,9 +153,7 @@ const Connectors = ({ openWalletDrawer }: ConnectorsProps) => {
                   <Text fontWeight="bold" fontSize="xl">
                     $
                     {totalBalance &&
-                      dollarUSLocale.format(
-                        Number(shortenBalance(totalBalance)),
-                      )}{' '}
+                      shortenBalance(totalBalance)}{' '}
                     USD
                   </Text>
                 )}

--- a/src/components/Layout/WalletDrawer/WalletDetails.tsx
+++ b/src/components/Layout/WalletDrawer/WalletDetails.tsx
@@ -5,6 +5,7 @@ import { tokenDetails } from '@/data/WalletData'
 import { getTokenValue } from '@/utils/WalletUtils/getTokenValue'
 import WalletDetailsWrapper from './WalletDetailsWrapper'
 import TokenDetailsMenu from '../Token/TokenDetailsMenu'
+import { shortenBalance } from '@/utils/textUtils'
 
 const WalletDetails = ({
   symbol,
@@ -32,7 +33,7 @@ const WalletDetails = ({
         <VStack spacing="0" align="flex-end">
           <Text fontWeight="bold">{balance}</Text>
           <Text mr={3} color="GrayText" fontSize="smaller" fontWeight="bold">
-            ${getTokenValue(tokensArray, symbol)}
+            ${shortenBalance(getTokenValue(tokensArray, symbol))}
           </Text>
         </VStack>
         <TokenDetailsMenu token={symbol} />


### PR DESCRIPTION
# Wallet Bug

_ As a user, I would want to view the both total values of all tokens and also the breakdown of each token in my wallet. Currently, on the wallet, a User can't see the total values of all the tokens in the wallet, this is because it is displaying NAN USD.

result 
<img width="449" alt="image" src="https://user-images.githubusercontent.com/70170061/234990382-2e971b17-c275-4c35-ac41-20102b089e95.png">


## Linked issues

fixes https://github.com/EveripediaNetwork/issues/issues/1245