### PR TITLE
Make the Carousel slide smooth

### DIFF
--- a/src/components/Landing/FeaturedWikis.tsx
+++ b/src/components/Landing/FeaturedWikis.tsx
@@ -6,8 +6,10 @@ import { FeaturedWikiCard } from './FeaturedWikiCard'
 import { LoadingFeaturedWikiCard } from './LoadingFeaturedWikiCard'
 import Autoplay from 'embla-carousel-autoplay'
 import { WikiCarousel } from '../Elements/Carousel/Carousel'
+import { EmblaOptionsType } from 'embla-carousel-react'
 
 export const FeaturedWikis = ({ featuredWikis }: { featuredWikis: Wiki[] }) => {
+  const OPTIONS: EmblaOptionsType = { loop: true }
   return (
     <Flex pt="1" minH="500px">
       <Box
@@ -49,6 +51,7 @@ export const FeaturedWikis = ({ featuredWikis }: { featuredWikis: Wiki[] }) => {
                 </Box>
               )}
               plugins={[Autoplay()]}
+              options={OPTIONS}
             />
           </>
         ) : (


### PR DESCRIPTION
# Carousel slider

The featured wikis slider usually snaps back to the beginning after reaching the last item on the slide

## How should this be tested?

1. Before
https://github.com/EveripediaNetwork/ep-ui/assets/75235148/810d8388-d8ee-4524-8764-651aa490dcb8


2. Now
https://github.com/EveripediaNetwork/ep-ui/assets/75235148/38c3789a-0aa0-4ca8-874e-db18387b9a16




## Linked issues
closes https://github.com/EveripediaNetwork/issues/issues/1444
