### PR TITLE
fix wiki image sizing in wiki

### DIFF
--- a/src/components/Wiki/WikiPage/CustomRenderers/customImageRender.tsx
+++ b/src/components/Wiki/WikiPage/CustomRenderers/customImageRender.tsx
@@ -12,9 +12,7 @@ export const customImageRender = ({
   return (
     <Image
       quality={95}
-      loader={
-        typeof src === 'string' && src.startsWith('http') ? cfLoader : undefined
-      }
+      loader={cfLoader}
       src={src || ''}
       alt="wiki"
       width={900}

--- a/src/components/Wiki/WikiPage/CustomRenderers/customImageRender.tsx
+++ b/src/components/Wiki/WikiPage/CustomRenderers/customImageRender.tsx
@@ -1,5 +1,6 @@
-import { Image } from '@/components/Elements/Image/Image'
+import Image from 'next/image'
 import React from 'react'
+import { cfLoader } from '@/components/Elements/Image/Image'
 
 export const customImageRender = ({
   ...props
@@ -7,13 +8,22 @@ export const customImageRender = ({
   React.ImgHTMLAttributes<HTMLImageElement>,
   HTMLImageElement
 >) => {
+  const { src } = props
   return (
     <Image
-      h="300px"
-      my={2}
-      objectFit="contain"
-      src={props.src || ''}
+      quality={95}
+      loader={
+        typeof src === 'string' && src.startsWith('http') ? cfLoader : undefined
+      }
+      src={src || ''}
       alt="wiki"
+      width={900}
+      height={400}
+      style={{
+        width: 'auto',
+        height: 'auto',
+        position: 'static',
+      }}
     />
   )
 }


### PR DESCRIPTION
# Summary
Fixes wiki image size to be the same in viewing mode and editing mode

<details>
<summary> Before </summary>

![Screenshot 2024-02-05 at 4 00 18 PM](https://github.com/EveripediaNetwork/ep-ui/assets/30352484/ba85a012-4880-44d1-9df7-7d008d84922d)
</details>

<details>
<summary> After </summary>

![Screenshot 2024-02-05 at 4 20 39 PM](https://github.com/EveripediaNetwork/ep-ui/assets/30352484/2ae1c29c-cdec-4f70-8590-17446f8503f9)

</details>


## Linked issues
closes https://github.com/EveripediaNetwork/issues/issues/2242
