### PR TITLE
fix not found page translations

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import { LinkButton } from '@/components/Elements'
 import { Flex, Box, Image, Text, Button } from '@chakra-ui/react'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useRouter } from 'next/router'
+import { GetStaticProps } from 'next'
 
 const WikiNotFound = () => {
   const router = useRouter()
@@ -59,3 +61,11 @@ const WikiNotFound = () => {
 }
 
 export default WikiNotFound
+
+export const getStaticProps: GetStaticProps = async (context) => {
+  return {
+    props: {
+      ...(await serverSideTranslations(context.locale ?? 'en', ['common'])),
+    },
+  }
+}


### PR DESCRIPTION
# Summary
Fixes the translation issue on the not found page

<img width="1440" alt="Screenshot 2024-04-24 at 2 29 41 PM" src="https://github.com/EveripediaNetwork/ep-ui/assets/30352484/b945ec2e-2aa8-479b-891c-91c7f95cbe70">


## Linked issues
closes https://github.com/EveripediaNetwork/issues/issues/2574
