### PR TITLE
made ui update on glossary page

### DIFF
--- a/src/components/Glossary/GlossaryAlphabets.tsx
+++ b/src/components/Glossary/GlossaryAlphabets.tsx
@@ -4,21 +4,10 @@ import { Link } from 'react-scroll'
 import { GlossaryAlphabetsProps } from '@/types/GlossaryType'
 
 const GlossaryAlphabets = (props: GlossaryAlphabetsProps) => {
-  const { shouldBeFixed, heightOfElement, item } = props
+  const { item } = props
   return (
     <GridItem w="100%" cursor="pointer" textAlign="center">
-      <Link
-        activeClass="active"
-        to={item}
-        spy
-        smooth
-        offset={
-          shouldBeFixed
-            ? -(heightOfElement || 284)
-            : -(heightOfElement ? heightOfElement + 228 : 512)
-        }
-        duration={70}
-      >
+      <Link activeClass="active" to={item} spy smooth duration={70}>
         <Text
           fontWeight="semibold"
           fontSize={{ base: 'md', xl: 'lg' }}

--- a/src/components/Glossary/GlossaryAlphabets.tsx
+++ b/src/components/Glossary/GlossaryAlphabets.tsx
@@ -6,7 +6,7 @@ import { GlossaryAlphabetsProps } from '@/types/GlossaryType'
 const GlossaryAlphabets = (props: GlossaryAlphabetsProps) => {
   const { item } = props
   return (
-    <GridItem w="100%" cursor="pointer" textAlign="center">
+    <GridItem w="100%" cursor="pointer">
       <Link activeClass="active" to={item} spy smooth duration={70}>
         <Text
           fontWeight="semibold"

--- a/src/components/Glossary/GlossaryAlphabets.tsx
+++ b/src/components/Glossary/GlossaryAlphabets.tsx
@@ -4,10 +4,21 @@ import { Link } from 'react-scroll'
 import { GlossaryAlphabetsProps } from '@/types/GlossaryType'
 
 const GlossaryAlphabets = (props: GlossaryAlphabetsProps) => {
-  const { item } = props
+  const { shouldBeFixed, heightOfElement, item } = props
   return (
     <GridItem w="100%" cursor="pointer">
-      <Link activeClass="active" to={item} spy smooth duration={70}>
+      <Link
+        activeClass="active"
+        to={item}
+        spy
+        smooth
+        offset={
+          shouldBeFixed
+            ? -(heightOfElement || 284)
+            : -(heightOfElement ? heightOfElement + 228 : 512)
+        }
+        duration={70}
+      >
         <Text
           fontWeight="semibold"
           fontSize={{ base: 'md', xl: 'lg' }}

--- a/src/components/Glossary/GlossaryFilterSection.tsx
+++ b/src/components/Glossary/GlossaryFilterSection.tsx
@@ -22,16 +22,11 @@ const GlossaryFilterSection = (props: GlossaryFilterSectionProps) => {
     setActiveIndex,
   } = props
   return (
-    <>
-      <Box
-        w="full"
-        my={shouldBeFixed ? 5 : 0}
-        px={{
-          base: `${shouldBeFixed ? '4' : '0'}`,
-          lg: `${shouldBeFixed ? 'auto' : '0'}`,
-          xl: `${shouldBeFixed ? '64' : '0'}`,
-        }}
-      >
+    <Box
+      w={shouldBeFixed ? 'min(90%, 1100px)' : 'full'}
+      mx={shouldBeFixed ? 'auto' : ''}
+    >
+      <Box my={shouldBeFixed ? 5 : 0}>
         <InputGroup size="md" w="full">
           <InputLeftElement
             ml={{ base: '15px', xl: 'unset' }}
@@ -60,7 +55,6 @@ const GlossaryFilterSection = (props: GlossaryFilterSectionProps) => {
         alignItems="center"
         justifyContent={{ lg: 'start', '2xl': 'center' }}
         gap={{ base: '3', '2xl': '4' }}
-        px={shouldBeFixed ? '4' : '0'}
       >
         {COMMONLY_SEARCHED_WIKIS.slice(0, 5)?.map((word, i) => {
           return (
@@ -88,7 +82,7 @@ const GlossaryFilterSection = (props: GlossaryFilterSectionProps) => {
           )
         })}
       </Flex>
-    </>
+    </Box>
   )
 }
 

--- a/src/components/Glossary/GlossaryFilterSection.tsx
+++ b/src/components/Glossary/GlossaryFilterSection.tsx
@@ -23,7 +23,7 @@ const GlossaryFilterSection = (props: GlossaryFilterSectionProps) => {
   } = props
   return (
     <>
-      <Box w="full" mb={shouldBeFixed ? 5 : 0}>
+      <Box w="full" my={shouldBeFixed ? 5 : 0} px={{ base: '4', lg: '32' }}>
         <InputGroup size="md" w="full">
           <InputLeftElement
             ml={{ base: '15px', xl: 'unset' }}
@@ -52,6 +52,7 @@ const GlossaryFilterSection = (props: GlossaryFilterSectionProps) => {
         alignItems="center"
         justifyContent={{ lg: 'start', '2xl': 'center' }}
         gap={{ base: '3', '2xl': '10' }}
+        px={{ base: '4', lg: '32' }}
       >
         {COMMONLY_SEARCHED_WIKIS.slice(0, 5)?.map((word, i) => {
           return (

--- a/src/components/Glossary/GlossaryFilterSection.tsx
+++ b/src/components/Glossary/GlossaryFilterSection.tsx
@@ -29,7 +29,7 @@ const GlossaryFilterSection = (props: GlossaryFilterSectionProps) => {
         px={{
           base: `${shouldBeFixed ? '4' : '0'}`,
           lg: `${shouldBeFixed ? 'auto' : '0'}`,
-          xl: `${shouldBeFixed ? '72' : '0'}`,
+          xl: `${shouldBeFixed ? '64' : '0'}`,
         }}
       >
         <InputGroup size="md" w="full">

--- a/src/components/Glossary/GlossaryFilterSection.tsx
+++ b/src/components/Glossary/GlossaryFilterSection.tsx
@@ -59,8 +59,7 @@ const GlossaryFilterSection = (props: GlossaryFilterSectionProps) => {
         wrap="wrap"
         alignItems="center"
         justifyContent={{ lg: 'start', '2xl': 'center' }}
-        gap={{ base: '3', '2xl': '10' }}
-        px={{ base: '4', lg: '32' }}
+        gap={{ base: '3', '2xl': '4' }}
       >
         {COMMONLY_SEARCHED_WIKIS.slice(0, 5)?.map((word, i) => {
           return (

--- a/src/components/Glossary/GlossaryFilterSection.tsx
+++ b/src/components/Glossary/GlossaryFilterSection.tsx
@@ -23,7 +23,15 @@ const GlossaryFilterSection = (props: GlossaryFilterSectionProps) => {
   } = props
   return (
     <>
-      <Box w="full" my={shouldBeFixed ? 5 : 0} px={{ base: '4', lg: '32' }}>
+      <Box
+        w="full"
+        my={shouldBeFixed ? 5 : 0}
+        px={{
+          base: `${shouldBeFixed ? '4' : '0'}`,
+          lg: `${shouldBeFixed ? 'auto' : '0'}`,
+          xl: `${shouldBeFixed ? '72' : '0'}`,
+        }}
+      >
         <InputGroup size="md" w="full">
           <InputLeftElement
             ml={{ base: '15px', xl: 'unset' }}

--- a/src/components/Glossary/GlossaryFilterSection.tsx
+++ b/src/components/Glossary/GlossaryFilterSection.tsx
@@ -45,7 +45,7 @@ const GlossaryFilterSection = (props: GlossaryFilterSectionProps) => {
             />
           </InputLeftElement>
           <Input
-            type="tel"
+            type="text"
             placeholder="Search for words"
             value={searchText}
             onChange={(e) => searchPage(e.target.value)}
@@ -60,6 +60,7 @@ const GlossaryFilterSection = (props: GlossaryFilterSectionProps) => {
         alignItems="center"
         justifyContent={{ lg: 'start', '2xl': 'center' }}
         gap={{ base: '3', '2xl': '4' }}
+        px={shouldBeFixed ? '4' : '0'}
       >
         {COMMONLY_SEARCHED_WIKIS.slice(0, 5)?.map((word, i) => {
           return (

--- a/src/components/Glossary/GlossaryHero.tsx
+++ b/src/components/Glossary/GlossaryHero.tsx
@@ -16,28 +16,26 @@ const GlossaryHero = React.forwardRef<HTMLParagraphElement, ChakraProps>(
       <Flex
         direction={{ base: 'column', lg: 'row' }}
         justify="space-between"
-        px={{ base: 3, lg: 10 }}
+        mx={{ base: 3, lg: 32 }}
+        borderBottom="1px"
+        borderBottomColor="carouselArrowBorderColor"
         {...props}
       >
         <VStack
           w="full"
-          alignItems="center"
-          textAlign="center"
+          alignItems="start"
+          textAlign="start"
           spacing={3}
-          my={14}
+          my={{ base: '4', lg: '8' }}
         >
-          <Heading w="full" fontSize={{ base: '32', md: '42', lg: '4xl' }}>
+          <Heading w="full" fontSize={{ base: '16', md: '42', lg: '4xl' }}>
             <chakra.span color="brandLinkColor">
               {' '}
               {t('glossaryTitle1')}
             </chakra.span>{' '}
             {t('glossaryTitle2')}
           </Heading>
-          <Text
-            w={{ base: '90%', md: '80%', lg: '90%', xl: '80%', '2xl': '60%' }}
-            fontSize={{ base: 'sm', md: 'lg', lg: 'xl' }}
-            ref={ref}
-          >
+          <Text fontSize={{ base: 'sm', md: 'lg', lg: 'xl' }} ref={ref}>
             {t('glossaryHero')}
           </Text>
         </VStack>

--- a/src/components/Glossary/GlossaryHero.tsx
+++ b/src/components/Glossary/GlossaryHero.tsx
@@ -16,7 +16,6 @@ const GlossaryHero = React.forwardRef<HTMLParagraphElement, ChakraProps>(
       <Flex
         direction={{ base: 'column', lg: 'row' }}
         justify="space-between"
-        mx={{ base: 3, lg: 32 }}
         borderBottom="1px"
         borderBottomColor="carouselArrowBorderColor"
         {...props}

--- a/src/components/Glossary/GlossaryIconButton.tsx
+++ b/src/components/Glossary/GlossaryIconButton.tsx
@@ -9,19 +9,26 @@ const GlossaryIconButton = ({
 }: GlosssaryIconButtonProps) => {
   return (
     <IconButton
-      width="full"
+      width="9"
+      height="9"
+      my="2"
       icon={
         isVisible ? (
-          <ChevronUpIcon fontSize="28px" color="linkColor" opacity="0.5" />
+          <ChevronUpIcon fontSize="28px" color="linkColor" />
         ) : (
-          <ChevronDownIcon fontSize="28px" color="linkColor" opacity="0.5" />
+          <ChevronDownIcon fontSize="28px" color="linkColor" />
         )
       }
       aria-label="Toggle Text"
       onClick={() => setIsVisible(!isVisible)}
+      alignSelf="center"
       size="xs"
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
       isRound
-      backgroundColor="transparent"
+      backgroundColor="blogPageBg"
+      _dark={{ bg: 'gray.700' }}
       _hover={{ backgroundColor: '#00000010' }}
       _focus={{ backgroundColor: '#00000010' }}
       _active={{ backgroundColor: '#00000010' }}

--- a/src/components/Glossary/GlossaryItems.tsx
+++ b/src/components/Glossary/GlossaryItems.tsx
@@ -41,7 +41,15 @@ const GlossaryItem = ({
         >
           <Element name={item}>
             <Box w="fit-content" py="1">
-              <Text fontSize={{ base: 'xl', lg: '4xl' }} fontWeight="bold">
+              <Text
+                fontSize={{ base: 'xl', lg: '4xl' }}
+                fontWeight="bold"
+                fontFamily="sans-serif"
+                style={{
+                  WebkitTextStroke: '1px black',
+                  color: '#FFFFFFEB',
+                }}
+              >
                 {item}
               </Text>
             </Box>

--- a/src/components/Glossary/GlossaryItems.tsx
+++ b/src/components/Glossary/GlossaryItems.tsx
@@ -28,12 +28,18 @@ const GlossaryItem = ({
   return (
     <Stack w="full" my="7">
       {glossaryAlphabets.map((item, i) => (
-        <chakra.div key={i} id={item} pt="50px" mt="-20px">
+        <chakra.div
+          key={i}
+          id={item}
+          pt="50px"
+          mt="-20px"
+          display="flex"
+          flexDirection={{ base: 'column', lg: 'row' }}
+        >
           <Element name={item}>
             <Box
-              w="full"
+              w="fit-content"
               py="1"
-              bg="glossaryItemBg"
               my="4"
               px={{ base: 8, md: 10, lg: '32' }}
             >
@@ -44,12 +50,10 @@ const GlossaryItem = ({
           </Element>
 
           <Flex
-            justifyContent="center"
-            alignItems="center"
-            mb="-40px"
-            mt="30px"
             direction="column"
             gap="14"
+            px={{ base: '0', lg: '4' }}
+            w="full"
           >
             {glossary
               .sort((a, b) => {

--- a/src/components/Glossary/GlossaryItems.tsx
+++ b/src/components/Glossary/GlossaryItems.tsx
@@ -37,7 +37,7 @@ const GlossaryItem = ({
           borderBottomColor="carouselArrowBorderColor"
           gap={{ base: '4', lg: '32' }}
           pb={{ base: '4', lg: '10' }}
-          pt={{ base: '4', lg: '6' }}
+          pt={{ base: '4', lg: '10' }}
         >
           <Element name={item}>
             <Box w="fit-content" py="1">

--- a/src/components/Glossary/GlossaryItems.tsx
+++ b/src/components/Glossary/GlossaryItems.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Stack, Box, Text, Flex, chakra } from '@chakra-ui/react'
+import { Stack, Text, Flex, chakra } from '@chakra-ui/react'
 import { Element } from 'react-scroll'
 import GlossaryWikiCard from './GlossaryWikiCard'
 import { GlossaryItemType } from '@/types/GlossaryType'
@@ -40,27 +40,20 @@ const GlossaryItem = ({
           pt={{ base: '4', lg: '10' }}
         >
           <Element name={item}>
-            <Box w="fit-content" py="1">
-              <Text
-                fontSize={{ base: 'xl', lg: '4xl' }}
-                fontWeight="bold"
-                fontFamily="sans-serif"
-                style={{
-                  WebkitTextStroke: '1px black',
-                  color: '#FFFFFFEB',
-                }}
-              >
-                {item}
-              </Text>
-            </Box>
+            <Text
+              fontSize={{ base: 'xl', lg: '4xl' }}
+              fontWeight="bold"
+              fontFamily="sans-serif"
+              style={{
+                WebkitTextStroke: '1px black',
+                color: '#FFFFFFEB',
+              }}
+            >
+              {item}
+            </Text>
           </Element>
 
-          <Flex
-            direction="column"
-            gap={{ base: '8', lg: '10' }}
-            px={{ base: '0', lg: '4' }}
-            w="full"
-          >
+          <Flex direction="column" gap="4" px={{ base: '0', lg: '4' }} w="full">
             {glossary
               .sort((a, b) => {
                 const aTitle = a.title.toLowerCase()

--- a/src/components/Glossary/GlossaryItems.tsx
+++ b/src/components/Glossary/GlossaryItems.tsx
@@ -26,23 +26,21 @@ const GlossaryItem = ({
   }
 
   return (
-    <Stack w="full" my="7">
+    <Stack w="full">
       {glossaryAlphabets.map((item, i) => (
         <chakra.div
           key={i}
           id={item}
-          pt="50px"
-          mt="-20px"
           display="flex"
           flexDirection={{ base: 'column', lg: 'row' }}
+          borderBottom="1px"
+          borderBottomColor="carouselArrowBorderColor"
+          gap={{ base: '4', lg: '32' }}
+          pb={{ base: '4', lg: '10' }}
+          pt={{ base: '4', lg: '6' }}
         >
           <Element name={item}>
-            <Box
-              w="fit-content"
-              py="1"
-              my="4"
-              px={{ base: 8, md: 10, lg: '32' }}
-            >
+            <Box w="fit-content" py="1">
               <Text fontSize={{ base: 'xl', lg: '4xl' }} fontWeight="bold">
                 {item}
               </Text>
@@ -51,7 +49,7 @@ const GlossaryItem = ({
 
           <Flex
             direction="column"
-            gap="14"
+            gap={{ base: '8', lg: '10' }}
             px={{ base: '0', lg: '4' }}
             w="full"
           >

--- a/src/components/Glossary/GlossaryWikiCard.tsx
+++ b/src/components/Glossary/GlossaryWikiCard.tsx
@@ -22,7 +22,7 @@ const GlossaryWikiCard = ({
       as="article"
       overflow="hidden"
       borderRadius="12px"
-      mt="6"
+      mt={{ base: '0', lg: '6' }}
       w={{ base: 'full', md: '90%' }}
       p="3"
       _hover={{
@@ -51,9 +51,9 @@ const GlossaryWikiCard = ({
               styles={{
                 px: '1',
                 py: '1',
-                bg: 'brand.700',
+                bg: 'brand.300',
                 color: 'black',
-                _dark: { bg: 'brand.300', color: 'white' },
+                _dark: { bg: 'brand.800', color: 'white' },
               }}
             >
               {summary.length > WIKI_SUMMARY_LIMIT

--- a/src/components/Glossary/GlossaryWikiCard.tsx
+++ b/src/components/Glossary/GlossaryWikiCard.tsx
@@ -20,11 +20,10 @@ const GlossaryWikiCard = ({
   return (
     <LinkBox
       as="article"
-      borderWidth="1px"
-      borderColor="borderColorHover"
       overflow="hidden"
       borderRadius="12px"
-      w={{ base: '85%', md: '90%', lg: '70%' }}
+      mt="6"
+      w={{ base: 'full', md: '90%' }}
       p="3"
       _hover={{
         bgColor: 'tagHoverColor',
@@ -33,11 +32,7 @@ const GlossaryWikiCard = ({
       <Box cursor="pointer" w="full">
         <VStack pb="2" w="full" px="3">
           <LinkOverlay href={`/wiki/${wikiId}`} w="full">
-            <Heading
-              size={{ base: 'sm', lg: 'md' }}
-              my="10px"
-              color="brand.500"
-            >
+            <Heading size={{ base: 'sm', lg: 'md' }} my="10px" fontSize="36px">
               <Highlight
                 query={highlightText}
                 styles={{

--- a/src/components/Glossary/GlossaryWikiCard.tsx
+++ b/src/components/Glossary/GlossaryWikiCard.tsx
@@ -22,7 +22,6 @@ const GlossaryWikiCard = ({
       as="article"
       overflow="hidden"
       borderRadius="12px"
-      mt={{ base: '0', lg: '6' }}
       w={{ base: 'full', md: '90%' }}
       p="3"
       _hover={{
@@ -30,7 +29,7 @@ const GlossaryWikiCard = ({
       }}
     >
       <Box cursor="pointer" w="full">
-        <VStack pb="2" w="full" px="3">
+        <VStack w="full" px="3">
           <LinkOverlay href={`/wiki/${wikiId}`} w="full">
             <Heading size={{ base: 'sm', lg: 'md' }} my="10px" fontSize="36px">
               <Highlight

--- a/src/pages/glossary/index.tsx
+++ b/src/pages/glossary/index.tsx
@@ -93,34 +93,51 @@ const Glossary: NextPage = () => {
         w="full"
         ref={newRef}
         alignItems="center"
-        borderTop="1px"
         mx="auto"
-        borderTopColor="carouselArrowBorderColor"
-        px={{ base: '9', lg: '32' }}
         top={shouldBeFixed ? '14' : '0'}
-        bg="blogPageBg"
         position={shouldBeFixed ? 'fixed' : 'relative'}
+        backgroundColor={shouldBeFixed ? 'blogPageBg' : ''}
+        _dark={{
+          bg: `${shouldBeFixed ? 'gray.700' : ''} `,
+        }}
         zIndex="sticky"
       >
-        <Box mx="auto" w="full" justifyContent="center" alignItems="center">
-          <Grid
-            templateColumns={{
-              base: 'repeat(9,1fr)',
-              md: 'repeat(20,1fr)',
-              lg: 'repeat(27,1fr)',
-            }}
-            gap={3}
-            py="4"
-          >
-            {glossaryAlphabetsData.map((item, i) => (
-              <GlossaryAlphabets
-                key={i}
-                item={item}
-                heightOfElement={heightOfElement}
-                shouldBeFixed={shouldBeFixed}
-              />
-            ))}
-          </Grid>
+        <Box
+          mx="auto"
+          display="flex"
+          flexDirection="column"
+          w="full"
+          justifyContent="center"
+          style={{
+            offset: `${
+              shouldBeFixed
+                ? -(heightOfElement || 284)
+                : -(heightOfElement ? heightOfElement + 228 : 512)
+            }`,
+          }}
+        >
+          <Box backgroundColor={shouldBeFixed ? '#F9FAFB' : ''}>
+            {shouldBeFixed && <GlossaryHero />}
+            <Grid
+              px={{ base: '4', lg: '32' }}
+              templateColumns={{
+                base: 'repeat(9,1fr)',
+                md: 'repeat(20,1fr)',
+                lg: 'repeat(27,1fr)',
+              }}
+              gap={3}
+              py={{ base: '4', lg: '8' }}
+            >
+              {glossaryAlphabetsData.map((item, i) => (
+                <GlossaryAlphabets
+                  key={i}
+                  item={item}
+                  heightOfElement={heightOfElement}
+                  shouldBeFixed={shouldBeFixed}
+                />
+              ))}
+            </Grid>
+          </Box>
           {!shouldBeFixed ? (
             <GlossaryFilterSection
               setSearchText={setSearchText}

--- a/src/pages/glossary/index.tsx
+++ b/src/pages/glossary/index.tsx
@@ -129,7 +129,6 @@ const Glossary: NextPage = () => {
           >
             {shouldBeFixed && <GlossaryHero />}
             <Grid
-              px={{ base: '4', lg: '32' }}
               templateColumns={{
                 base: 'repeat(9,1fr)',
                 md: 'repeat(20,1fr)',

--- a/src/pages/glossary/index.tsx
+++ b/src/pages/glossary/index.tsx
@@ -87,37 +87,42 @@ const Glossary: NextPage = () => {
   }
 
   return (
-    <Stack direction="column" w="full" pb="56">
+    <Stack
+      direction="column"
+      pb={{ base: '32', lg: '56' }}
+      w="min(90%, 1100px)"
+      mx="auto"
+    >
       <GlossaryHero ref={ref} />
-      <VStack
-        w="full"
-        ref={newRef}
-        alignItems="center"
-        mx="auto"
-        top={shouldBeFixed ? '14' : '0'}
-        position={shouldBeFixed ? 'fixed' : 'relative'}
-        backgroundColor={shouldBeFixed ? 'blogPageBg' : ''}
-        _dark={{
-          bg: `${shouldBeFixed ? 'gray.700' : ''} `,
-        }}
-        zIndex="sticky"
-      >
+      <VStack w="full" ref={newRef} alignItems="center" mx="auto">
         <Box
           mx="auto"
           display="flex"
           flexDirection="column"
           w="full"
           justifyContent="center"
+          top={shouldBeFixed ? '14' : '0'}
+          position={shouldBeFixed ? 'fixed' : 'relative'}
+          backgroundColor={shouldBeFixed ? 'blogPageBg' : ''}
+          _dark={{
+            bg: `${shouldBeFixed ? 'gray.700' : ''} `,
+          }}
+          zIndex="sticky"
           style={{
             offset: `${
               shouldBeFixed
                 ? -(heightOfElement || 284)
-                : -(heightOfElement ? heightOfElement + 228 : 512)
+                : -(heightOfElement ? heightOfElement + 500 : 1000)
             }`,
           }}
         >
           <Box
             backgroundColor={shouldBeFixed ? '#F9FAFB' : ''}
+            px={{
+              base: `${shouldBeFixed ? '4' : '0'}`,
+              lg: `${shouldBeFixed ? '12' : '0'}`,
+              xl: `${shouldBeFixed ? '56' : '0'}`,
+            }}
             _dark={{
               bg: `${shouldBeFixed ? 'gray.800' : ''} `,
             }}

--- a/src/pages/glossary/index.tsx
+++ b/src/pages/glossary/index.tsx
@@ -61,7 +61,7 @@ const Glossary: NextPage = () => {
         currentAlphabet === '#'
           ? /^\d/.test(result.title)
           : result.title.charAt(0).toLowerCase() ===
-            currentAlphabet.toLowerCase(),
+          currentAlphabet.toLowerCase(),
       ),
     )
     return filteredAlphabet
@@ -109,14 +109,18 @@ const Glossary: NextPage = () => {
           w="full"
           justifyContent="center"
           style={{
-            offset: `${
-              shouldBeFixed
-                ? -(heightOfElement || 284)
-                : -(heightOfElement ? heightOfElement + 228 : 512)
-            }`,
+            offset: `${shouldBeFixed
+              ? -(heightOfElement || 284)
+              : -(heightOfElement ? heightOfElement + 228 : 512)
+              }`,
           }}
         >
-          <Box backgroundColor={shouldBeFixed ? '#F9FAFB' : ''}>
+          <Box
+            backgroundColor={shouldBeFixed ? '#F9FAFB' : ''}
+            _dark={{
+              bg: `${shouldBeFixed ? 'gray.800' : ''} `,
+            }}
+          >
             {shouldBeFixed && <GlossaryHero />}
             <Grid
               px={{ base: '4', lg: '32' }}

--- a/src/pages/glossary/index.tsx
+++ b/src/pages/glossary/index.tsx
@@ -123,6 +123,7 @@ const Glossary: NextPage = () => {
               lg: `${shouldBeFixed ? '12' : '0'}`,
               xl: `${shouldBeFixed ? '56' : '0'}`,
             }}
+            py={{ base: '4', lg: '0' }}
             _dark={{
               bg: `${shouldBeFixed ? 'gray.800' : ''} `,
             }}

--- a/src/pages/glossary/index.tsx
+++ b/src/pages/glossary/index.tsx
@@ -61,7 +61,7 @@ const Glossary: NextPage = () => {
         currentAlphabet === '#'
           ? /^\d/.test(result.title)
           : result.title.charAt(0).toLowerCase() ===
-          currentAlphabet.toLowerCase(),
+            currentAlphabet.toLowerCase(),
       ),
     )
     return filteredAlphabet
@@ -109,10 +109,11 @@ const Glossary: NextPage = () => {
           w="full"
           justifyContent="center"
           style={{
-            offset: `${shouldBeFixed
-              ? -(heightOfElement || 284)
-              : -(heightOfElement ? heightOfElement + 228 : 512)
-              }`,
+            offset: `${
+              shouldBeFixed
+                ? -(heightOfElement || 284)
+                : -(heightOfElement ? heightOfElement + 228 : 512)
+            }`,
           }}
         >
           <Box

--- a/src/pages/glossary/index.tsx
+++ b/src/pages/glossary/index.tsx
@@ -44,7 +44,7 @@ const Glossary: NextPage = () => {
   const shouldBeFixed =
     entry?.intersectionRatio !== undefined && !entry?.isIntersecting
 
-  const heightOfElement = (newEntry?.boundingClientRect.height || 310) + 68
+  const heightOfElement = (newEntry?.boundingClientRect.height || 390) + 68
   const [isVisible, setIsVisible] = useState(false)
   const [activeIndex, setActiveIndex] = useState<number>()
   const [queryResult, setQueryResult] = useState<Wiki[]>()
@@ -111,35 +111,35 @@ const Glossary: NextPage = () => {
         >
           <Box
             backgroundColor={shouldBeFixed ? '#F9FAFB' : ''}
-            px={{
-              base: `${shouldBeFixed ? '4' : '0'}`,
-              lg: `${shouldBeFixed ? '12' : '0'}`,
-              xl: `${shouldBeFixed ? '64' : '0'}`,
-            }}
             py={{ base: '4', lg: '0' }}
             _dark={{
               bg: `${shouldBeFixed ? 'gray.800' : ''} `,
             }}
           >
-            {shouldBeFixed && <GlossaryHero />}
-            <Grid
-              templateColumns={{
-                base: 'repeat(9,1fr)',
-                md: 'repeat(20,1fr)',
-                lg: 'repeat(27,1fr)',
-              }}
-              gap={3}
-              py={{ base: '4', lg: '8' }}
+            <Box
+              w={shouldBeFixed ? 'min(90%, 1100px)' : ''}
+              mx={shouldBeFixed ? 'auto' : ''}
             >
-              {glossaryAlphabetsData.map((item, i) => (
-                <GlossaryAlphabets
-                  key={i}
-                  item={item}
-                  heightOfElement={heightOfElement}
-                  shouldBeFixed={shouldBeFixed}
-                />
-              ))}
-            </Grid>
+              {shouldBeFixed && <GlossaryHero />}
+              <Grid
+                templateColumns={{
+                  base: 'repeat(9,1fr)',
+                  md: 'repeat(20,1fr)',
+                  lg: 'repeat(27,1fr)',
+                }}
+                gap={3}
+                py={{ base: '4', lg: '8' }}
+              >
+                {glossaryAlphabetsData.map((item, i) => (
+                  <GlossaryAlphabets
+                    key={i}
+                    item={item}
+                    heightOfElement={heightOfElement}
+                    shouldBeFixed={shouldBeFixed}
+                  />
+                ))}
+              </Grid>
+            </Box>
           </Box>
           {!shouldBeFixed ? (
             <GlossaryFilterSection

--- a/src/pages/glossary/index.tsx
+++ b/src/pages/glossary/index.tsx
@@ -44,7 +44,7 @@ const Glossary: NextPage = () => {
   const shouldBeFixed =
     entry?.intersectionRatio !== undefined && !entry?.isIntersecting
 
-  const heightOfElement = (newEntry?.boundingClientRect.height || 96) + 68
+  const heightOfElement = (newEntry?.boundingClientRect.height || 310) + 68
   const [isVisible, setIsVisible] = useState(false)
   const [activeIndex, setActiveIndex] = useState<number>()
   const [queryResult, setQueryResult] = useState<Wiki[]>()
@@ -108,20 +108,13 @@ const Glossary: NextPage = () => {
             bg: `${shouldBeFixed ? 'gray.700' : ''} `,
           }}
           zIndex="sticky"
-          style={{
-            offset: `${
-              shouldBeFixed
-                ? -(heightOfElement || 284)
-                : -(heightOfElement ? heightOfElement + 500 : 1000)
-            }`,
-          }}
         >
           <Box
             backgroundColor={shouldBeFixed ? '#F9FAFB' : ''}
             px={{
               base: `${shouldBeFixed ? '4' : '0'}`,
               lg: `${shouldBeFixed ? '12' : '0'}`,
-              xl: `${shouldBeFixed ? '56' : '0'}`,
+              xl: `${shouldBeFixed ? '64' : '0'}`,
             }}
             py={{ base: '4', lg: '0' }}
             _dark={{


### PR DESCRIPTION
# Made ui update on the glossary page

_Made changes to the user interface of the glossary page to enhance user experience (UX) and achieve a sleeker/cleaner appearance._

![Screenshot (72)](https://github.com/EveripediaNetwork/ep-ui/assets/48678691/3ffdaede-de54-47b9-9a1a-e9fc511671d0)
![Screenshot (73)](https://github.com/EveripediaNetwork/ep-ui/assets/48678691/c2db1eb9-b5c9-489b-83a8-408d23dbdcfa)
![Screenshot (74)](https://github.com/EveripediaNetwork/ep-ui/assets/48678691/9ce0c03d-f333-4a49-96ba-4cd0024d5463)
![Screenshot (75)](https://github.com/EveripediaNetwork/ep-ui/assets/48678691/389ecaed-4a51-48a1-ac88-a1f7a73afbdd)
![Screenshot (76)](https://github.com/EveripediaNetwork/ep-ui/assets/48678691/a18b8d3d-cd26-4ab2-b7b1-a1eef4db8444)
![Screenshot (77)](https://github.com/EveripediaNetwork/ep-ui/assets/48678691/f4e16e65-2119-4467-952a-6b6fbaac503d)
![Screenshot (78)](https://github.com/EveripediaNetwork/ep-ui/assets/48678691/389cd81a-ec11-4dbe-8df2-8d54b50d8d0c)
![Screenshot (79)](https://github.com/EveripediaNetwork/ep-ui/assets/48678691/c6b64baf-d2e8-46b7-9a64-b07fcdb437eb)
![Screenshot (80)](https://github.com/EveripediaNetwork/ep-ui/assets/48678691/06b0fea4-81cb-4c9e-855b-6e3c35582a1c)
![Screenshot (81)](https://github.com/EveripediaNetwork/ep-ui/assets/48678691/ffa257db-68c0-43d5-862d-7416c349aa8e)
![Screenshot (82)](https://github.com/EveripediaNetwork/ep-ui/assets/48678691/ab8607e6-3366-4e70-bcdc-d5861b3b31dc)



closes https://github.com/EveripediaNetwork/issues/issues/2412
