### PR TITLE
Inclusion of a copy icon on the wallet drawer's page

### DIFF
--- a/src/components/Icons/CopyIcon.tsx
+++ b/src/components/Icons/CopyIcon.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Icon, IconProps, useColorModeValue } from '@chakra-ui/react'
+
+const CopyIcon = (props: IconProps) => {
+  const fill = useColorModeValue('#4A5568', 'whiteAlpha.700')
+  const opacity = useColorModeValue('1', '0.64')
+  return (
+    <Icon viewBox="0 0 18 18" fill={fill} {...props}>
+      <path
+        d="M12 9.675V12.825C12 15.45 10.95 16.5 8.325 16.5H5.175C2.55 16.5 1.5 15.45 1.5 12.825V9.675C1.5 7.05 2.55 6 5.175 6H8.325C10.95 6 12 7.05 12 9.675Z"
+        fill-opacity={opacity}
+        fill={fill}
+      />
+      <path
+        d="M12.8251 1.5H9.67507C7.36276 1.5 6.2783 2.32057 6.05237 4.30426C6.00511 4.71926 6.34881 5.0625 6.7665 5.0625H8.32507C11.4751 5.0625 12.9376 6.525 12.9376 9.675V11.2336C12.9376 11.6513 13.2808 11.995 13.6958 11.9477C15.6795 11.7218 16.5001 10.6373 16.5001 8.325V5.175C16.5001 2.55 15.4501 1.5 12.8251 1.5Z"
+        fill-opacity={opacity}
+        fill={fill}
+      />
+    </Icon>
+  )
+}
+
+export default CopyIcon

--- a/src/components/Layout/WalletDrawer/WalletDrawer.tsx
+++ b/src/components/Layout/WalletDrawer/WalletDrawer.tsx
@@ -18,10 +18,14 @@ import {
   MenuItem,
   Spinner,
   useToast,
+  Icon,
 } from '@chakra-ui/react'
 import { useAccount } from 'wagmi'
 import { FocusableElement } from '@chakra-ui/utils'
-import { RiArrowLeftSLine, RiRefreshLine } from 'react-icons/ri'
+import {
+  RiArrowLeftSLine,
+  RiRefreshLine,
+} from 'react-icons/ri'
 import { ChevronDownIcon } from '@chakra-ui/icons'
 import { shortenAccount } from '@/utils/textUtils'
 import Connectors from '@/components/Layout/WalletDrawer/Connectors'
@@ -33,6 +37,7 @@ import NetworkMenu from '@/components/Layout/Network/NetworkMenu'
 import { useENSData } from '@/hooks/useENSData'
 import { useHiIQBalance } from '@/hooks/useHiIQBalance'
 import { useFetchWalletBalance } from '@/hooks/UseFetchWallet'
+import CopyIcon from '@/components/Icons/CopyIcon'
 
 type WalletDrawerType = {
   toggleOperations: {
@@ -145,9 +150,12 @@ const WalletDrawer = ({
                   )}
                 </Menu>
                 {isUserConnected && (
-                  <Text color="fadedText2" pl={1} fontSize="sm">
-                    {username || (userAddress && shortenAccount(userAddress))}
-                  </Text>
+                  <HStack>
+                    <Text color="fadedText2" pl={1} fontSize="sm">
+                      {username || (userAddress && shortenAccount(userAddress))}
+                    </Text>
+                    <Icon as={CopyIcon} />
+                  </HStack>
                 )}
               </Box>
             </HStack>

--- a/src/components/Layout/WalletDrawer/WalletDrawer.tsx
+++ b/src/components/Layout/WalletDrawer/WalletDrawer.tsx
@@ -13,7 +13,6 @@ import {
   MenuButton,
   Menu,
   HStack,
-  Image,
   MenuList,
   MenuItem,
   Spinner,
@@ -26,7 +25,6 @@ import { RiArrowLeftSLine, RiRefreshLine } from 'react-icons/ri'
 import { ChevronDownIcon } from '@chakra-ui/icons'
 import { shortenAccount } from '@/utils/textUtils'
 import Connectors from '@/components/Layout/WalletDrawer/Connectors'
-import { walletsLogos } from '@/data/WalletData'
 import DisplayAvatar from '@/components/Elements/Avatar/DisplayAvatar'
 import { useDispatch } from 'react-redux'
 import { updateWalletDetails } from '@/store/slices/user-slice'
@@ -129,19 +127,6 @@ const WalletDrawer = ({
                   </MenuButton>
                   {isUserConnected && (
                     <MenuList py={0}>
-                      <MenuItem py={3}>
-                        <Image
-                          boxSize="24px"
-                          borderRadius="full"
-                          src={`/images/logos/${walletsLogos[0]}`}
-                          alt="MetaMask"
-                          mr={3}
-                        />
-                        <Text fontSize="small" fontWeight="bold">
-                          MetaMask
-                        </Text>
-                      </MenuItem>
-                      <Divider />
                       <MenuItem
                         onClick={handleAccountRefresh}
                         closeOnSelect={false}

--- a/src/components/Layout/WalletDrawer/WalletDrawer.tsx
+++ b/src/components/Layout/WalletDrawer/WalletDrawer.tsx
@@ -35,6 +35,7 @@ import { useENSData } from '@/hooks/useENSData'
 import { useHiIQBalance } from '@/hooks/useHiIQBalance'
 import { useFetchWalletBalance } from '@/hooks/UseFetchWallet'
 import CopyIcon from '@/components/Icons/CopyIcon'
+import { Link } from '@/components/Elements'
 
 type WalletDrawerType = {
   toggleOperations: {
@@ -92,7 +93,6 @@ const WalletDrawer = ({
       position: 'top-right',
     })
   }
-
 
   return toggleOperations.isOpen ? (
     <Drawer
@@ -160,10 +160,19 @@ const WalletDrawer = ({
                 </Menu>
                 {isUserConnected && (
                   <HStack>
-                    <Text color="fadedText2" pl={1} fontSize="sm">
+                    <Link
+                      fontSize="sm"
+                      color="fadedText2"
+                      href={`/account/${userAddress}`}
+                      pl={1}
+                    >
                       {username || (userAddress && shortenAccount(userAddress))}
-                    </Text>
-                    <Icon cursor="pointer" as={CopyIcon} onClick={copyToClipboard} />
+                    </Link>
+                    <Icon
+                      cursor="pointer"
+                      as={CopyIcon}
+                      onClick={copyToClipboard}
+                    />
                   </HStack>
                 )}
               </Box>

--- a/src/components/Layout/WalletDrawer/WalletDrawer.tsx
+++ b/src/components/Layout/WalletDrawer/WalletDrawer.tsx
@@ -22,10 +22,7 @@ import {
 } from '@chakra-ui/react'
 import { useAccount } from 'wagmi'
 import { FocusableElement } from '@chakra-ui/utils'
-import {
-  RiArrowLeftSLine,
-  RiRefreshLine,
-} from 'react-icons/ri'
+import { RiArrowLeftSLine, RiRefreshLine } from 'react-icons/ri'
 import { ChevronDownIcon } from '@chakra-ui/icons'
 import { shortenAccount } from '@/utils/textUtils'
 import Connectors from '@/components/Layout/WalletDrawer/Connectors'
@@ -84,6 +81,18 @@ const WalletDrawer = ({
       })
     }
   }
+
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(userAddress as string)
+    toast({
+      description: 'Address copied to clipboard',
+      status: 'success',
+      duration: 4000,
+      isClosable: true,
+      position: 'top-right',
+    })
+  }
+
 
   return toggleOperations.isOpen ? (
     <Drawer
@@ -154,7 +163,7 @@ const WalletDrawer = ({
                     <Text color="fadedText2" pl={1} fontSize="sm">
                       {username || (userAddress && shortenAccount(userAddress))}
                     </Text>
-                    <Icon as={CopyIcon} />
+                    <Icon cursor="pointer" as={CopyIcon} onClick={copyToClipboard} />
                   </HStack>
                 )}
               </Box>


### PR DESCRIPTION
# Inclusion of a copy icon on the wallet drawer's page

- [x] We would want to make some adjustments to the drawer's session of the IQ.wiki page, on the right side where the address is, let's get a button to copy the address to the clipboard
- [x] Also, on the drawer page, let's have a link to the profile page of the user's page instead of having the meta mask


fixes https://github.com/EveripediaNetwork/issues/issues/1527