### PR TITLE
disabled rating hovering after selection

### DIFF
--- a/src/components/Wiki/WikiPage/InsightComponents/WikiStarRating.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/WikiStarRating.tsx
@@ -73,7 +73,10 @@ const wikiStarRating = ({
             variant="unstyled"
             color={ratingValue <= (currHoverRating || 0) ? 'brand.500' : ''}
             aria-label={`rating-${ratingValue}`}
-            onMouseOver={() => setCurrHoverRating(i + 1)}
+            onMouseOver={() => {
+              if (loading) return null
+              setCurrHoverRating(i + 1)
+            }}
             onClick={() => {
               sendFeedback(ratingValue)
             }}


### PR DESCRIPTION
# Disabled rating hovering after selection

After submitting a star rating on a particular wiki, users shouldn't be able to modify their rating by hovering over the stars again. This flaw can compromise the accuracy of feedback. I disable interaction with the star rating component after submission, ensuring the integrity of the user's initial choice and maintaining reliable data collection.

## How should this be tested?

1. On the IQ.wiki page, click on activity on the navbar
2. Click on any of the cards on the activity page, takes you to the wiki article page
3. Scroll right side downwards to the rating section and try rating the article

fixes https://github.com/EveripediaNetwork/issues/issues/2375
