### PR TITLE
fix twitter preview image

### DIFF
--- a/src/components/SEO/Rank.tsx
+++ b/src/components/SEO/Rank.tsx
@@ -7,7 +7,7 @@ const RankHeader = () => (
     description="Live update for nft and tokens marketcap"
     canonical="https://iq.wiki/rank"
     openGraph={{
-      title: 'Rank- MarketCap',
+      title: 'Rank - MarketCap',
       description:
         'A list of cryptocurrencies, NFTs and crypto founders ranked by their individual market cap',
       images: [

--- a/src/components/SEO/Rank.tsx
+++ b/src/components/SEO/Rank.tsx
@@ -20,7 +20,7 @@ const RankHeader = () => (
       ],
     }}
     twitter={{
-      cardType: 'summary_large_image',
+      cardType: 'summary',
       handle: '@IQWiki',
       site: 'IQWiki',
     }}


### PR DESCRIPTION
Fixes rank page twitter preview image.

<img width="618" alt="Screenshot 2023-12-07 at 1 56 32 PM" src="https://github.com/EveripediaNetwork/ep-ui/assets/30352484/5534a256-243a-4d2a-b4b1-6bbfad62dfe4">

Closes https://github.com/EveripediaNetwork/issues/issues/2067