### PR TITLE
Youtube link regex fix

### DIFF
--- a/src/data/WikiLinks.ts
+++ b/src/data/WikiLinks.ts
@@ -83,7 +83,10 @@ export const LINK_OPTIONS = [
     type: LinkType.SOCIAL,
     label: 'Youtube',
     icon: AiFillYoutube,
-    tests: [/https:\/\/(www.)?youtube.com\/\w+/],
+    tests: [
+      /https:\/\/(www.)?youtube.com\/\w+/,
+      /https:\/\/www\.youtube\.com\/(@\w+)\b/,
+    ],
   },
   {
     id: CommonMetaIds.FACEBOOK_PROFILE,

--- a/src/data/WikiLinks.ts
+++ b/src/data/WikiLinks.ts
@@ -83,10 +83,7 @@ export const LINK_OPTIONS = [
     type: LinkType.SOCIAL,
     label: 'Youtube',
     icon: AiFillYoutube,
-    tests: [
-      /https:\/\/(www.)?youtube.com\/\w+/,
-      /https:\/\/www\.youtube\.com\/(@\w+)\b/,
-    ],
+    tests: [/https:\/\/(www.)?youtube.com\/[\w@]+/],
   },
   {
     id: CommonMetaIds.FACEBOOK_PROFILE,


### PR DESCRIPTION
# Youtube link regex fix

This PR fixes the issue with the input field not accepting '@' as part of the special characters that should be accepted for links.

## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/1844
