### PR TITLE
Fixes missing Bonk token missing details

### DIFF
--- a/src/services/token-stats/utils.ts
+++ b/src/services/token-stats/utils.ts
@@ -24,13 +24,20 @@ export const getTokenFromURI = (coingeckoUrl: string) =>
     .reverse()
     .find((c) => /\w+/.test(c)) as string
 
+const getCmcTokenFromUri = (coinMarketCapUrl: string) => {
+  const pattern = /\/currencies\/([^\/]+)/
+  const match = coinMarketCapUrl.match(pattern)
+  return match ? match[1] : null
+}
+
+//TODO: make cmc url test more robust
 export const fetchTokenStats = async (
   coingeckoUrl?: string,
   coinMarketCap?: string,
 ) => {
   if (!coingeckoUrl || !coinMarketCap) return undefined
   const token = getTokenFromURI(coingeckoUrl)
-  const cmcToken = getTokenFromURI(coinMarketCap)
+  const cmcToken = getCmcTokenFromUri(coinMarketCap)
   if (!token || !cmcToken) return undefined
   const tokenDetails = remappingTokenIds(token, cmcToken)
   const { data } = await store.dispatch(getTokenStats.initiate(tokenDetails))


### PR DESCRIPTION
# Fixes missing market cap, conversion details for Bonk token

- Refactor `getTokenFromUri` function to fetch correct token name


## Notes or observations
- The issue was caused due to coinmarketcap url wiki metadata being incorrectly set to `https://coinmarketcap.com/currencies/bonk1/#Chart`

![image](https://github.com/EveripediaNetwork/ep-ui/assets/58448956/73316cb7-0f71-4ed4-8c12-4be701114ac9)


## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/2193
