### PR TITLE
Fix featured wikis rerendering issue

### DIFF
--- a/src/components/Categories/TrendingCategoryCard.tsx
+++ b/src/components/Categories/TrendingCategoryCard.tsx
@@ -36,13 +36,13 @@ const TrendingCategoryCard = ({
           {title}
         </Text>
       </Flex>
-      <WikiCarousel
-        data={wikis}
-        item={(wiki) => (
+      <WikiCarousel plugins={[Autoplay()]}>
+        {wikis.map((wiki) => (
           <chakra.div
             key={`wiki-${wiki.id}`}
             px={{ base: '1', md: '4' }}
             py="10px"
+            flex="0 0 100%"
           >
             <TrendingCategoryItem
               title={wiki.title}
@@ -53,9 +53,8 @@ const TrendingCategoryCard = ({
               wikiId={wiki.id}
             />
           </chakra.div>
-        )}
-        plugins={[Autoplay()]}
-      />
+        ))}
+      </WikiCarousel>
     </Box>
   )
 }

--- a/src/components/Elements/Carousel/Carousel.tsx
+++ b/src/components/Elements/Carousel/Carousel.tsx
@@ -10,12 +10,11 @@ import { IconType } from 'react-icons/lib'
 import 'slick-carousel/slick/slick.css'
 import 'slick-carousel/slick/slick-theme.css'
 
-type WikiCarouselProps<T> = {
-  data: T[]
-  item: (item: T) => JSX.Element
+type WikiCarouselProps = {
   options?: EmblaOptionsType
   plugins?: any[]
   Buttons?: false
+  children: React.ReactNode
 }
 
 interface ArrowProps {
@@ -31,13 +30,12 @@ interface CarouselProps {
   topArrow: string
 }
 
-export const WikiCarousel = <T extends unknown>({
-  data,
-  item,
+export const WikiCarousel = ({
   options,
   plugins,
   Buttons,
-}: WikiCarouselProps<T>) => {
+  children,
+}: WikiCarouselProps) => {
   const [emblaRef, emblaApi] = useEmblaCarousel({ ...options }, plugins)
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [scrollSnaps, setScrollSnaps] = useState<number[]>([])
@@ -109,13 +107,7 @@ export const WikiCarousel = <T extends unknown>({
         overflow="hidden"
         w="full"
       >
-        <Flex w="full">
-          {data?.map((e, i) => (
-            <Box key={i} flex="0 0 100%" minW="0" maxW="100%">
-              {item(e)}
-            </Box>
-          ))}
-        </Flex>
+        <Flex w="full">{children}</Flex>
       </chakra.div>
       <Flex w="full" alignItems="center" gap="3" pt="6" justifyContent="center">
         {scrollSnaps.map((_, index) => (

--- a/src/components/Landing/FeaturedWikis.tsx
+++ b/src/components/Landing/FeaturedWikis.tsx
@@ -43,16 +43,13 @@ export const FeaturedWikis = ({ featuredWikis }: { featuredWikis: Wiki[] }) => {
         </chakra.div>
         {featuredWikis ? (
           <chakra.div px={5}>
-            <WikiCarousel
-              data={featuredWikis}
-              item={(wiki) => (
-                <Box key={`wiki-${wiki.id}`}>
+            <WikiCarousel plugins={[Autoplay()]} options={OPTIONS}>
+              {featuredWikis.map((wiki) => (
+                <Box flex="0 0 100%" key={`wiki-${wiki.id}`}>
                   <FeaturedWikiCard wiki={wiki} />
                 </Box>
-              )}
-              plugins={[Autoplay()]}
-              options={OPTIONS}
-            />
+              ))}
+            </WikiCarousel>
           </chakra.div>
         ) : (
           <LoadingFeaturedWikiCard />


### PR DESCRIPTION
### Summary

Fixes https://github.com/EveripediaNetwork/issues/issues/1787.

This pr fixes the rerendering issue that was causing multiple network request for images in the featured wiki carousel

## How should this be tested?
- Open the network tab in chrome dev tools
- clear the previous requests
- images from the feature carousel should no longer be requested continuously

### Demo
<details>
<summary>Before</summary>

https://github.com/EveripediaNetwork/ep-ui/assets/30352484/00897079-aa47-441f-9cf3-5b56c550c2d2
</details>

<details>
<summary>After</summary>

https://github.com/EveripediaNetwork/ep-ui/assets/30352484/dbac91bd-e434-4695-816b-e53a54415660


</details>
