### PR TITLE
Wiki updated msg

### DIFF
--- a/src/components/CreateWiki/CreateWikiTopBar/WikiPublish/WikiPublishButton.tsx
+++ b/src/components/CreateWiki/CreateWikiTopBar/WikiPublish/WikiPublishButton.tsx
@@ -41,7 +41,7 @@ const NetworkErrorNotification = dynamic(
 )
 
 export const WikiPublishButton = () => {
-  const wiki = useAppSelector((state) => state.wiki)
+  const wiki = useAppSelector(state => state.wiki)
   const [submittingWiki, setSubmittingWiki] = useBoolean()
   const { address: userAddress, isConnected: isUserConnected } = useAccount()
   const { userCanEdit } = useWhiteListValidator(userAddress)
@@ -117,16 +117,15 @@ export const WikiPublishButton = () => {
       getDetectedProvider()
     } else {
       getConnectedChain(detectedProvider)
-      detectedProvider.on('chainChanged', (newlyConnectedChain) =>
+      detectedProvider.on('chainChanged', newlyConnectedChain =>
         setConnectedChainId(newlyConnectedChain),
       )
     }
 
     return () => {
       if (detectedProvider) {
-        detectedProvider.removeListener(
-          'chainChanged',
-          (newlyConnectedChain) => setConnectedChainId(newlyConnectedChain),
+        detectedProvider.removeListener('chainChanged', newlyConnectedChain =>
+          setConnectedChainId(newlyConnectedChain),
         )
       }
     }
@@ -236,7 +235,7 @@ export const WikiPublishButton = () => {
         ...wiki,
         user: { id: userAddress },
         content: sanitizeContentToPublish(String(wiki.content)),
-        metadata: wiki.metadata.filter((m) => m.value),
+        metadata: wiki.metadata.filter(m => m.value),
       }
 
       if (finalWiki.id === CreateNewWikiSlug)
@@ -316,6 +315,7 @@ export const WikiPublishButton = () => {
         txHash={txHash}
         wikiHash={wikiHash}
         activeStep={activeStep}
+        isNewWiki={isNewCreateWiki}
         state={loadingState}
         isOpen={isWikiProcessModalOpen}
         onClose={handlePopupClose}

--- a/src/components/CreateWiki/CreateWikiTopBar/WikiPublish/WikiPublishButton.tsx
+++ b/src/components/CreateWiki/CreateWikiTopBar/WikiPublish/WikiPublishButton.tsx
@@ -41,7 +41,7 @@ const NetworkErrorNotification = dynamic(
 )
 
 export const WikiPublishButton = () => {
-  const wiki = useAppSelector(state => state.wiki)
+  const wiki = useAppSelector((state) => state.wiki)
   const [submittingWiki, setSubmittingWiki] = useBoolean()
   const { address: userAddress, isConnected: isUserConnected } = useAccount()
   const { userCanEdit } = useWhiteListValidator(userAddress)
@@ -117,15 +117,16 @@ export const WikiPublishButton = () => {
       getDetectedProvider()
     } else {
       getConnectedChain(detectedProvider)
-      detectedProvider.on('chainChanged', newlyConnectedChain =>
+      detectedProvider.on('chainChanged', (newlyConnectedChain) =>
         setConnectedChainId(newlyConnectedChain),
       )
     }
 
     return () => {
       if (detectedProvider) {
-        detectedProvider.removeListener('chainChanged', newlyConnectedChain =>
-          setConnectedChainId(newlyConnectedChain),
+        detectedProvider.removeListener(
+          'chainChanged',
+          (newlyConnectedChain) => setConnectedChainId(newlyConnectedChain),
         )
       }
     }
@@ -235,7 +236,7 @@ export const WikiPublishButton = () => {
         ...wiki,
         user: { id: userAddress },
         content: sanitizeContentToPublish(String(wiki.content)),
-        metadata: wiki.metadata.filter(m => m.value),
+        metadata: wiki.metadata.filter((m) => m.value),
       }
 
       if (finalWiki.id === CreateNewWikiSlug)

--- a/src/components/CreateWiki/EditorModals/WikiProcessModal.tsx
+++ b/src/components/CreateWiki/EditorModals/WikiProcessModal.tsx
@@ -17,12 +17,6 @@ import { Step, Steps } from 'chakra-ui-steps'
 import config from '@/config'
 import { useRouter } from 'next/router'
 
-const steps = [
-  { label: 'Signed Wiki' },
-  { label: 'Sent to Relayer' },
-  { label: 'Wiki created' },
-]
-
 type WikiProcessType = {
   isOpen: boolean
   onClose: () => void
@@ -32,6 +26,7 @@ type WikiProcessType = {
   txHash: string | undefined
   msg: string
   wikiId: string
+  isNewWiki:boolean
 }
 
 const WikiProcessModal = ({
@@ -43,11 +38,16 @@ const WikiProcessModal = ({
   txHash,
   msg,
   wikiId,
+  isNewWiki,
 }: WikiProcessType) => {
   const cancelRef = React.useRef<FocusableElement>(null)
 
   const router = useRouter()
-
+  const steps = [
+    { label: 'Signed Wiki' },
+    { label: 'Sent to Relayer' },
+    { label: isNewWiki ? 'Wiki created' : 'Wiki updated' },
+  ]
   if (!isOpen) return null
 
   return (

--- a/src/components/CreateWiki/EditorModals/WikiProcessModal.tsx
+++ b/src/components/CreateWiki/EditorModals/WikiProcessModal.tsx
@@ -26,7 +26,7 @@ type WikiProcessType = {
   txHash: string | undefined
   msg: string
   wikiId: string
-  isNewWiki:boolean
+  isNewWiki: boolean
 }
 
 const WikiProcessModal = ({

--- a/src/hooks/useGetSignedHash.ts
+++ b/src/hooks/useGetSignedHash.ts
@@ -43,7 +43,7 @@ export const useGetSignedHash = () => {
     signTypedDataAsync,
   } = useSignTypedData()
 
-  const { refetch } = useWaitForTransaction({ hash: txHash })
+  const { refetch } = useWaitForTransaction({ hash: txHash as `0x${string}`})
   const { data: feeData } = useFeeData({
     formatUnits: 'gwei',
   })
@@ -64,7 +64,7 @@ export const useGetSignedHash = () => {
         deadline: deadline.current,
       },
     })
-      .then((response) => {
+      .then(response => {
         if (response) {
           setActiveStep(1)
         } else {
@@ -72,7 +72,7 @@ export const useGetSignedHash = () => {
           setMsg(defaultErrorMessage)
         }
       })
-      .catch((err) => {
+      .catch(err => {
         setIsLoading('error')
         setMsg(err.message || defaultErrorMessage)
         logEvent({
@@ -115,7 +115,7 @@ export const useGetSignedHash = () => {
               setActiveStep(3)
               setMsg(isNewCreateWiki ? successMessage : editedMessage)
               // clear all edit based metadata from redux state
-              Object.values(EditSpecificMetaIds).forEach((id) => {
+              Object.values(EditSpecificMetaIds).forEach(id => {
                 dispatch({
                   type: 'wiki/updateMetadata',
                   payload: {

--- a/src/hooks/useGetSignedHash.ts
+++ b/src/hooks/useGetSignedHash.ts
@@ -64,7 +64,7 @@ export const useGetSignedHash = () => {
         deadline: deadline.current,
       },
     })
-      .then(response => {
+      .then((response) => {
         if (response) {
           setActiveStep(1)
         } else {
@@ -72,7 +72,7 @@ export const useGetSignedHash = () => {
           setMsg(defaultErrorMessage)
         }
       })
-      .catch(err => {
+      .catch((err) => {
         setIsLoading('error')
         setMsg(err.message || defaultErrorMessage)
         logEvent({
@@ -115,7 +115,7 @@ export const useGetSignedHash = () => {
               setActiveStep(3)
               setMsg(isNewCreateWiki ? successMessage : editedMessage)
               // clear all edit based metadata from redux state
-              Object.values(EditSpecificMetaIds).forEach(id => {
+              Object.values(EditSpecificMetaIds).forEach((id) => {
                 dispatch({
                   type: 'wiki/updateMetadata',
                   payload: {

--- a/src/utils/CreateWikiUtils/createWikiMessages.ts
+++ b/src/utils/CreateWikiUtils/createWikiMessages.ts
@@ -6,6 +6,7 @@ export const initialMsg =
 export const defaultErrorMessage =
   'Oops, An Error Occurred. Wiki could not be created'
 export const successMessage = 'Wiki has been created successfully.'
+export const editedMessage = 'Wiki has been updated successfully'
 export const ValidationErrorMessage = (type: string) => {
   switch (type) {
     case ValidatorCodes.CATEGORY:


### PR DESCRIPTION
# Updated the Process Modal Msg 

When updating a wiki the modal message now shows "wiki successfully updated" 

## How should this be tested?

1. Before
![image](https://github.com/EveripediaNetwork/ep-ui/assets/75235148/9bfbced5-8307-4369-a2ec-25b72cdb95b3)

2. Now 
![image](https://github.com/EveripediaNetwork/ep-ui/assets/75235148/8daa35e2-c0e3-4db9-986a-5c6fccd93d56)


## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/1332
