### PR TITLE
Infinite scroll bug

### DIFF
--- a/src/components/Profile/Collections.tsx
+++ b/src/components/Profile/Collections.tsx
@@ -51,7 +51,7 @@ export const Collections = ({
       </TabList>
       <TabPanels>
         {SECTIONS.map((section, sid) => (
-          <TabPanel key={sid} p="0">
+          <TabPanel key={sid} p={{ md: '8', xl: 0 }}>
             <section.Component />
           </TabPanel>
         ))}

--- a/src/components/Profile/UserWikis/UserCreatedWikis.tsx
+++ b/src/components/Profile/UserWikis/UserCreatedWikis.tsx
@@ -8,6 +8,7 @@ import { useInfiniteData } from '@/hooks/useInfiniteData'
 import { useTranslation } from 'react-i18next'
 import Collected from '../Collected'
 import { Activity } from '@/types/ActivityDataType'
+import { ITEM_PER_PAGE } from '@/data/Constants'
 
 const UserCreatedWikis = ({ createdWikis }: { createdWikis: Activity[] }) => {
   const router = useRouter()
@@ -43,7 +44,7 @@ const UserCreatedWikis = ({ createdWikis }: { createdWikis: Activity[] }) => {
         </Center>
       )}
       <Collected wikis={wikis} />
-      {loading || hasMore ? (
+      {(loading || hasMore) && wikis.length > ITEM_PER_PAGE ? (
         <Center mt={8} ref={createdWikisSentryRef} w="full" h="16">
           <Spinner size="xl" />
         </Center>

--- a/src/hooks/useInfiniteData.ts
+++ b/src/hooks/useInfiniteData.ts
@@ -10,7 +10,9 @@ type Opts = {
 }
 
 export const useInfiniteData = <T>(opts: Opts, initialData: T[] = []) => {
-  const [hasMore, setHasMore] = useState<boolean>(true)
+  const [hasMore, setHasMore] = useState<boolean>(
+    true && initialData.length > 0,
+  )
   const [data, setData] = useState<T[]>(initialData)
   const [offset, setOffset] = useState<number>(0)
   const [loading, setLoading] = useState<boolean>(opts.defaultLoading || false)
@@ -30,7 +32,7 @@ export const useInfiniteData = <T>(opts: Opts, initialData: T[] = []) => {
       const { data: resData } = result
 
       if (resData && resData.length > 0) {
-        setData((prevData) => [...prevData, ...resData])
+        setData(prevData => [...prevData, ...resData])
         setOffset(updatedOffset)
         if (resData.length < ITEM_PER_PAGE) setHasMore(false)
         else setHasMore(true)

--- a/src/hooks/useInfiniteData.ts
+++ b/src/hooks/useInfiniteData.ts
@@ -32,7 +32,7 @@ export const useInfiniteData = <T>(opts: Opts, initialData: T[] = []) => {
       const { data: resData } = result
 
       if (resData && resData.length > 0) {
-        setData(prevData => [...prevData, ...resData])
+        setData((prevData) => [...prevData, ...resData])
         setOffset(updatedOffset)
         if (resData.length < ITEM_PER_PAGE) setHasMore(false)
         else setHasMore(true)

--- a/src/pages/account/[profile].tsx
+++ b/src/pages/account/[profile].tsx
@@ -74,7 +74,7 @@ const Profile = ({ profileData, createdWikis, editedWikis }: ProfileProps) => {
 
 Profile.footer = false
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
+export const getServerSideProps: GetServerSideProps = async context => {
   const userIdentifier = context.params?.profile as string
 
   // Redirect if /accounts/settings is hit

--- a/src/pages/account/[profile].tsx
+++ b/src/pages/account/[profile].tsx
@@ -74,7 +74,7 @@ const Profile = ({ profileData, createdWikis, editedWikis }: ProfileProps) => {
 
 Profile.footer = false
 
-export const getServerSideProps: GetServerSideProps = async context => {
+export const getServerSideProps: GetServerSideProps = async (context) => {
   const userIdentifier = context.params?.profile as string
 
   // Redirect if /accounts/settings is hit

--- a/src/services/wikis/index.ts
+++ b/src/services/wikis/index.ts
@@ -183,7 +183,7 @@ export const wikiApi = createApi({
   baseQuery: graphqlRequestBaseQuery({ url: config.graphqlUrl }),
   refetchOnMountOrArgChange: 30,
   refetchOnFocus: true,
-  endpoints: builder => ({
+  endpoints: (builder) => ({
     getWikis: builder.query<RecentWikisBuilder[], void>({
       query: () => ({ document: GET_WIKIS }),
       transformResponse: (response: GetRecentWikisResponse) => response.wikis,
@@ -220,7 +220,7 @@ export const wikiApi = createApi({
         }
       },
       transformResponse: (response: GetUserWikiResponse) => {
-        if (response && response.userById && response.userById.wikisCreated) {
+        if (response?.userById?.wikisCreated) {
           return response.userById.wikisCreated
         }
         return []
@@ -317,7 +317,7 @@ export const wikiApi = createApi({
         variables: { limit, offset, type, category },
       }),
       transformResponse: (response: ActivitiesByCategoryData) =>
-        response.activitiesByCategory.map(activity => activity.content[0]),
+        response.activitiesByCategory.map((activity) => activity.content[0]),
     }),
     postWiki: builder.mutation<string, { data: Partial<Wiki> }>({
       query: ({ data }) => ({
@@ -330,7 +330,7 @@ export const wikiApi = createApi({
         response.pinJSON.IpfsHash,
     }),
     postWikiViewCount: builder.mutation<number, string>({
-      query: string => ({
+      query: (string) => ({
         document: POST_WIKI_VIEW_COUNT,
         variables: {
           id: string,

--- a/src/services/wikis/index.ts
+++ b/src/services/wikis/index.ts
@@ -183,7 +183,7 @@ export const wikiApi = createApi({
   baseQuery: graphqlRequestBaseQuery({ url: config.graphqlUrl }),
   refetchOnMountOrArgChange: 30,
   refetchOnFocus: true,
-  endpoints: (builder) => ({
+  endpoints: builder => ({
     getWikis: builder.query<RecentWikisBuilder[], void>({
       query: () => ({ document: GET_WIKIS }),
       transformResponse: (response: GetRecentWikisResponse) => response.wikis,
@@ -220,7 +220,10 @@ export const wikiApi = createApi({
         }
       },
       transformResponse: (response: GetUserWikiResponse) => {
-        return response.userById.wikisCreated
+        if (response && response.userById && response.userById.wikisCreated) {
+          return response.userById.wikisCreated
+        }
+        return []
       },
     }),
     getUserEditedWikis: builder.query<UserActivity[], WikiArg>({
@@ -314,7 +317,7 @@ export const wikiApi = createApi({
         variables: { limit, offset, type, category },
       }),
       transformResponse: (response: ActivitiesByCategoryData) =>
-        response.activitiesByCategory.map((activity) => activity.content[0]),
+        response.activitiesByCategory.map(activity => activity.content[0]),
     }),
     postWiki: builder.mutation<string, { data: Partial<Wiki> }>({
       query: ({ data }) => ({
@@ -327,7 +330,7 @@ export const wikiApi = createApi({
         response.pinJSON.IpfsHash,
     }),
     postWikiViewCount: builder.mutation<number, string>({
-      query: (string) => ({
+      query: string => ({
         document: POST_WIKI_VIEW_COUNT,
         variables: {
           id: string,


### PR DESCRIPTION
# Fixing Infinite Scroll Bug

This PR works 

- on handling the error state of the api call 
- avoid infinite scroll when the initial created or edited wiki is less than the items_per_page. 
- avoid infinite scroll when the initial created or edited wiki is empty

