### PR TITLE
updates wiki initial message

### DIFF
--- a/src/utils/CreateWikiUtils/createWikiMessages.ts
+++ b/src/utils/CreateWikiUtils/createWikiMessages.ts
@@ -2,7 +2,7 @@ import { ValidatorCodes } from '@everipedia/iq-utils'
 
 export const initialEditorValue = ' '
 export const initialMsg =
-  'Your Wiki is being processed. It will be available on the blockchain soon.'
+  'Your Wiki is being processed and will be available within 5 minutes depending on blockchain congestion'
 export const defaultErrorMessage =
   'Oops, An Error Occurred. Wiki could not be created'
 export const successMessage = 'Wiki has been created successfully.'


### PR DESCRIPTION
#updates wiki initial message

It takes a long period of time before a wiki gets published, and the user would need to wait for about 5 minutes since it would need to be signed/approved on the blockchain. we need to review the time for this to happen and show a pop-up message for the delay.

## Linked issues

fixes https://github.com/EveripediaNetwork/issues/issues/1329