### PR TITLE
fixed multiple rating for a wiki post

### DIFF
--- a/src/components/Wiki/WikiPage/InsightComponents/WikiStarRating.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/WikiStarRating.tsx
@@ -23,6 +23,13 @@ const wikiStarRating = ({
   const [hasSelectedRating, setHasSelectedRating] = React.useState(false)
   const [loading, setLoading] = React.useState(false)
 
+  React.useEffect(() => {
+    const storedRating = localStorage.getItem(`wikiRating_${contentId}`)
+    if (storedRating) {
+      setIsRated(true)
+    }
+  }, [contentId, setIsRated])
+
   const sendFeedback = async (rating: number) => {
     setHasSelectedRating(true)
     setLoading(true)
@@ -33,6 +40,7 @@ const wikiStarRating = ({
     refetch?.()
     setLoading(false)
     setIsRated(true)
+    localStorage.setItem(`wikiRating_${contentId}`, rating.toString())
   }
 
   return isAvgRating ? (


### PR DESCRIPTION
# Fixed multiple rating for a wiki post

_On the rating widget, it was noticed that users can rate a wiki multiple times upon refresh of that page. I fixed the issue allowing a user on a single to just rate the wiki once and shouldn't be able to rate the wiki again ._

## How should this be tested?

1. Go to the IQ.wiki page, click on any wiki article
2. Rate the article
3. Refresh the page or go back to previous page and select the wiki

closes https://github.com/EveripediaNetwork/issues/issues/2397
