### PR TITLE
Fix wiki not being linked

### DIFF
--- a/src/components/CreateWiki/EditorModals/EditWikiDetailsModal/LinkedWikisInput.tsx
+++ b/src/components/CreateWiki/EditorModals/EditWikiDetailsModal/LinkedWikisInput.tsx
@@ -96,12 +96,11 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
     wiki.linkedWikis &&
     Object.values(wiki.linkedWikis).some((wikis) => wikis.length > 0)
 
-  function getWikiPreviewByTitle(
+  const getWikiPreviewByTitle = (
     wikiPreviews: WikiPreview[],
     wikiTitle: string,
-  ): WikiPreview | undefined {
-    return wikiPreviews.find((preview) => preview.title === wikiTitle)
-  }
+  ): WikiPreview | undefined =>
+    wikiPreviews.find((preview) => preview.title === wikiTitle)
 
   return (
     <Stack rounded="md" _dark={{ borderColor: 'whiteAlpha.300' }} spacing="2">

--- a/src/components/CreateWiki/EditorModals/EditWikiDetailsModal/LinkedWikisInput.tsx
+++ b/src/components/CreateWiki/EditorModals/EditWikiDetailsModal/LinkedWikisInput.tsx
@@ -64,9 +64,6 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [search])
 
-  console.log('search', search)
-  console.log('res: ', results)
-
   const handleAddWiki = () => {
     if (selectedWiki === '') return
     dispatch({
@@ -98,6 +95,13 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
   const containsLinkedWikis =
     wiki.linkedWikis &&
     Object.values(wiki.linkedWikis).some((wikis) => wikis.length > 0)
+
+  function getWikiPreviewByTitle(
+    wikiPreviews: WikiPreview[],
+    wikiTitle: string,
+  ): WikiPreview | undefined {
+    return wikiPreviews.find((preview) => preview.title === wikiTitle)
+  }
 
   return (
     <Stack rounded="md" _dark={{ borderColor: 'whiteAlpha.300' }} spacing="2">
@@ -134,7 +138,8 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
               </Center>
             }
             onChange={(val) => {
-              setSelectedWiki(val)
+              const wikiPreview = getWikiPreviewByTitle(results, val)
+              setSelectedWiki(wikiPreview?.id ?? '')
               setSearch('')
             }}
           >
@@ -170,7 +175,9 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
                     key={`option-${result.id}`}
                     value={result.title}
                     textTransform="capitalize"
-                  />
+                  >
+                    {result.title}
+                  </AutoCompleteItem>
                 ))}
               </AutoCompleteList>
             )}

--- a/src/components/CreateWiki/EditorModals/EditWikiDetailsModal/LinkedWikisInput.tsx
+++ b/src/components/CreateWiki/EditorModals/EditWikiDetailsModal/LinkedWikisInput.tsx
@@ -25,7 +25,6 @@ import {
 import { store } from '@/store/store'
 import { RiArrowRightDownLine, RiCloseLine } from 'react-icons/ri'
 
-
 const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
   const dispatch = useAppDispatch()
   const [search, setSearch] = React.useState('')
@@ -60,14 +59,13 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
         setResults(data.slice(0, 6))
         setLoading(false)
       })
-    }
-    else setResults([])
+    } else setResults([])
     if (search !== '') setSelectedWiki('')
     // eslint-disable-next-line react-hooks/exhaustive-deps
-}, [search])
+  }, [search])
 
-console.log("search", search)
-console.log("res: ", results)
+  console.log('search', search)
+  console.log('res: ', results)
 
   const handleAddWiki = () => {
     if (selectedWiki === '') return
@@ -147,9 +145,9 @@ console.log("res: ", results)
               disabled={!linkType}
               placeholder="Search a wiki"
               value={(search || selectedWiki) ?? ''}
-              onChange={(e) =>{
-                setSearch(e.target.value)}
-              }
+              onChange={(e) => {
+                setSearch(e.target.value)
+              }}
               type="text"
               autoFocus
             />

--- a/src/components/CreateWiki/EditorModals/EditWikiDetailsModal/LinkedWikisInput.tsx
+++ b/src/components/CreateWiki/EditorModals/EditWikiDetailsModal/LinkedWikisInput.tsx
@@ -170,9 +170,7 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
                     key={`option-${result.id}`}
                     value={result.title}
                     textTransform="capitalize"
-                  >
-                    {result.title}
-                  </AutoCompleteItem>
+                  />
                 ))}
               </AutoCompleteList>
             )}


### PR DESCRIPTION
# Fixes blockchain wiki not being linked in wiki metadata editor

- Used a getWikiByTitle function to fetch the selected linked wiki, instead of using the wiki title.

![image](https://github.com/EveripediaNetwork/ep-ui/assets/58448956/660639d1-802c-402d-b066-450f86729cda)

This part needs to remain same, as the `value` prop being different was causing the bnb chain bug according to my research.