### PR TITLE
Fix rank table spacing on mobile

### DIFF
--- a/src/components/Rank/FounderRankCardItem.tsx
+++ b/src/components/Rank/FounderRankCardItem.tsx
@@ -223,12 +223,12 @@ const FounderRankingItem = ({
                   <React.Fragment key={`blockchain${i}`}>
                     {i > 0 && (
                       <Box as="span" color="brandLinkColor">
-                        ,
+                        , &nbsp;
                       </Box>
                     )}
                     <Link href={`/wiki/${blockchain}`} color="brandLinkColor">
                       {blockchain.charAt(0).toUpperCase() +
-                        blockchain.slice(1).replace('-', ' ')}
+                        blockchain.slice(1).replace('-', '')}
                     </Link>
                   </React.Fragment>
                 )

--- a/src/components/Rank/FounderRankCardItem.tsx
+++ b/src/components/Rank/FounderRankCardItem.tsx
@@ -70,8 +70,9 @@ const FounderRankingItem = ({
         fontWeight={500}
         fontSize="14px"
         px={{ base: 3, md: '6' }}
+        minW="65px"
       >
-        <Text color="rankingListText">
+        <Text color="rankingListText" width="fit-content">
           {order === 'descending'
             ? index + offset + 1
             : listingLimit + offset - index}
@@ -147,6 +148,7 @@ const FounderRankingItem = ({
         fontWeight={500}
         fontSize="14px"
         px={2}
+        minW="150px"
       >
         <Flex
           gap="2.5"
@@ -186,7 +188,12 @@ const FounderRankingItem = ({
       >
         <Text color="rankingListText">{marketCap}</Text>
       </Td>
-      <Td borderColor="rankingListBorder" fontWeight={500} fontSize="14px">
+      <Td
+        borderColor="rankingListBorder"
+        fontWeight={500}
+        fontSize="14px"
+        minW="150px"
+      >
         <Flex gap="1" minH={5} justifyContent={'center'} alignItems={'center'}>
           <Text color="rankingListText">{marketCapChange}</Text>
           {item.nftMarketData ? (
@@ -213,7 +220,12 @@ const FounderRankingItem = ({
           )}
         </Flex>
       </Td>
-      <Td borderColor="rankingListBorder" fontWeight={500} fontSize="14px">
+      <Td
+        borderColor="rankingListBorder"
+        fontWeight={500}
+        fontSize="14px"
+        minW="150px"
+      >
         {item.linkedWikis?.blockchains ? (
           <Flex flexWrap="wrap">
             {item.linkedWikis.blockchains
@@ -238,7 +250,12 @@ const FounderRankingItem = ({
           <Text>NA</Text>
         )}
       </Td>
-      <Td borderColor="rankingListBorder" fontWeight={500} fontSize="14px">
+      <Td
+        borderColor="rankingListBorder"
+        fontWeight={500}
+        fontSize="14px"
+        minW="155px"
+      >
         {dateFounded ? (
           <Link href={`/wiki/${item.id}/events`} color="brandLinkColor">
             <Text>{formatDate(dateFounded)}</Text>

--- a/src/components/Rank/FoundersRankTable.tsx
+++ b/src/components/Rank/FoundersRankTable.tsx
@@ -69,6 +69,7 @@ export const FoundersRankTableHead = ({
               fontSize="12px"
               textTransform="capitalize"
               color="rankingListTableHeading"
+              px={{ base: item.label === '#' ? 3 : 2, md: '6' }}
             >
               <Flex
                 alignItems="center"

--- a/src/components/Rank/RankCardItem.tsx
+++ b/src/components/Rank/RankCardItem.tsx
@@ -67,6 +67,7 @@ const RankingItem = ({
         fontWeight={500}
         fontSize="14px"
         px={{ base: 3, md: '6' }}
+        minW="72px"
       >
         <Text color="rankingListText" width={'fit-content'}>
           {order === 'descending'
@@ -80,6 +81,8 @@ const RankingItem = ({
         fontSize="14px"
         pl={{ base: 0, md: '2' }}
         pr={{ base: 2, md: 6 }}
+        // maxW='350px'
+        minW="200px"
       >
         <Flex gap="2.5" alignItems="center">
           <Box
@@ -105,7 +108,7 @@ const RankingItem = ({
               overflow={'hidden'}
               textOverflow={'ellipsis'}
               whiteSpace={'nowrap'}
-              maxW={{ base: '70px', md: '200px' }}
+              maxW={{ base: '175px', md: '200px' }}
               overflowX={'hidden'}
             >
               {item.nftMarketData ? (
@@ -147,6 +150,7 @@ const RankingItem = ({
         fontWeight={500}
         fontSize="14px"
         px={{ base: 2, md: 6 }}
+        minW="150px"
       >
         <Text color="rankingListText">{price}</Text>
       </Td>
@@ -155,6 +159,7 @@ const RankingItem = ({
         fontWeight={500}
         fontSize="14px"
         px={{ base: 2, md: 6 }}
+        minW="150px"
       >
         <Flex gap="1">
           <Text color="rankingListText">{marketCap}</Text>
@@ -195,6 +200,8 @@ const RankingItem = ({
         fontWeight={500}
         fontSize="14px"
         px={{ base: 2, md: 6 }}
+        maxW="350px"
+        minW="250px"
       >
         {item.linkedWikis?.founders ? (
           <Flex flexWrap="wrap">
@@ -209,7 +216,7 @@ const RankingItem = ({
                     color="brandLinkColor"
                   >
                     {founderName}
-                    {i !== arr.length - 1 && arr.length > 1 && ', '}
+                    {i !== arr.length - 1 && arr.length > 1 && ','} &nbsp;
                   </Link>
                 )
               })}
@@ -226,6 +233,7 @@ const RankingItem = ({
         fontWeight={500}
         fontSize="14px"
         px={{ base: 2, md: 6 }}
+        minW="150px"
       >
         {item.linkedWikis?.blockchains ? (
           <Flex flexWrap="wrap">
@@ -236,12 +244,12 @@ const RankingItem = ({
                   <React.Fragment key={`blockchain${i}`}>
                     {i > 0 && (
                       <Box as="span" color="brandLinkColor">
-                        ,
+                        , &nbsp;
                       </Box>
                     )}
                     <Link href={`/wiki/${blockchain}`} color="brandLinkColor">
                       {blockchain.charAt(0).toUpperCase() +
-                        blockchain.slice(1).replace('-', ' ')}
+                        blockchain.slice(1).replace('-', '')}
                     </Link>
                   </React.Fragment>
                 )
@@ -256,6 +264,7 @@ const RankingItem = ({
         fontWeight={500}
         fontSize="14px"
         px={{ base: 2, md: 6 }}
+        minW="150px"
       >
         {dateFounded ? (
           <Link href={`/wiki/${item.id}/events`} color="brandLinkColor">

--- a/src/components/Rank/RankCardItem.tsx
+++ b/src/components/Rank/RankCardItem.tsx
@@ -67,7 +67,7 @@ const RankingItem = ({
         fontWeight={500}
         fontSize="14px"
         px={{ base: 3, md: '6' }}
-        minW="72px"
+        minW="65px"
       >
         <Text color="rankingListText" width={'fit-content'}>
           {order === 'descending'
@@ -159,7 +159,7 @@ const RankingItem = ({
         fontWeight={500}
         fontSize="14px"
         px={{ base: 2, md: 6 }}
-        minW="150px"
+        minW="175px"
       >
         <Flex gap="1">
           <Text color="rankingListText">{marketCap}</Text>

--- a/src/pages/rank/[[...category]].tsx
+++ b/src/pages/rank/[[...category]].tsx
@@ -268,11 +268,14 @@ const Rank = ({
   }
   const { t } = useTranslation('rank')
   return (
-    <Box minW={'full'} w="100%">
+    <Box
+    //  minW={'full'}
+    // w="100%"
+    >
       <RankHeader />
       <Flex
-        w="100%"
-        minW={'full'}
+        // w="100%"
+        // minW={'full'}
         pb={16}
         pt={4}
         flexWrap="wrap"
@@ -328,6 +331,7 @@ const Rank = ({
               display={'flex'}
               flexDir={'column'}
               alignItems={'center'}
+              w="100%"
             >
               <Flex
                 h={350}


### PR DESCRIPTION
# Rank table spacing fix

- Fixes excessive space on crypto and NFT tabs on mobile
![image](https://github.com/EveripediaNetwork/ep-ui/assets/58448956/61851538-a4f3-48f0-b13a-bb4b586eb9da)
After
![image](https://github.com/EveripediaNetwork/ep-ui/assets/58448956/c49154ce-1266-4549-aa39-08deffca1110)


- Fix name formatting on some table items
![image](https://github.com/EveripediaNetwork/ep-ui/assets/58448956/d6b35090-1b2e-4b17-98af-4a61f7f5f436)

After
![image](https://github.com/EveripediaNetwork/ep-ui/assets/58448956/7fcf3e80-eeed-46d7-90f4-a0932cfe9b42)


## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/2326
