### PR TITLE
Fix issue with wiki link

### DIFF
--- a/src/editor-plugins/wikiLink/frame/index.tsx
+++ b/src/editor-plugins/wikiLink/frame/index.tsx
@@ -108,7 +108,7 @@ const WikiLinkFrame = ({ editorContext }: { editorContext: PluginContext }) => {
         <input
           className="wikiLink__input"
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={e => setSearch(e.target.value)}
           type="text"
           placeholder="Search Wiki"
         />
@@ -119,7 +119,7 @@ const WikiLinkFrame = ({ editorContext }: { editorContext: PluginContext }) => {
             {shortenText(wikiSelected.title, 30)}
           </h3>
           <div className="wikiLink__previewTagsContainer">
-            {wikiSelected.tags?.map((tag) => (
+            {wikiSelected.tags?.map(tag => (
               <span
                 style={{
                   backgroundColor: `hsl(${Math.floor(
@@ -149,9 +149,9 @@ const WikiLinkFrame = ({ editorContext }: { editorContext: PluginContext }) => {
       {!loading && search.length >= 3 && results.length === 0 && (
         <div className="wikiLink__noResultsMsg">No results found</div>
       )}
-      {wikiList.length > 0 && (
+      {wikiList.length > 0 && !wikiSelected && (
         <div className="wikiLink__resultsContainer">
-          {wikiList.map((wiki) => (
+          {wikiList.map(wiki => (
             <button
               key={wiki.id}
               type="button"

--- a/src/editor-plugins/wikiLink/frame/index.tsx
+++ b/src/editor-plugins/wikiLink/frame/index.tsx
@@ -108,7 +108,7 @@ const WikiLinkFrame = ({ editorContext }: { editorContext: PluginContext }) => {
         <input
           className="wikiLink__input"
           value={search}
-          onChange={e => setSearch(e.target.value)}
+          onChange={(e) => setSearch(e.target.value)}
           type="text"
           placeholder="Search Wiki"
         />
@@ -119,7 +119,7 @@ const WikiLinkFrame = ({ editorContext }: { editorContext: PluginContext }) => {
             {shortenText(wikiSelected.title, 30)}
           </h3>
           <div className="wikiLink__previewTagsContainer">
-            {wikiSelected.tags?.map(tag => (
+            {wikiSelected.tags?.map((tag) => (
               <span
                 style={{
                   backgroundColor: `hsl(${Math.floor(
@@ -151,7 +151,7 @@ const WikiLinkFrame = ({ editorContext }: { editorContext: PluginContext }) => {
       )}
       {wikiList.length > 0 && !wikiSelected && (
         <div className="wikiLink__resultsContainer">
-          {wikiList.map(wiki => (
+          {wikiList.map((wiki) => (
             <button
               key={wiki.id}
               type="button"


### PR DESCRIPTION
# Fix issue with wiki link

_A user is unable to select a wiki wanting to interlink, the button for the previous and next are far below for links that has much wikis and there is no way to scroll down to make it faster


<img width="519" alt="image" src="https://github.com/EveripediaNetwork/ep-ui/assets/70170061/23b89d96-328f-49b5-a3ba-838e305c9111">


fixes https://github.com/EveripediaNetwork/issues/issues/1513