### PR TITLE
Fix media error

### DIFF
--- a/src/components/CreateWiki/EditorModals/MediaModal.tsx
+++ b/src/components/CreateWiki/EditorModals/MediaModal.tsx
@@ -35,7 +35,7 @@ import { WikiImageObjectProps } from '@/types/CreateWikiType'
 import { saveImage } from '@/utils/CreateWikiUtils/saveImage'
 import { useTranslation } from 'next-i18next'
 
-const MAX_MEDIA = 12
+const MAX_MEDIA = 25
 
 const MediaModal = ({
   onClose = () => {},
@@ -254,6 +254,7 @@ const MediaModal = ({
                 setImage={handleSetImage}
                 showFetchedImage={false}
                 modalUpload
+                media={wiki.media}
               />
             </Flex>
             {wiki.media !== undefined && wiki.media?.length > 0 && (
@@ -276,7 +277,7 @@ const MediaModal = ({
                         wiki.media?.length > MAX_MEDIA
                       }
                     >
-                      <Text fontSize="xs">Save {wiki.media.length}</Text>
+                      <Text fontSize="xs">Save</Text>
                     </Button>
                   </Tooltip>
                   <Button onClick={onClose} variant="outline" size="md">

--- a/src/components/CreateWiki/EditorModals/MediaModal.tsx
+++ b/src/components/CreateWiki/EditorModals/MediaModal.tsx
@@ -17,6 +17,7 @@ import {
   Stack,
   useToast,
   Select,
+  Tooltip,
 } from '@chakra-ui/react'
 import { RiCloseLine, RiImageLine } from 'react-icons/ri'
 import { useAppDispatch, useAppSelector } from '@/store/hook'
@@ -258,9 +259,26 @@ const MediaModal = ({
             {wiki.media !== undefined && wiki.media?.length > 0 && (
               <Box mb={4} justifyContent="center" display="flex">
                 <Stack spacing={4} direction="row" align="center">
-                  <Button size="md" onClick={onClose}>
-                    <Text fontSize="xs">Save</Text>
-                  </Button>
+                  <Tooltip
+                    isDisabled={
+                      wiki.media !== undefined &&
+                      wiki.media?.length > 0 &&
+                      wiki.media?.length <= MAX_MEDIA
+                    }
+                    label="Media items limited to 12"
+                  >
+                    <Button
+                      size="md"
+                      onClick={onClose}
+                      isDisabled={
+                        wiki.media === undefined ||
+                        wiki.media?.length <= 0 ||
+                        wiki.media?.length > MAX_MEDIA
+                      }
+                    >
+                      <Text fontSize="xs">Save {wiki.media.length}</Text>
+                    </Button>
+                  </Tooltip>
                   <Button onClick={onClose} variant="outline" size="md">
                     <Text fontSize="xs">Cancel</Text>
                   </Button>

--- a/src/components/Elements/ImageInput/ImageInput.tsx
+++ b/src/components/Elements/ImageInput/ImageInput.tsx
@@ -100,8 +100,8 @@ const ImageInput = ({
   ) => {
     const url = event.target.value
     const urlType = linkRecognizer(url)
-
-    if (!urlType.type) {
+    const isVideoUnavailable = await fetch(`/api/checkVideo?url=${url}`)
+    if (!urlType.type || isVideoUnavailable) {
       setImageSrc(undefined)
       toast({
         title: 'Paste a valid image URL',
@@ -111,7 +111,7 @@ const ImageInput = ({
       return
     }
 
-    if (urlType.type === 'youtube') {
+    if (urlType.type === 'youtube' && !isVideoUnavailable) {
       const videoID = urlType?.value
       dispatch({
         type: 'wiki/addMedia',

--- a/src/components/Elements/ImageInput/ImageInput.tsx
+++ b/src/components/Elements/ImageInput/ImageInput.tsx
@@ -130,7 +130,7 @@ const ImageInput = ({
       if (isVideoUnavailable) {
         setImageSrc(undefined)
         toast({
-          title: 'Video is unavailable',
+          title: 'Video is unavailable, please check url and try again',
           status: 'error',
           duration: 3000,
         })

--- a/src/pages/api/checkVideo.ts
+++ b/src/pages/api/checkVideo.ts
@@ -1,0 +1,35 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  //cast as string
+  const { url } = req.query as { url: string }
+  let isUnavailable
+  console.log('url', url)
+  if (!url) {
+    return res.status(400).json({
+      error: 'Please provide a YouTube video URL',
+      videoUnavailable: true,
+    })
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {},
+    })
+
+    const text = await response.text()
+    console.log('text', text.slice(0, 50))
+    isUnavailable = text.includes('Video unavailable')
+
+    res.status(200).json({ videoUnavailable: isUnavailable })
+  } catch (error) {
+    console.error('Error fetching video page:', error)
+    res
+      .status(500)
+      .json({ error: 'Error fetching video page', videoUnavailable: true })
+  }
+}

--- a/src/pages/api/checkVideo.ts
+++ b/src/pages/api/checkVideo.ts
@@ -4,14 +4,12 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
 ) {
-  //cast as string
   const { url } = req.query as { url: string }
   let isUnavailable
-  console.log('url', url)
   if (!url) {
     return res.status(400).json({
       error: 'Please provide a YouTube video URL',
-      videoUnavailable: true,
+      isUnavailable: true,
     })
   }
 
@@ -22,14 +20,13 @@ export default async function handler(
     })
 
     const text = await response.text()
-    console.log('text', text.slice(0, 50))
     isUnavailable = text.includes('Video unavailable')
 
-    res.status(200).json({ videoUnavailable: isUnavailable })
+    res.status(200).json({ isUnavailable })
   } catch (error) {
     console.error('Error fetching video page:', error)
     res
       .status(500)
-      .json({ error: 'Error fetching video page', videoUnavailable: true })
+      .json({ error: 'Error fetching video page', isUnavailable: true })
   }
 }


### PR DESCRIPTION
# Fixes media error
- Check for invalid youtube vids
- Prevent editor from exceeding media items limit of 25

## Notes or observations
currently checking for valid videos using a workaround to avoid using youtube API

```js
try {
    const response = await fetch(url, {
      method: 'GET',
      headers: {},
    })

    const text = await response.text()
    isUnavailable = text.includes('Video unavailable')

    res.status(200).json({ isUnavailable })
  } catch (error) {
    console.error('Error fetching video page:', error)
    res
      .status(500)
      .json({ error: 'Error fetching video page', isUnavailable: true })
  }
}
```

## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/2276
