### PR TITLE
add admin icon to wallet drawer

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -90,6 +90,7 @@
   "DayMode": "Light Mode",
   "NightMode": "Dark Mode",
   "Profile": "Profile",
+  "Admin": "Admin",
   "Settings": "Settings",
   "Logout": "Logout",
   "SearchWikiPlaceholder": "Search wikis, categories, tags and users",

--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -96,6 +96,7 @@
   "DayMode": "주간 모드",
   "NightMode": "야간 모드",
   "Profile": "프로필",
+  "Admin": "관리자",
   "Settings": "설정",
   "Logout": "로그아웃",
   "SearchWikiPlaceholder": "위키, 카테고리, 태그 및 사용자 검색",

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -88,6 +88,7 @@
   "branding": "品牌",
   "NightMode": "夜间模式",
   "Profile": "个人资料",
+  "Admin": "行政",
   "Settings": "设置",
   "Logout": "登出",
   "SearchWikiPlaceholder": "搜索 wikis、类别、标签和用户",

--- a/src/components/Layout/Navbar/AdminLink.tsx
+++ b/src/components/Layout/Navbar/AdminLink.tsx
@@ -1,0 +1,38 @@
+import { HStack, Icon, Link } from '@chakra-ui/react'
+import React from 'react'
+import { useTranslation } from 'next-i18next'
+import { FaUserCog } from 'react-icons/fa'
+
+const AdminLink = ({ isInMobileMenu }: { isInMobileMenu?: boolean }) => {
+  const { t } = useTranslation('common')
+  return (
+    <HStack
+      px={isInMobileMenu ? 0 : 3}
+      minH={'48px'}
+      sx={{
+        '&:hover, &:focus, &:active': {
+          bgColor: 'subMenuHoverBg',
+        },
+      }}
+      width={'full'}
+    >
+      <Icon
+        fontSize={{ base: 28, md: 24 }}
+        color="linkColor"
+        fontWeight={600}
+        as={FaUserCog}
+      />
+      <Link
+        fontSize={{ base: 'lg', md: 'md' }}
+        fontWeight={'semibold'}
+        href={'/admin'}
+        color="linkColor"
+        pl={isInMobileMenu ? 3 : 1}
+      >
+        <span>{t('Admin')}</span>
+      </Link>
+    </HStack>
+  )
+}
+
+export default AdminLink

--- a/src/components/Layout/WalletDrawer/WalletDrawerBody.tsx
+++ b/src/components/Layout/WalletDrawer/WalletDrawerBody.tsx
@@ -14,7 +14,7 @@ import React, { useEffect, useState } from 'react'
 import WalletDetails from './WalletDetails'
 import { useFetchWalletBalance } from '@/hooks/UseFetchWallet'
 import { useDispatch, useSelector } from 'react-redux'
-import { RootState } from '@/store/store'
+import { RootState, store } from '@/store/store'
 import { useTranslation } from 'next-i18next'
 import {
   fetchRateAndCalculateTotalBalance,
@@ -31,10 +31,14 @@ import { LogOutBtn } from '../Navbar/Logout'
 import { useAddress } from '@/hooks/useAddress'
 import { ProfileLink } from '../Navbar/ProfileLink'
 import SettingsLink from '../Navbar/SettingsLink'
+import AdminLink from '../Navbar/AdminLink'
+import { adminApiClient, checkIsAdmin } from '@/services/admin'
 
 export const WalletDrawerBody = () => {
   const { t } = useTranslation('common')
   const { address } = useAddress()
+  const [isAdmin, setIsAdmin] = React.useState(false)
+  const token = useSelector((state: RootState) => state.user.token)
   const { userBalance } = useFetchWalletBalance(address)
   const { walletDetails, totalBalance, balanceBreakdown, hiiq } = useSelector(
     (state: RootState) => state.user,
@@ -63,6 +67,19 @@ export const WalletDrawerBody = () => {
       })
     }
   }, [walletDetails])
+
+  useEffect(() => {
+    async function fetchAuth() {
+      if (address && token) {
+        adminApiClient.setHeader('authorization', token)
+        const { data } = await store.dispatch(checkIsAdmin?.initiate(undefined))
+        if (data) {
+          setIsAdmin(true)
+        }
+      }
+    }
+    fetchAuth()
+  }, [address])
 
   return (
     <>
@@ -162,6 +179,7 @@ export const WalletDrawerBody = () => {
               alignItems="flex-start"
               display={{ base: 'none', md: 'block' }}
             >
+              {isAdmin && <AdminLink />}
               <ProfileLink />
               <SettingsLink />
               <ColorModeToggle isInMobileMenu={false} />


### PR DESCRIPTION
# Admin Icon on wallet drawer

This PR adds the admin icon to the wallet drawer. 
Also adds the text translation in the alternate languages

## How should this be tested?

Click on the user avatar to see the admin link added to the top of the wallet drawer. 
![image](https://github.com/EveripediaNetwork/ep-ui/assets/50779080/e034e4b5-7902-4a8a-b4a3-11a4cd875cb1)


## Notes or observations

Only users with admin privileges can see this changes

## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/2478