### PR TITLE
Wiki Page Overflow

### DIFF
--- a/src/styles/markdown.module.css
+++ b/src/styles/markdown.module.css
@@ -34,14 +34,7 @@
   font-size: 16px;
   line-height: 1.625;
   word-wrap: break-word;
-  width: 560px;
 }
-@media (min-width: 1200px) {
-  .markdownBody {
-    max-width: 900px;
-  }
-}
-
 
 .markdownBody details,
 .markdownBody figcaption,
@@ -512,7 +505,7 @@ html[data-theme='dark'] .markdownBody a {
   padding: 6px;
   border: 1px solid #d0d7de;
   word-break: break-all;
-  width:'50%';
+  /* width:50%; */
 }
 
 .markdownBody table td  {

--- a/src/styles/markdown.module.css
+++ b/src/styles/markdown.module.css
@@ -34,7 +34,14 @@
   font-size: 16px;
   line-height: 1.625;
   word-wrap: break-word;
+  width: 560px;
 }
+@media (min-width: 1200px) {
+  .markdownBody {
+    max-width: 900px;
+  }
+}
+
 
 .markdownBody details,
 .markdownBody figcaption,
@@ -218,6 +225,7 @@ html[data-theme='dark'] .markdownBody a {
   border-spacing: 0;
   border-collapse: collapse;
   width: 100%;
+  table-layout: fixed;
 }
 .markdownBody .table-container {
   overflow-x: auto;
@@ -501,8 +509,14 @@ html[data-theme='dark'] .markdownBody a {
 
 .markdownBody table th,
 .markdownBody table td {
-  padding: 6px 13px;
+  padding: 6px;
   border: 1px solid #d0d7de;
+  word-break: break-all;
+  width:'50%';
+}
+
+.markdownBody table td  {
+  vertical-align: top;
 }
 
 .markdownBody table tr {


### PR DESCRIPTION
# Wiki Page Overflow 

_Wiki Page Overflow _

Some wiki pages like  [https://iq.wiki/wiki/kucoin ](https://iq.wiki/wiki/kucoin) have content that overflow the page

## How should this be tested?

1. Before 
![image](https://github.com/EveripediaNetwork/ep-ui/assets/75235148/81feaa91-291b-4176-9a0f-13d29f8c5df7)

2. After
![image](https://github.com/EveripediaNetwork/ep-ui/assets/75235148/6159f48c-ca27-4cfb-b457-605fa6d48d22)


## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/1377
