### PR TITLE
Add debug log to show network information before publishing a wiki

### DIFF
--- a/src/components/CreateWiki/CreateWikiTopBar/WikiPublish/WikiPublishButton.tsx
+++ b/src/components/CreateWiki/CreateWikiTopBar/WikiPublish/WikiPublishButton.tsx
@@ -205,6 +205,7 @@ export const WikiPublishButton = () => {
   }
 
   const handleWikiPublish = async (override?: boolean) => {
+    console.log('ℹ️ DEBUG SHOW NETWORK: ', { connectedChainId, chainId })
     if (connectedChainId !== chainId) {
       setShowNetworkModal(true)
       return


### PR DESCRIPTION
This pull request adds a debug log to the WikiPublishButton component in the CreateWikiTopBar directory. The log displays network information before publishing a wiki.