### PR TITLE
Feat add AI tokens

### DIFF
--- a/src/components/Landing/RankingList.tsx
+++ b/src/components/Landing/RankingList.tsx
@@ -51,8 +51,8 @@ const RankingList = ({ rankings, listingLimit }: RankingListProps) => {
     setAiTokenItems(
       sortByMarketCap(
         'descending',
-        TokensListing.filter(
-          (item) => item?.tokenMarketData?.isAiToken === true,
+        TokensListing.filter((item) =>
+          item.tags.some((tag) => tag.id === 'AI'),
         ),
       ),
     )
@@ -69,8 +69,8 @@ const RankingList = ({ rankings, listingLimit }: RankingListProps) => {
         setAiTokenItems(
           sortByMarketCap(
             'descending',
-            TokensListing.filter(
-              (item) => item?.tokenMarketData?.isAiToken === true,
+            TokensListing.filter((item) =>
+              item.tags.some((tag) => tag.id === 'AI'),
             ),
           ),
         )

--- a/src/components/Landing/RankingList.tsx
+++ b/src/components/Landing/RankingList.tsx
@@ -39,7 +39,9 @@ const RankingList = ({ rankings, listingLimit }: RankingListProps) => {
   const [aiTokenItems, setAiTokenItems] = useState<RankCardType[]>([])
   const [nftItems, setNftItems] = useState<RankCardType[]>([])
   const [sortOrder, setOrder] = useState<SortOrder>('descending')
-  const [selectedRanking, setSelectedRanking] = useState<String | undefined>('cryptocurrencies')
+  const [selectedRanking, setSelectedRanking] = useState<String | undefined>(
+    'cryptocurrencies',
+  )
 
   if (
     TokensListing &&
@@ -50,7 +52,9 @@ const RankingList = ({ rankings, listingLimit }: RankingListProps) => {
     setAiTokenItems(
       sortByMarketCap(
         'descending',
-        TokensListing.filter((item) => item?.tokenMarketData?.isAiToken === true),
+        TokensListing.filter(
+          (item) => item?.tokenMarketData?.isAiToken === true,
+        ),
       ),
     )
     setNftItems(sortByMarketCap('descending', NFTsListing))
@@ -66,7 +70,9 @@ const RankingList = ({ rankings, listingLimit }: RankingListProps) => {
         setAiTokenItems(
           sortByMarketCap(
             'descending',
-            TokensListing.filter((item) => item?.tokenMarketData?.isAiToken === true),
+            TokensListing.filter(
+              (item) => item?.tokenMarketData?.isAiToken === true,
+            ),
           ),
         )
         setNftItems(sortByMarketCap(newSortOrder, NFTsListing))
@@ -98,7 +104,13 @@ const RankingList = ({ rankings, listingLimit }: RankingListProps) => {
         maxW="768"
       >{`${t('rankingListDescription')}`}</Text>
       <Box maxW="1208px" mx="auto">
-        <Tabs mt={10} p="0" onChange={(index)=>setSelectedRanking(getKeyByValue(CATEGORIES_WITH_INDEX,index))}>
+        <Tabs
+          mt={10}
+          p="0"
+          onChange={(index) =>
+            setSelectedRanking(getKeyByValue(CATEGORIES_WITH_INDEX, index))
+          }
+        >
           <Flex justifyContent="center">
             <TabList border="none" display="flex" gap={{ base: '5', md: '8' }}>
               <RankingListButton

--- a/src/components/Landing/RankingList.tsx
+++ b/src/components/Landing/RankingList.tsx
@@ -106,7 +106,7 @@ const RankingList = ({ rankings, listingLimit }: RankingListProps) => {
         <Tabs
           mt={10}
           pl="4"
-          overflowX={"auto"}
+          overflowX={'auto'}
           onChange={(index) =>
             setSelectedRanking(getKeyByValue(CATEGORIES_WITH_INDEX, index))
           }

--- a/src/components/Landing/RankingList.tsx
+++ b/src/components/Landing/RankingList.tsx
@@ -26,6 +26,7 @@ import { getKeyByValue } from '@/utils/DataTransform/getKeyByValue'
 type RankingListProps = {
   rankings: {
     NFTsListing: RankCardType[]
+    aiTokensListing: RankCardType[]
     TokensListing: RankCardType[]
   }
   listingLimit: number
@@ -33,7 +34,7 @@ type RankingListProps = {
 
 const RankingList = ({ rankings, listingLimit }: RankingListProps) => {
   const { t } = useTranslation()
-  const { TokensListing, NFTsListing } = rankings
+  const { TokensListing, aiTokensListing, NFTsListing } = rankings
   const [tokenItems, setTokenItems] = useState<RankCardType[]>([])
   const [aiTokenItems, setAiTokenItems] = useState<RankCardType[]>([])
   const [nftItems, setNftItems] = useState<RankCardType[]>([])
@@ -44,41 +45,27 @@ const RankingList = ({ rankings, listingLimit }: RankingListProps) => {
 
   if (
     TokensListing &&
+    aiTokensListing &&
     NFTsListing &&
-    (!tokenItems.length || !nftItems.length)
+    (!tokenItems.length || !nftItems.length || !aiTokenItems.length)
   ) {
     setTokenItems(sortByMarketCap('descending', TokensListing))
-    setAiTokenItems(
-      sortByMarketCap(
-        'descending',
-        TokensListing.filter((item) =>
-          item.tags.some((tag) => tag.id === 'AI'),
-        ),
-      ),
-    )
+    setAiTokenItems(sortByMarketCap('descending', aiTokensListing))
     setNftItems(sortByMarketCap('descending', NFTsListing))
   }
 
   const onClickMap: OnClickMap = {
     Marketcap: function () {
-      if (tokenItems && nftItems) {
+      if (tokenItems && nftItems && aiTokenItems) {
         const newSortOrder =
           sortOrder === 'ascending' ? 'descending' : 'ascending'
         setOrder(newSortOrder)
         setTokenItems(sortByMarketCap(newSortOrder, TokensListing))
-        setAiTokenItems(
-          sortByMarketCap(
-            'descending',
-            TokensListing.filter((item) =>
-              item.tags.some((tag) => tag.id === 'AI'),
-            ),
-          ),
-        )
+        setAiTokenItems(sortByMarketCap(newSortOrder, aiTokensListing))
         setNftItems(sortByMarketCap(newSortOrder, NFTsListing))
       }
     },
   }
-
   return (
     <Box
       px={{ base: 3, md: 8 }}
@@ -107,9 +94,9 @@ const RankingList = ({ rankings, listingLimit }: RankingListProps) => {
           mt={10}
           pl="4"
           overflowX={'auto'}
-          onChange={(index) =>
+          onChange={(index) => {
             setSelectedRanking(getKeyByValue(CATEGORIES_WITH_INDEX, index))
-          }
+          }}
         >
           <Flex justifyContent="center">
             <TabList border="none" display="flex" gap={{ base: '2', md: '8' }}>

--- a/src/components/Landing/RankingList.tsx
+++ b/src/components/Landing/RankingList.tsx
@@ -105,13 +105,14 @@ const RankingList = ({ rankings, listingLimit }: RankingListProps) => {
       <Box maxW="1208px" mx="auto">
         <Tabs
           mt={10}
-          p="0"
+          pl="4"
+          overflowX={"auto"}
           onChange={(index) =>
             setSelectedRanking(getKeyByValue(CATEGORIES_WITH_INDEX, index))
           }
         >
           <Flex justifyContent="center">
-            <TabList border="none" display="flex" gap={{ base: '5', md: '8' }}>
+            <TabList border="none" display="flex" gap={{ base: '2', md: '8' }}>
               <RankingListButton
                 label="Cryptocurrencies"
                 icon={RiCoinsFill}

--- a/src/components/Landing/RankingList.tsx
+++ b/src/components/Landing/RankingList.tsx
@@ -12,8 +12,7 @@ import {
 } from '@chakra-ui/react'
 import { useTranslation } from 'react-i18next'
 import { BiImage } from 'react-icons/bi'
-import { FaBrain } from 'react-icons/fa'
-import { RiCoinsFill } from 'react-icons/ri'
+import { RiCoinsFill, RiRobotFill } from 'react-icons/ri'
 import { OnClickMap, RankCardType, SortOrder } from '@/types/RankDataTypes'
 import RankingListButton from '../Rank/RankButton'
 import { RankTable, RankTableHead } from '../Rank/RankTable'
@@ -120,7 +119,7 @@ const RankingList = ({ rankings, listingLimit }: RankingListProps) => {
               />
               <RankingListButton
                 label="AI Tokens"
-                icon={FaBrain}
+                icon={RiRobotFill}
                 fontSize={{ lg: 'md' }}
               />
               <RankingListButton

--- a/src/components/Rank/RankButton.tsx
+++ b/src/components/Rank/RankButton.tsx
@@ -12,7 +12,7 @@ const RankingListButton = ({
       display="flex"
       alignItems="center"
       color="homeDescriptionColor"
-      gap="3"
+      gap="2"
       _selected={{
         color: 'brandLinkColor',
         borderBottom: '2px solid',
@@ -26,7 +26,7 @@ const RankingListButton = ({
         h={{ lg: '32px', md: '24px' }}
         color="primaryPinkIcon"
       />
-      <Text color="inherit" fontWeight={600} {...props}>
+      <Text color="inherit" fontWeight={600} {...props} whiteSpace={"nowrap"} >
         {label}
       </Text>
     </Tab>

--- a/src/components/Rank/RankButton.tsx
+++ b/src/components/Rank/RankButton.tsx
@@ -26,7 +26,7 @@ const RankingListButton = ({
         h={{ lg: '32px', md: '24px' }}
         color="primaryPinkIcon"
       />
-      <Text color="inherit" fontWeight={600} {...props} whiteSpace={"nowrap"} >
+      <Text color="inherit" fontWeight={600} {...props} whiteSpace={'nowrap'}>
         {label}
       </Text>
     </Tab>

--- a/src/components/Rank/RankCardItem.tsx
+++ b/src/components/Rank/RankCardItem.tsx
@@ -40,13 +40,13 @@ const RankingItem = ({
   listingLimit: number
 }) => {
   const marketCap = item.nftMarketData
-    ? marketCapFormatter(item.nftMarketData.market_cap_usd)
-    : marketCapFormatter(item.tokenMarketData.market_cap)
+    ? marketCapFormatter(item.nftMarketData?.market_cap_usd)
+    : marketCapFormatter(item.tokenMarketData?.market_cap)
 
   const price = `$${
     item.nftMarketData
-      ? priceFormatter(item.nftMarketData.floor_price_usd)
-      : priceFormatter(item.tokenMarketData.current_price)
+      ? priceFormatter(item.nftMarketData?.floor_price_usd)
+      : priceFormatter(item.tokenMarketData?.current_price)
   }`
 
   const dateFounded = item?.events?.find(
@@ -85,8 +85,8 @@ const RankingItem = ({
             <Image
               src={
                 item.nftMarketData
-                  ? item.nftMarketData.image
-                  : item.tokenMarketData.image
+                  ? item.nftMarketData?.image
+                  : item.tokenMarketData?.image
               }
               alt={item.title}
               w="40px"
@@ -115,8 +115,8 @@ const RankingItem = ({
             </Box>
             <Text color="rankingListText">
               {item.nftMarketData
-                ? item.nftMarketData.alias
-                : item.tokenMarketData.alias}
+                ? item.nftMarketData?.alias
+                : item.tokenMarketData?.alias}
             </Text>
           </Box>
         </Flex>
@@ -133,13 +133,13 @@ const RankingItem = ({
               fontSize="10px"
               lineHeight="15px"
               color={
-                item.nftMarketData.floor_price_in_usd_24h_percentage_change < 0
+                item.nftMarketData?.floor_price_in_usd_24h_percentage_change < 0
                   ? 'red.500'
                   : 'green.500'
               }
             >
               {Math.abs(
-                item.nftMarketData.floor_price_in_usd_24h_percentage_change,
+                item.nftMarketData?.floor_price_in_usd_24h_percentage_change,
               ).toFixed(2)}
               %
             </Text>
@@ -149,12 +149,12 @@ const RankingItem = ({
               fontSize="10px"
               lineHeight="15px"
               color={
-                item.tokenMarketData.price_change_24h < 0
+                item.tokenMarketData?.price_change_24h < 0
                   ? 'red.500'
                   : 'green.500'
               }
             >
-              {Math.abs(item.tokenMarketData.price_change_24h).toFixed(2)}%
+              {Math.abs(item.tokenMarketData?.price_change_24h).toFixed(2)}%
             </Text>
           )}
         </Flex>
@@ -162,10 +162,10 @@ const RankingItem = ({
       <Td borderColor="rankingListBorder" fontWeight={500} fontSize="14px">
         {item.linkedWikis?.founders ? (
           <Flex flexWrap="wrap">
-            {formatFoundersArray(item.linkedWikis.founders)
+            {formatFoundersArray(item.linkedWikis?.founders)
               ?.slice(0, MAX_LINKED_WIKIS)
               ?.map((founderName, i, arr) => {
-                const founder = item.linkedWikis.founders[i]
+                const founder = item.linkedWikis?.founders[i]
                 return (
                   <Link
                     href={`wiki/${founder}`}

--- a/src/data/RankingListData.ts
+++ b/src/data/RankingListData.ts
@@ -3,8 +3,8 @@ import { RiArrowDownSFill } from 'react-icons/ri'
 
 export const CATEGORIES_WITH_INDEX = {
   cryptocurrencies: 0,
-  nfts: 2,
   aitokens: 1,
+  nfts: 2,
 }
 
 export const RankingListHead: RankinglistHeadProps = [

--- a/src/data/RankingListData.ts
+++ b/src/data/RankingListData.ts
@@ -4,7 +4,7 @@ import { RiArrowDownSFill } from 'react-icons/ri'
 export const CATEGORIES_WITH_INDEX = {
   cryptocurrencies: 0,
   nfts: 2,
-  aiTokens: 1,
+  aitokens: 1,
 }
 
 export const RankingListHead: RankinglistHeadProps = [

--- a/src/data/RankingListData.ts
+++ b/src/data/RankingListData.ts
@@ -3,7 +3,8 @@ import { RiArrowDownSFill } from 'react-icons/ri'
 
 export const CATEGORIES_WITH_INDEX = {
   cryptocurrencies: 0,
-  nfts: 1,
+  nfts: 2,
+  aiTokens: 1,
 }
 
 export const RankingListHead: RankinglistHeadProps = [

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,7 +19,12 @@ import { sortLeaderboards } from '@/utils/DataTransform/leaderboard.utils'
 import { RankCardType } from '@/types/RankDataTypes'
 import RankingList from '@/components/Landing/RankingList'
 import { nftLisitngAPI } from '@/services/nftlisting'
-import { getNFTRanking, getTokenRanking, rankingAPI } from '@/services/ranking'
+import {
+  getAiTokenRanking,
+  getNFTRanking,
+  getTokenRanking,
+  rankingAPI,
+} from '@/services/ranking'
 import { Hero } from '@/components/Landing/Hero'
 import { DayRangeType, getDateRange } from '@/utils/HomepageUtils/getDate'
 import { TrendingData } from '@/types/Home'
@@ -36,6 +41,7 @@ interface HomePageProps {
   leaderboards: LeaderBoardType[]
   rankings: {
     NFTsListing: RankCardType[]
+    aiTokensListing: RankCardType[]
     TokensListing: RankCardType[]
   }
   trending: TrendingData
@@ -116,6 +122,15 @@ export const getServerSideProps: GetServerSideProps = async () => {
       offset: 1,
     }),
   )
+  const { data: aiTokensList } = await store.dispatch(
+    getAiTokenRanking.initiate({
+      kind: 'NFT',
+      limit: RANKING_LIST_LIMIT,
+      offset: 1,
+      category: 'AI',
+    }),
+  )
+  console.log("after: ", aiTokensList)
 
   const { data: todayTrending } = await store.dispatch(
     getTrendingWikis.initiate({
@@ -171,6 +186,7 @@ export const getServerSideProps: GetServerSideProps = async () => {
 
   const rankings = {
     NFTsListing: NFTsList || [],
+    aiTokensListing: aiTokensList || [],
     TokensListing: TokensList || [],
   }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -124,13 +124,13 @@ export const getServerSideProps: GetServerSideProps = async () => {
   )
   const { data: aiTokensList } = await store.dispatch(
     getAiTokenRanking.initiate({
-      kind: 'NFT',
+      kind: 'TOKEN',
       limit: RANKING_LIST_LIMIT,
       offset: 1,
       category: 'AI',
     }),
   )
-  console.log("after: ", aiTokensList)
+  console.log('after: ', aiTokensList)
 
   const { data: todayTrending } = await store.dispatch(
     getTrendingWikis.initiate({

--- a/src/pages/rank/index.tsx
+++ b/src/pages/rank/index.tsx
@@ -118,7 +118,7 @@ const Rank = ({
     })
   console.log('rank page aiTokenData', aiTokenData)
   const { data: nftData, isFetching: NFTisFetching } = useGetNFTRankingQuery({
-    kind: 'NFT',
+    kind: 'TOKEN',
     offset: nftOffset,
     limit: LISTING_LIMIT,
   })

--- a/src/pages/rank/index.tsx
+++ b/src/pages/rank/index.tsx
@@ -116,7 +116,7 @@ const Rank = ({
       limit: LISTING_LIMIT,
       category: 'AI',
     })
-console.log("rank page aiTokenData", aiTokenData)
+  console.log('rank page aiTokenData', aiTokenData)
   const { data: nftData, isFetching: NFTisFetching } = useGetNFTRankingQuery({
     kind: 'NFT',
     offset: nftOffset,

--- a/src/pages/rank/index.tsx
+++ b/src/pages/rank/index.tsx
@@ -116,7 +116,7 @@ const Rank = ({
       limit: LISTING_LIMIT,
       category: 'AI',
     })
-
+console.log("rank page aiTokenData", aiTokenData)
   const { data: nftData, isFetching: NFTisFetching } = useGetNFTRankingQuery({
     kind: 'NFT',
     offset: nftOffset,

--- a/src/pages/rank/index.tsx
+++ b/src/pages/rank/index.tsx
@@ -183,6 +183,7 @@ const Rank = ({
       <Flex
         maxW={{ base: '100%', '2xl': '1280px', md: '95%' }}
         mx="auto"
+        pl={2}
         py={16}
         flexWrap="wrap"
         gap={{ base: 10, md: 0, lg: 4 }}
@@ -194,9 +195,10 @@ const Rank = ({
           }
           w="full"
           onChange={handleCategoryChange}
+          overflowX={"auto"}
         >
           <Flex justifyContent="center">
-            <TabList border="none" display="flex" gap={{ base: '5', md: '8' }}>
+            <TabList border="none" display="flex" gap={{ base: '2', md: '8' }}>
               <RankingListButton
                 label="Cryptocurrencies"
                 icon={RiCoinsFill}

--- a/src/pages/rank/index.tsx
+++ b/src/pages/rank/index.tsx
@@ -125,7 +125,7 @@ const Rank = ({
     setAiTokenItems(
       sortByMarketCap(
         'descending',
-        tokenData.filter((item) => item?.tokenMarketData.isAiToken === true),
+        tokenData.filter((item) => item.tags.some((tag) => tag.id === 'AI')),
       ),
     )
     hasRenderedInitialItems.current = true
@@ -138,7 +138,7 @@ const Rank = ({
       setAiTokenItems(
         sortByMarketCap(
           'descending',
-          tokenData.filter((item) => item?.tokenMarketData?.isAiToken === true),
+          tokenData.filter((item) => item.tags.some((tag) => tag.id === 'AI')),
         ),
       )
     }
@@ -155,8 +155,8 @@ const Rank = ({
         setAiTokenItems(
           sortByMarketCap(
             newSortOrder,
-            tokenData.filter(
-              (item) => item?.tokenMarketData?.isAiToken === true,
+            tokenData.filter((item) =>
+              item.tags.some((tag) => tag.id === 'AI'),
             ),
           ),
         )

--- a/src/pages/rank/index.tsx
+++ b/src/pages/rank/index.tsx
@@ -126,7 +126,7 @@ const Rank = ({
     setAiTokenItems(
       sortByMarketCap(
         'descending',
-        tokenData.filter((item) => item?.tokenMarketData?.isAiToken === true),
+        tokenData.filter((item) => item?.tokenMarketData.current_price > 100),
       ),
     )
     hasRenderedInitialItems.current = true
@@ -139,7 +139,9 @@ const Rank = ({
       setAiTokenItems(
         sortByMarketCap(
           'descending',
-          tokenData.filter((item) => item?.tokenMarketData?.isAiToken === true),
+          tokenData.filter(
+            (item) => item?.tokenMarketData?.current_price > 100,
+          ),
         ),
       )
     }
@@ -274,7 +276,7 @@ const Rank = ({
                 AI Token wikis ranked by Market Cap Prices
               </Text>
               <RankTable
-                hasPagination
+                hasPagination={aiTokenItems.length >= LISTING_LIMIT}
                 currentPage={aiTokensOffset}
                 totalCount={totalTokens}
                 pageSize={LISTING_LIMIT}

--- a/src/pages/rank/index.tsx
+++ b/src/pages/rank/index.tsx
@@ -11,8 +11,7 @@ import {
   Tbody,
 } from '@chakra-ui/react'
 import { BiImage } from 'react-icons/bi'
-import { FaBrain } from 'react-icons/fa'
-import { RiCoinsFill } from 'react-icons/ri'
+import { RiCoinsFill, RiRobotFill } from 'react-icons/ri'
 import RankHeader from '@/components/SEO/Rank'
 import RankingListButton from '@/components/Rank/RankButton'
 import { RankTable, RankTableHead } from '@/components/Rank/RankTable'
@@ -126,7 +125,7 @@ const Rank = ({
     setAiTokenItems(
       sortByMarketCap(
         'descending',
-        tokenData.filter((item) => item?.tokenMarketData.current_price > 100),
+        tokenData.filter((item) => item?.tokenMarketData.isAiToken === true),
       ),
     )
     hasRenderedInitialItems.current = true
@@ -139,9 +138,7 @@ const Rank = ({
       setAiTokenItems(
         sortByMarketCap(
           'descending',
-          tokenData.filter(
-            (item) => item?.tokenMarketData?.current_price > 100,
-          ),
+          tokenData.filter((item) => item?.tokenMarketData?.isAiToken === true),
         ),
       )
     }
@@ -207,7 +204,7 @@ const Rank = ({
               />
               <RankingListButton
                 label="AI Tokens"
-                icon={FaBrain}
+                icon={RiRobotFill}
                 fontSize={{ lg: '20px' }}
               />
               <RankingListButton

--- a/src/pages/rank/index.tsx
+++ b/src/pages/rank/index.tsx
@@ -195,7 +195,7 @@ const Rank = ({
           }
           w="full"
           onChange={handleCategoryChange}
-          overflowX={"auto"}
+          overflowX={'auto'}
         >
           <Flex justifyContent="center">
             <TabList border="none" display="flex" gap={{ base: '2', md: '8' }}>

--- a/src/pages/rank/index.tsx
+++ b/src/pages/rank/index.tsx
@@ -59,10 +59,12 @@ export const sortByMarketCap = (order: SortOrder, items: RankCardType[]) => {
 const Rank = ({
   totalTokens,
   totalNfts,
+  totalAiTokens,
   pagination,
 }: {
   totalNfts: number
   totalTokens: number
+  totalAiTokens: number
   pagination: { category: string; page: number }
 }) => {
   const hasRenderedInitialItems = useRef(false)
@@ -276,7 +278,7 @@ const Rank = ({
               <RankTable
                 hasPagination={aiTokenItems.length >= LISTING_LIMIT}
                 currentPage={aiTokensOffset}
-                totalCount={totalTokens}
+                totalCount={totalAiTokens}
                 pageSize={LISTING_LIMIT}
                 onPageChange={(page) => setAiTokensOffset(page)}
               >

--- a/src/pages/rank/index.tsx
+++ b/src/pages/rank/index.tsx
@@ -11,6 +11,7 @@ import {
   Tbody,
 } from '@chakra-ui/react'
 import { BiImage } from 'react-icons/bi'
+import { FaBrain } from 'react-icons/fa'
 import { RiCoinsFill } from 'react-icons/ri'
 import RankHeader from '@/components/SEO/Rank'
 import RankingListButton from '@/components/Rank/RankButton'
@@ -66,18 +67,24 @@ const Rank = ({
 }) => {
   const hasRenderedInitialItems = useRef(false)
   const [tokenItems, setTokenItems] = useState<RankCardType[]>([])
+  const [aiTokenItems, setAiTokenItems] = useState<RankCardType[]>([])
   const [nftItems, setNftItems] = useState<RankCardType[]>([])
   const [sortOrder, setOrder] = useState<SortOrder>('descending')
   const router = useRouter()
   const { pathname } = router
+
   const [nftOffset, setNftOffset] = useState<number>(
     pagination.category === 'nfts' ? pagination.page : 1,
   )
   const [tokensOffset, setTokensOffset] = useState<number>(
     pagination.category === 'cryptocurrencies' ? pagination.page : 1,
   )
+  const [aiTokensOffset, setAiTokensOffset] = useState<number>(
+    pagination.category === 'aitokens' ? pagination.page : 1,
+  )
 
   const totalTokenOffset = LISTING_LIMIT * (tokensOffset - 1)
+  const totalAiTokenOffset = LISTING_LIMIT * (aiTokensOffset - 1)
   const totalNftCount = LISTING_LIMIT * (nftOffset - 1)
 
   const handleCategoryChange = (index: number) => {
@@ -116,6 +123,12 @@ const Rank = ({
   ) {
     setTokenItems(sortByMarketCap('descending', tokenData))
     setNftItems(sortByMarketCap('descending', nftData))
+    setAiTokenItems(
+      sortByMarketCap(
+        'descending',
+        tokenData.filter((item) => item?.tokenMarketData?.isAiToken === true),
+      ),
+    )
     hasRenderedInitialItems.current = true
   }
 
@@ -123,6 +136,12 @@ const Rank = ({
     if (tokenData && nftData && hasRenderedInitialItems.current) {
       setTokenItems(sortByMarketCap('descending', tokenData))
       setNftItems(sortByMarketCap('descending', nftData))
+      setAiTokenItems(
+        sortByMarketCap(
+          'descending',
+          tokenData.filter((item) => item?.tokenMarketData?.isAiToken === true),
+        ),
+      )
     }
   }, [tokenData, nftData])
 
@@ -134,6 +153,14 @@ const Rank = ({
         setOrder(newSortOrder)
         setTokenItems(sortByMarketCap(newSortOrder, tokenData))
         setNftItems(sortByMarketCap(newSortOrder, nftData))
+        setAiTokenItems(
+          sortByMarketCap(
+            newSortOrder,
+            tokenData.filter(
+              (item) => item?.tokenMarketData?.isAiToken === true,
+            ),
+          ),
+        )
       }
     },
   }
@@ -174,6 +201,11 @@ const Rank = ({
               <RankingListButton
                 label="Cryptocurrencies"
                 icon={RiCoinsFill}
+                fontSize={{ lg: '20px' }}
+              />
+              <RankingListButton
+                label="AI Tokens"
+                icon={FaBrain}
                 fontSize={{ lg: '20px' }}
               />
               <RankingListButton
@@ -222,6 +254,51 @@ const Rank = ({
                         <InvalidRankCardItem
                           key={`invalid-token${index}`}
                           index={totalTokenOffset + index}
+                        />
+                      ),
+                    )
+                  )}
+                </Tbody>
+              </RankTable>
+            </TabPanel>
+            <TabPanel>
+              <Text
+                color="homeDescriptionColor"
+                fontSize={{ base: 'lg', lg: 22 }}
+                mx="auto"
+                mb={12}
+                px={4}
+                textAlign="center"
+                maxW="750"
+              >
+                AI Token wikis ranked by Market Cap Prices
+              </Text>
+              <RankTable
+                hasPagination
+                currentPage={aiTokensOffset}
+                totalCount={totalTokens}
+                pageSize={LISTING_LIMIT}
+                onPageChange={(page) => setAiTokensOffset(page)}
+              >
+                <RankTableHead onClickMap={onClickMap} />
+                <Tbody>
+                  {isFetching || !aiTokenItems ? (
+                    <LoadingRankCardSkeleton length={20} />
+                  ) : (
+                    aiTokenItems?.map((token, index) =>
+                      token ? (
+                        <RankingItem
+                          listingLimit={LISTING_LIMIT}
+                          offset={totalAiTokenOffset}
+                          order={sortOrder}
+                          key={token.id}
+                          index={index}
+                          item={token}
+                        />
+                      ) : (
+                        <InvalidRankCardItem
+                          key={`invalid-token${index}`}
+                          index={totalAiTokenOffset + index}
                         />
                       ),
                     )

--- a/src/pages/rank/index.tsx
+++ b/src/pages/rank/index.tsx
@@ -19,7 +19,7 @@ import {
   getCategoryTotal,
   useGetNFTRankingQuery,
   useGetTokenRankingQuery,
-  useGetAiTokenRankingQuery
+  useGetAiTokenRankingQuery,
 } from '@/services/ranking'
 import { InvalidRankCardItem } from '@/components/Rank/InvalidRankCardItem'
 import { store } from '@/store/store'
@@ -107,12 +107,13 @@ const Rank = ({
     limit: LISTING_LIMIT,
   })
 
-  const { data: aiTokenData, isFetching: aiTokenisFetching } = useGetAiTokenRankingQuery({
-    kind: 'TOKEN',
-    offset: aiTokensOffset,
-    limit: LISTING_LIMIT,
-    category: 'AI',
-  })
+  const { data: aiTokenData, isFetching: aiTokenisFetching } =
+    useGetAiTokenRankingQuery({
+      kind: 'TOKEN',
+      offset: aiTokensOffset,
+      limit: LISTING_LIMIT,
+      category: 'AI',
+    })
 
   const { data: nftData, isFetching: NFTisFetching } = useGetNFTRankingQuery({
     kind: 'NFT',
@@ -137,7 +138,12 @@ const Rank = ({
   }
 
   useEffect(() => {
-    if (tokenData && nftData && aiTokenData && hasRenderedInitialItems.current) {
+    if (
+      tokenData &&
+      nftData &&
+      aiTokenData &&
+      hasRenderedInitialItems.current
+    ) {
       setTokenItems(sortByMarketCap('descending', tokenData))
       setAiTokenItems(sortByMarketCap('descending', aiTokenData))
       setNftItems(sortByMarketCap('descending', nftData))

--- a/src/pages/rank/index.tsx
+++ b/src/pages/rank/index.tsx
@@ -116,9 +116,11 @@ const Rank = ({
       limit: LISTING_LIMIT,
       category: 'AI',
     })
+
   console.log('rank page aiTokenData', aiTokenData)
+
   const { data: nftData, isFetching: NFTisFetching } = useGetNFTRankingQuery({
-    kind: 'TOKEN',
+    kind: 'NFT',
     offset: nftOffset,
     limit: LISTING_LIMIT,
   })

--- a/src/services/ranking/index.tsx
+++ b/src/services/ranking/index.tsx
@@ -4,7 +4,7 @@ import {
   GET_NFT_RANKINGS,
   GET_RANK_COUNT,
   GET_TOKEN_RANKINGS,
-  GET_AI_TOKEN_RANKINGS
+  GET_AI_TOKEN_RANKINGS,
 } from '@/services/ranking/queries'
 import config from '@/config'
 import { RankCardType } from '@/types/RankDataTypes'
@@ -108,5 +108,9 @@ export const {
   useGetCategoryTotalQuery,
 } = rankingAPI
 
-export const { getNFTRanking, getTokenRanking, getAiTokenRanking, getCategoryTotal } =
-  rankingAPI.endpoints
+export const {
+  getNFTRanking,
+  getTokenRanking,
+  getAiTokenRanking,
+  getCategoryTotal,
+} = rankingAPI.endpoints

--- a/src/services/ranking/index.tsx
+++ b/src/services/ranking/index.tsx
@@ -85,7 +85,7 @@ export const rankingAPI = createApi({
         kind: string
         limit?: number
         offset?: number
-        category?: string
+        category: string
       }) => ({
         document: GET_AI_TOKEN_RANKINGS,
         variables: { kind, limit, offset, category },

--- a/src/services/ranking/index.tsx
+++ b/src/services/ranking/index.tsx
@@ -4,6 +4,7 @@ import {
   GET_NFT_RANKINGS,
   GET_RANK_COUNT,
   GET_TOKEN_RANKINGS,
+  GET_AI_TOKEN_RANKINGS
 } from '@/services/ranking/queries'
 import config from '@/config'
 import { RankCardType } from '@/types/RankDataTypes'
@@ -66,6 +67,31 @@ export const rankingAPI = createApi({
       }),
       transformResponse: (response: RankListResponse) => response.rankList,
     }),
+    getAiTokenRanking: builder.query<
+      RankCardType[],
+      {
+        kind: string
+        limit: number
+        offset: number
+        category: string
+      }
+    >({
+      query: ({
+        kind,
+        limit,
+        offset,
+        category,
+      }: {
+        kind: string
+        limit?: number
+        offset?: number
+        category?: string
+      }) => ({
+        document: GET_AI_TOKEN_RANKINGS,
+        variables: { kind, limit, offset, category },
+      }),
+      transformResponse: (response: RankListResponse) => response.rankList,
+    }),
     getCategoryTotal: builder.query<RankCount, { category: string }>({
       query: ({ category }: { category: string }) => ({
         document: GET_RANK_COUNT,
@@ -78,8 +104,9 @@ export const rankingAPI = createApi({
 export const {
   useGetNFTRankingQuery,
   useGetTokenRankingQuery,
+  useGetAiTokenRankingQuery,
   useGetCategoryTotalQuery,
 } = rankingAPI
 
-export const { getNFTRanking, getTokenRanking, getCategoryTotal } =
+export const { getNFTRanking, getTokenRanking, getAiTokenRanking, getCategoryTotal } =
   rankingAPI.endpoints

--- a/src/services/ranking/queries.tsx
+++ b/src/services/ranking/queries.tsx
@@ -43,6 +43,9 @@ export const GET_TOKEN_RANKINGS = gql`
         id
         title
         ipfs
+        tags {
+          id
+        }
         created
         media {
           thumbnail

--- a/src/services/ranking/queries.tsx
+++ b/src/services/ranking/queries.tsx
@@ -37,8 +37,48 @@ export const GET_NFT_RANKINGS = gql`
 `
 
 export const GET_TOKEN_RANKINGS = gql`
-  query getNFTRanking($kind: RankType, $limit: Int, $offset: Int) {
+  query getTokenRanking($kind: RankType, $limit: Int, $offset: Int) {
     rankList(kind: $kind, limit: $limit, offset: $offset) {
+      ... on TokenRankListData {
+        id
+        title
+        ipfs
+        tags {
+          id
+        }
+        created
+        media {
+          thumbnail
+        }
+        images {
+          id
+        }
+        linkedWikis {
+          founders
+          blockchains
+        }
+        events {
+          date
+          type
+        }
+        tokenMarketData {
+          hasWiki
+          image
+          name
+          alias
+          current_price
+          market_cap
+          market_cap_rank
+          price_change_24h
+          market_cap_change_24h
+        }
+      }
+    }
+  }
+`
+export const GET_AI_TOKEN_RANKINGS = gql`
+  query getTokenRanking($kind: RankType, $limit: Int, $offset: Int, $category: TokenCategory ) {
+    rankList(kind: $kind, limit: $limit, offset: $offset, category: $category) {
       ... on TokenRankListData {
         id
         title

--- a/src/types/RankDataTypes.ts
+++ b/src/types/RankDataTypes.ts
@@ -7,6 +7,7 @@ export interface RankCardType {
   hasWiki: any
   id: string
   title: string
+  tags: Tag[]
   ipfs: string
   media: Medum[]
   images: Image[]
@@ -17,6 +18,10 @@ export interface RankCardType {
     blockchains: string[]
   }
   events: BaseEvents[]
+}
+
+export type Tag = {
+  id: string
 }
 
 export interface Medum {

--- a/src/types/RankDataTypes.ts
+++ b/src/types/RankDataTypes.ts
@@ -61,7 +61,7 @@ export interface TokenMarketData {
   alias: string
   current_price: number
   image: string
-  isAiToken: boolean
+  isAiToken?: boolean
 }
 
 export interface RankTableProps {

--- a/src/types/RankDataTypes.ts
+++ b/src/types/RankDataTypes.ts
@@ -61,6 +61,7 @@ export interface TokenMarketData {
   alias: string
   current_price: number
   image: string
+  isAiToken: boolean
 }
 
 export interface RankTableProps {


### PR DESCRIPTION
# Add `AI Tokens` tab to rankings table on landing and rank page.

Adds AI token table to ranking table. Existing token data is filtered and rendered in AI tokens tab sorted by market cap.

WIP screenshot

![image](https://github.com/EveripediaNetwork/ep-ui/assets/58448956/71eeb8e3-d6bf-461d-a3e2-4296bbbbdaad)


## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/1799
