### PR TITLE
Change "IQ.Wiki" to "IQ.wiki" for consistency and branding accuracy.

### DIFF
--- a/src/components/About/AboutOurTeam.tsx
+++ b/src/components/About/AboutOurTeam.tsx
@@ -107,7 +107,7 @@ const AboutOurTeam = () => {
                   )}
                   {teamMember.socials.iqWiki && (
                     <IconButtonSocial
-                      name="IQ.Wiki"
+                      name="IQ.wiki"
                       onClick={() => window.open(teamMember.socials.iqWiki)}
                     />
                   )}

--- a/src/components/Faq/CreateWikisFAQ.tsx
+++ b/src/components/Faq/CreateWikisFAQ.tsx
@@ -37,7 +37,7 @@ const CreateWikisFAQ = () => {
             comprehensive - the system will generate the unique URL from the
             title.{' '}
             <iframe
-              title="Getting Started with creating wikis on IQ.WIKI"
+              title="Getting Started with creating wikis on IQ.wiki"
               src="https://www.youtube.com/embed/Y4gWJUFchrc"
             />{' '}
           </>

--- a/src/components/Glossary/GlossaryHero.tsx
+++ b/src/components/Glossary/GlossaryHero.tsx
@@ -24,7 +24,7 @@ const GlossaryHero = React.forwardRef<HTMLParagraphElement, ChakraProps>(
         my={14}
       >
         <Heading w="full" fontSize={{ base: '32', md: '42', lg: '4xl' }}>
-          <chakra.span color="brandLinkColor"> IQ.WIKI</chakra.span> Glossary
+          <chakra.span color="brandLinkColor"> IQ.wiki</chakra.span> Glossary
         </Heading>
         <Text
           w={{ base: '90%', md: '80%', xl: '90%' }}

--- a/src/components/Layout/Footer/Footer.tsx
+++ b/src/components/Layout/Footer/Footer.tsx
@@ -77,7 +77,7 @@ const Footer = () => {
             <Newsletter
               buttonTitle="Subscribe"
               header="Subscribe to our newsletter"
-              body="Never miss any of the most popular and trending articles on IQ.Wiki
+              body="Never miss any of the most popular and trending articles on IQ.wiki
         when you sign up to our email newsletter."
               url="https://www.getdrip.com/forms/505929689/submissions/new"
               {...newsletterOptions}

--- a/src/components/SEO/Blog.tsx
+++ b/src/components/SEO/Blog.tsx
@@ -4,12 +4,12 @@ import React from 'react'
 const BlogHeader = () => (
   <NextSeo
     title="Blog"
-    description="Stay up to date with latest stories and gist brought to you by IQ.Wiki"
+    description="Stay up to date with latest stories and gist brought to you by IQ.wiki"
     canonical="https://iq.wiki/blog"
     openGraph={{
       title: 'Blog',
       description:
-        'Stay up to date with latest stories and gist brought to you by IQ.Wiki',
+        'Stay up to date with latest stories and gist brought to you by IQ.wiki',
     }}
     twitter={{
       cardType: 'summary_large_image',

--- a/src/components/SEO/Default.tsx
+++ b/src/components/SEO/Default.tsx
@@ -8,21 +8,21 @@ interface SEOHeaderProps {
 
 const SEOHeader = ({ router }: SEOHeaderProps) => (
   <DefaultSeo
-    title="IQ.Wiki | Largest Blockchain & Crypto Encyclopedia"
-    titleTemplate="%s | IQ.Wiki"
+    title="IQ.wiki | Largest Blockchain & Crypto Encyclopedia"
+    titleTemplate="%s | IQ.wiki"
     description="World's largest Blockchain & Crypto Encyclopedia"
     canonical={`https://iq.wiki${router.asPath || ''}`}
     openGraph={{
-      title: 'IQ.Wiki | Crypto Encyclopedia',
+      title: 'IQ.wiki | Crypto Encyclopedia',
       description: "World's largest crypto knowledge base",
       type: 'website',
-      site_name: 'IQ.Wiki',
+      site_name: 'IQ.wiki',
       images: [
         {
           url: 'https://iq.wiki/images/defaults/og-image-default.png',
           width: 1200,
           height: 630,
-          alt: 'IQ.Wiki | Crypto Encyclopedia',
+          alt: 'IQ.wiki | Crypto Encyclopedia',
         },
       ],
     }}

--- a/src/components/SEO/Static.tsx
+++ b/src/components/SEO/Static.tsx
@@ -22,12 +22,12 @@ export const AboutHeader = () => (
 export const FaqSEO = () => (
   <NextSeo
     title="FAQ"
-    description="Frequently Asked Questions about IQ.Wiki"
-    titleTemplate="%s | IQ.Wiki"
+    description="Frequently Asked Questions about IQ.wiki"
+    titleTemplate="%s | IQ.wiki"
     canonical="https://iq.wiki/static/faq"
     openGraph={{
       title: 'FAQ',
-      description: 'Frequently Asked Questions about IQ.Wiki',
+      description: 'Frequently Asked Questions about IQ.wiki',
     }}
     twitter={{
       cardType: 'summary_large_image',
@@ -40,13 +40,13 @@ export const FaqSEO = () => (
 export const PrivacyPolicySEO = () => (
   <NextSeo
     title="Our Policy"
-    description="IQ.Wiki Security center: Your Personal Information is our primary responsibility at IQ.Wiki"
-    titleTemplate="%s | IQ.Wiki"
+    description="IQ.wiki Security center: Your Personal Information is our primary responsibility at IQ.wiki"
+    titleTemplate="%s | IQ.wiki"
     canonical="https://iq.wiki/static/privacy"
     openGraph={{
       title: 'Our Policy',
       description:
-        'IQ.Wiki Security center: Your Personal Information is our primary responsibility at IQ.Wiki',
+        'IQ.wiki Security center: Your Personal Information is our primary responsibility at IQ.wiki',
     }}
     twitter={{
       cardType: 'summary_large_image',
@@ -59,13 +59,13 @@ export const PrivacyPolicySEO = () => (
 export const CareersHeader = () => (
   <NextSeo
     title="Jobs"
-    description="Join us to spread the knowledge of blockchain | Search Job Openings across IQ.Wiki Network"
-    titleTemplate="%s | IQ.Wiki"
+    description="Join us to spread the knowledge of blockchain | Search Job Openings across IQ.wiki Network"
+    titleTemplate="%s | IQ.wiki"
     canonical="https://iq.wiki/careers"
     openGraph={{
       title: 'Jobs',
       description:
-        'Join us to spread the knowledge of blockchain | Search Job Openings across IQ.Wiki Network',
+        'Join us to spread the knowledge of blockchain | Search Job Openings across IQ.wiki Network',
     }}
     twitter={{
       cardType: 'summary_large_image',
@@ -78,12 +78,12 @@ export const CareersHeader = () => (
 export const CaPrivacyRightsHeader = () => (
   <NextSeo
     title="CA Privacy Rights"
-    description="Get Started, Explore and make the most of IQ.Wiki"
-    titleTemplate="%s | IQ.Wiki"
+    description="Get Started, Explore and make the most of IQ.wiki"
+    titleTemplate="%s | IQ.wiki"
     canonical="https://iq.wiki/static/CaPrivacyRights"
     openGraph={{
       title: 'CA Privacy Rights',
-      description: 'Get Started, Explore and make the most of IQ.Wiki',
+      description: 'Get Started, Explore and make the most of IQ.wiki',
     }}
     twitter={{
       cardType: 'summary_large_image',
@@ -96,12 +96,12 @@ export const CaPrivacyRightsHeader = () => (
 export const TermsHeader = () => (
   <NextSeo
     title="Terms of Service  "
-    description="Get Started, Explore and make the most of IQ.Wiki"
-    titleTemplate="%s | IQ.Wiki"
+    description="Get Started, Explore and make the most of IQ.wiki"
+    titleTemplate="%s | IQ.wiki"
     canonical="https://iq.wiki/static/terms"
     openGraph={{
       title: 'Terms of Service',
-      description: 'Get Started, Explore and make the most of IQ.Wiki',
+      description: 'Get Started, Explore and make the most of IQ.wiki',
     }}
     twitter={{
       cardType: 'summary_large_image',
@@ -114,12 +114,12 @@ export const TermsHeader = () => (
 export const GuidelinesHeader = () => (
   <NextSeo
     title="Our Guidelines"
-    description="IQ.Wiki guidelines for the community and network"
-    titleTemplate="%s | IQ.Wiki"
+    description="IQ.wiki guidelines for the community and network"
+    titleTemplate="%s | IQ.wiki"
     canonical="https://iq.wiki/static/guidelines"
     openGraph={{
       title: 'Our Guidelines',
-      description: 'IQ.Wiki guidelines for the community and network',
+      description: 'IQ.wiki guidelines for the community and network',
     }}
     twitter={{
       cardType: 'summary_large_image',

--- a/src/components/SEO/UserProfile.tsx
+++ b/src/components/SEO/UserProfile.tsx
@@ -33,11 +33,11 @@ export const UserProfileHeader = ({
         }
       />
       <NextSeo
-        title={`${username} · IQ.Wiki`}
+        title={`${username} · IQ.wiki`}
         description={`Blockchain wikis created by ${username}`}
         openGraph={{
-          title: `${username} · IQ.Wiki`,
-          description: bio || 'check out this user on IQ.Wiki',
+          title: `${username} · IQ.wiki`,
+          description: bio || 'check out this user on IQ.wiki',
           url: `${env.NEXT_PUBLIC_DOMAIN}/account/${username}`,
           type: 'profile',
           profile: {

--- a/src/data/NotificationChannelsData.ts
+++ b/src/data/NotificationChannelsData.ts
@@ -8,8 +8,8 @@ export const NotificationChannelsData: {
 }[] = [
   {
     id: 'EVERIPEDIA_NOTIFICATIONS',
-    title: 'IQ.Wiki Notifications',
-    description: 'Occasional updates from the IQ.Wiki team',
+    title: 'IQ.wiki Notifications',
+    description: 'Occasional updates from the IQ.wiki team',
     isChecked: false,
   },
 ]

--- a/src/hooks/useWeb3Token.ts
+++ b/src/hooks/useWeb3Token.ts
@@ -15,7 +15,7 @@ export const useWeb3Token = () => {
       (msg) => signer.signMessage({ message: msg }),
       {
         statement:
-          'Welcome to IQ.Wiki ! Click to sign in and accept the IQ.Wiki Terms of Service: https://everipedia.com/static/terms. This request will not trigger a blockchain transaction or cost any gas fees. Your authentication status will reset after 24 hours. ',
+          'Welcome to IQ.wiki ! Click to sign in and accept the IQ.wiki Terms of Service: https://everipedia.com/static/terms. This request will not trigger a blockchain transaction or cost any gas fees. Your authentication status will reset after 24 hours. ',
         expires_in: '1h',
       },
     )

--- a/src/pages/blog/[digest].tsx
+++ b/src/pages/blog/[digest].tsx
@@ -129,7 +129,7 @@ export const BlogPostPage = ({
                 textAlign="center"
               >
                 Join thousands of others in receiving the most interesting wikis
-                on IQ.Wiki every week
+                on IQ.wiki every week
               </Text>
               <Button
                 as="a"

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -34,7 +34,7 @@ export const Blog = ({ blogEntries }: { blogEntries: BlogType[] }) => {
             minWidth={100}
           >
             <Heading as="h1" size="2xl" letterSpacing="wide">
-              IQ.Wiki Blog
+              IQ.wiki Blog
             </Heading>
             <Flex alignItems="center" mt={[5, 0]}>
               <Text mr={5}>More from us</Text>

--- a/src/pages/branding/index.tsx
+++ b/src/pages/branding/index.tsx
@@ -120,11 +120,11 @@ const BrandingPage = () => {
   return (
     <Box bg="brandHero" pb="28" mt="-3">
       <NextSeo
-        title="IQ.Wiki Branding kit & official logos"
-        description="IQ.Wiki Branding kit & official logos"
+        title="IQ.wiki Branding kit & official logos"
+        description="IQ.wiki Branding kit & official logos"
         openGraph={{
-          title: 'IQ.Wiki Branding kit & official logos',
-          description: 'IQ.Wiki Branding kit & official logos',
+          title: 'IQ.wiki Branding kit & official logos',
+          description: 'IQ.wiki Branding kit & official logos',
         }}
       />
       <Box maxW={{ base: '90%', '2xl': '1280px' }} mx="auto">
@@ -139,7 +139,7 @@ const BrandingPage = () => {
               mb={{ base: 6, lg: 10 }}
               mt={{ base: 18 }}
             >
-              IQ.WIKI Branding kit
+              IQ.wiki Branding kit
             </Heading>
             <Text
               textAlign={{ base: 'center', lg: 'initial' }}
@@ -234,7 +234,7 @@ const BrandingPage = () => {
         <Box mt={20}>
           <Flex flexDir="column" gap={5}>
             <Heading textAlign={{ base: 'center', lg: 'initial' }}>
-              IQ.WIKI LOGO
+              IQ.wiki LOGO
             </Heading>
             <Text
               fontSize={{ lg: '2xl', base: 'sm' }}
@@ -340,7 +340,7 @@ const BrandingPage = () => {
             <List display="flex" flexDir="column" gap="10">
               <ListItem>
                 <ListIcon as={AiOutlineClose} color="primaryPink" />
-                Do not use the IQ.Wiki logo in any way that suggests that we are
+                Do not use the IQ.wiki logo in any way that suggests that we are
                 sponsoring, endorsing or affliated to your project in any way.
               </ListItem>
               <ListItem>

--- a/src/pages/careers/index.tsx
+++ b/src/pages/careers/index.tsx
@@ -10,7 +10,7 @@ const OurCareers = () => {
   return (
     <main>
       <CareersHero
-        title="IQ.Wiki Careers"
+        title="IQ.wiki Careers"
         description="Do you wish to join our great team? we're looking for
           Intellectual Individuals who are committed to doing well by doing
           good. here is the list of our open positions."

--- a/src/pages/terms.tsx
+++ b/src/pages/terms.tsx
@@ -17,11 +17,11 @@ const Terms = () => (
       <Flex gap={10} flexDirection={{ base: 'column', lg: 'row' }}>
         <Flex gap={5} flex="3" flexDirection="column">
           <Text>
-            Welcome to IQ.Wiki, the website and online service of Distributed
+            Welcome to IQ.wiki, the website and online service of Distributed
             Machines Inc. (&quot;IQ.wiki,&quot; &quot;we,&quot; &quot;us&quot;
             or &quot;our&quot;). This page explains the terms by which you may
             use our online and/or mobile services, website, and software
-            provided on or in connection with the IQ.Wiki service (collectively
+            provided on or in connection with the IQ.wiki service (collectively
             the &quot;Service&quot;). By accessing or using the Service, you
             (&quot;you&quot; or &quot;your&quot;), signify that you have read,
             understand and agree to be bound by the terms of service and

--- a/src/pages/us-careers_deprecated.tsx
+++ b/src/pages/us-careers_deprecated.tsx
@@ -8,7 +8,7 @@ const OurCareers = () => {
   return (
     <main>
       <CareersHero
-        title="IQ.Wiki US Careers"
+        title="IQ.wiki US Careers"
         description="Do you wish to join our great team? we're looking for
           Intellectual Individuals who are committed to doing well by doing
           good. here is the list of our open positions."

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -7,7 +7,7 @@ export const resources = {
     translation: {
       // |||||||||||||||||||| SECTIONS ||||||||||||||||||||
       // init
-      //--Copies for IQ.Wiki--
+      //--Copies for IQ.wiki--
 
       //Home page
       everipedia: 'IQ.wiki',
@@ -16,7 +16,7 @@ export const resources = {
       iq_descriptionShort: 'Start your crypto journey with IQ.wiki!',
       exploreHeroBttn: 'Explore',
       learnMoreHeroBttn: 'Learn more',
-      trendingWikis: 'Latest from IQ.Wiki',
+      trendingWikis: 'Latest from IQ.wiki',
       rankingListHeading: 'Wiki Rank By MarketCap',
       rankingListDescription:
         'A list of wikis in different categories, including DeFi, NFTs, DAOs and Cryptocurrencies, ranked based on marketcap.',
@@ -51,7 +51,7 @@ export const resources = {
       privacyPolicy: 'Privacy Policy',
       termsOfService: 'Terms of service',
       privacyRights: 'Your CA Privacy Rights',
-      copyRight: 'IQ.Wiki Powered By ',
+      copyRight: 'IQ.wiki Powered By ',
 
       //Desktop Nav
       Explore: 'Explore',
@@ -217,7 +217,7 @@ export const resources = {
 
       //Global text
       seenItAll: 'Yay! You have seen it all 🥳 ',
-      //---End of Copies for IQ.Wiki--
+      //---End of Copies for IQ.wiki--
 
       // ---------------------------------------------------------------
 


### PR DESCRIPTION
Change "IQ.Wiki" to "IQ.wiki" for consistency and branding accuracy.

Changes:
Replaced "IQ.Wiki" to "IQ.wiki" for consistency and branding accuracy.

