### PR TITLE
improving glossary ui page

### DIFF
--- a/src/components/Glossary/GlossaryAlphabetSection.tsx
+++ b/src/components/Glossary/GlossaryAlphabetSection.tsx
@@ -5,44 +5,36 @@ import { glossaryAlphabetsData } from '@/data/GlossaryAlphabetsData'
 import { GlossaryAlphabetsSectionProps } from '@/types/GlossaryType'
 
 const GlossaryAlphabetSection = (props: GlossaryAlphabetsSectionProps) => {
-  const { shouldBeFixed, heightOfElement, showAlphabetBlock } = props
+  const { shouldBeFixed, heightOfElement } = props
   return (
     <Box
-      backgroundColor={shouldBeFixed ? '#F9FAFB' : ''}
+      backgroundColor={shouldBeFixed ? 'blogPageBg' : ''}
       _dark={{
-        bg: `${shouldBeFixed ? 'gray.800' : ''} `,
+        bg: `${shouldBeFixed ? 'gray.700' : ''} `,
       }}
-      display={{ base: showAlphabetBlock ? 'block' : 'none', md: 'block' }}
     >
       <Box
-        backgroundColor={shouldBeFixed ? 'blogPageBg' : ''}
-        _dark={{
-          bg: `${shouldBeFixed ? 'gray.700' : ''} `,
-        }}
+        w={shouldBeFixed ? 'min(90%, 1100px)' : ''}
+        mx={shouldBeFixed ? 'auto' : ''}
       >
-        <Box
-          w={shouldBeFixed ? 'min(90%, 1100px)' : ''}
-          mx={shouldBeFixed ? 'auto' : ''}
+        <Grid
+          templateColumns={{
+            base: 'repeat(9,1fr)',
+            md: 'repeat(20,1fr)',
+            lg: 'repeat(27,1fr)',
+          }}
+          gap={3}
+          py={{ base: '4' }}
         >
-          <Grid
-            templateColumns={{
-              base: 'repeat(9,1fr)',
-              md: 'repeat(20,1fr)',
-              lg: 'repeat(27,1fr)',
-            }}
-            gap={3}
-            py={{ base: '4' }}
-          >
-            {glossaryAlphabetsData.map((item, i) => (
-              <GlossaryAlphabets
-                key={i}
-                item={item}
-                heightOfElement={heightOfElement}
-                shouldBeFixed={shouldBeFixed}
-              />
-            ))}
-          </Grid>
-        </Box>
+          {glossaryAlphabetsData.map((item, i) => (
+            <GlossaryAlphabets
+              key={i}
+              item={item}
+              heightOfElement={heightOfElement}
+              shouldBeFixed={shouldBeFixed}
+            />
+          ))}
+        </Grid>
       </Box>
     </Box>
   )

--- a/src/components/Glossary/GlossaryAlphabetSection.tsx
+++ b/src/components/Glossary/GlossaryAlphabetSection.tsx
@@ -1,0 +1,51 @@
+import { Box, Grid } from '@chakra-ui/react'
+import React from 'react'
+import GlossaryAlphabets from './GlossaryAlphabets'
+import { glossaryAlphabetsData } from '@/data/GlossaryAlphabetsData'
+import { GlossaryAlphabetsSectionProps } from '@/types/GlossaryType'
+
+const GlossaryAlphabetSection = (props: GlossaryAlphabetsSectionProps) => {
+  const { shouldBeFixed, heightOfElement, showAlphabetBlock } = props
+  return (
+    <Box
+      backgroundColor={shouldBeFixed ? '#F9FAFB' : ''}
+      _dark={{
+        bg: `${shouldBeFixed ? 'gray.800' : ''} `,
+      }}
+      display={{ base: showAlphabetBlock ? 'block' : 'none', md: 'block' }}
+    >
+      <Box
+        backgroundColor={shouldBeFixed ? 'blogPageBg' : ''}
+        _dark={{
+          bg: `${shouldBeFixed ? 'gray.700' : ''} `,
+        }}
+      >
+        <Box
+          w={shouldBeFixed ? 'min(90%, 1100px)' : ''}
+          mx={shouldBeFixed ? 'auto' : ''}
+        >
+          <Grid
+            templateColumns={{
+              base: 'repeat(9,1fr)',
+              md: 'repeat(20,1fr)',
+              lg: 'repeat(27,1fr)',
+            }}
+            gap={3}
+            py={{ base: '4' }}
+          >
+            {glossaryAlphabetsData.map((item, i) => (
+              <GlossaryAlphabets
+                key={i}
+                item={item}
+                heightOfElement={heightOfElement}
+                shouldBeFixed={shouldBeFixed}
+              />
+            ))}
+          </Grid>
+        </Box>
+      </Box>
+    </Box>
+  )
+}
+
+export default GlossaryAlphabetSection

--- a/src/components/Glossary/GlossaryFilterSection.tsx
+++ b/src/components/Glossary/GlossaryFilterSection.tsx
@@ -23,65 +23,72 @@ const GlossaryFilterSection = (props: GlossaryFilterSectionProps) => {
   } = props
   return (
     <Box
-      w={shouldBeFixed ? 'min(90%, 1100px)' : 'full'}
-      mx={shouldBeFixed ? 'auto' : ''}
+      backgroundColor={shouldBeFixed ? 'blogPageBg' : ''}
+      _dark={{
+        bg: `${shouldBeFixed ? 'gray.700' : ''} `,
+      }}
     >
-      <Box my={shouldBeFixed ? 5 : 0}>
-        <InputGroup size="md" w="full">
-          <InputLeftElement
-            ml={{ base: '15px', xl: 'unset' }}
-            pointerEvents="none"
-            h="full"
-          >
-            <Search2Icon
-              color="gray.300"
-              fontSize={{ base: 'sm', lg: 'auto' }}
-              ml={{ base: '-8', lg: 0 }}
-            />
-          </InputLeftElement>
-          <Input
-            type="text"
-            placeholder="Search for words"
-            value={searchText}
-            onChange={(e) => searchPage(e.target.value)}
-            _placeholder={{ color: 'placeholderColor' }}
-          />
-        </InputGroup>
-      </Box>
-      <Flex
-        my="4"
-        w="full"
-        wrap="wrap"
-        alignItems="center"
-        justifyContent={{ lg: 'start', '2xl': 'center' }}
-        gap={{ base: '3', '2xl': '4' }}
+      <Box
+        w={shouldBeFixed ? 'min(90%, 1100px)' : 'full'}
+        mx={shouldBeFixed ? 'auto' : ''}
       >
-        {COMMONLY_SEARCHED_WIKIS.slice(0, 5)?.map((word, i) => {
-          return (
-            <Tag
-              size="lg"
-              key={word}
-              bg={i === activeIndex ? 'tagActiveBgColor' : 'transparent'}
-              color={i === activeIndex ? 'tagActiveColor' : 'tagColor'}
-              cursor="pointer"
-              borderRadius="full"
-              borderWidth="thin"
-              fontWeight="normal"
-              fontSize={{ base: 'sm', lg: 'md' }}
-              _hover={{
-                bgColor: 'tagHoverColor',
-              }}
-              onClick={() => {
-                setActiveIndex(i)
-                setSearchText(word)
-                searchPage(word)
-              }}
+        <Box my={shouldBeFixed ? 5 : 0}>
+          <InputGroup size="md" w="full">
+            <InputLeftElement
+              ml={{ base: '15px', xl: 'unset' }}
+              pointerEvents="none"
+              h="full"
             >
-              <TagLabel>{word}</TagLabel>
-            </Tag>
-          )
-        })}
-      </Flex>
+              <Search2Icon
+                color="gray.300"
+                fontSize={{ base: 'sm', lg: 'auto' }}
+                ml={{ base: '-8', lg: 0 }}
+              />
+            </InputLeftElement>
+            <Input
+              type="text"
+              placeholder="Search for words"
+              value={searchText}
+              onChange={(e) => searchPage(e.target.value)}
+              _placeholder={{ color: 'placeholderColor' }}
+            />
+          </InputGroup>
+        </Box>
+        <Flex
+          my="4"
+          w="full"
+          wrap="wrap"
+          alignItems="center"
+          justifyContent={{ lg: 'start', '2xl': 'center' }}
+          gap={{ base: '3', '2xl': '4' }}
+        >
+          {COMMONLY_SEARCHED_WIKIS.slice(0, 5)?.map((word, i) => {
+            return (
+              <Tag
+                size="lg"
+                key={word}
+                bg={i === activeIndex ? 'tagActiveBgColor' : 'transparent'}
+                color={i === activeIndex ? 'tagActiveColor' : 'tagColor'}
+                cursor="pointer"
+                borderRadius="full"
+                borderWidth="thin"
+                fontWeight="normal"
+                fontSize={{ base: 'sm', lg: 'md' }}
+                _hover={{
+                  bgColor: 'tagHoverColor',
+                }}
+                onClick={() => {
+                  setActiveIndex(i)
+                  setSearchText(word)
+                  searchPage(word)
+                }}
+              >
+                <TagLabel>{word}</TagLabel>
+              </Tag>
+            )
+          })}
+        </Flex>
+      </Box>
     </Box>
   )
 }

--- a/src/pages/glossary/index.tsx
+++ b/src/pages/glossary/index.tsx
@@ -103,10 +103,6 @@ const Glossary: NextPage = () => {
           justifyContent="center"
           top={shouldBeFixed ? '14' : '0'}
           position={shouldBeFixed ? 'fixed' : 'relative'}
-          backgroundColor={shouldBeFixed ? 'blogPageBg' : ''}
-          _dark={{
-            bg: `${shouldBeFixed ? 'gray.700' : ''} `,
-          }}
           zIndex="sticky"
         >
           <Box
@@ -117,27 +113,34 @@ const Glossary: NextPage = () => {
             }}
           >
             <Box
-              w={shouldBeFixed ? 'min(90%, 1100px)' : ''}
-              mx={shouldBeFixed ? 'auto' : ''}
+              backgroundColor={shouldBeFixed ? 'blogPageBg' : ''}
+              _dark={{
+                bg: `${shouldBeFixed ? 'gray.700' : ''} `,
+              }}
             >
-              <Grid
-                templateColumns={{
-                  base: 'repeat(9,1fr)',
-                  md: 'repeat(20,1fr)',
-                  lg: 'repeat(27,1fr)',
-                }}
-                gap={3}
-                py={{ base: '4', lg: '8' }}
+              <Box
+                w={shouldBeFixed ? 'min(90%, 1100px)' : ''}
+                mx={shouldBeFixed ? 'auto' : ''}
               >
-                {glossaryAlphabetsData.map((item, i) => (
-                  <GlossaryAlphabets
-                    key={i}
-                    item={item}
-                    heightOfElement={heightOfElement}
-                    shouldBeFixed={shouldBeFixed}
-                  />
-                ))}
-              </Grid>
+                <Grid
+                  templateColumns={{
+                    base: 'repeat(9,1fr)',
+                    md: 'repeat(20,1fr)',
+                    lg: 'repeat(27,1fr)',
+                  }}
+                  gap={3}
+                  py={{ base: '4', lg: '8' }}
+                >
+                  {glossaryAlphabetsData.map((item, i) => (
+                    <GlossaryAlphabets
+                      key={i}
+                      item={item}
+                      heightOfElement={heightOfElement}
+                      shouldBeFixed={shouldBeFixed}
+                    />
+                  ))}
+                </Grid>
+              </Box>
             </Box>
           </Box>
           {!shouldBeFixed ? (

--- a/src/pages/glossary/index.tsx
+++ b/src/pages/glossary/index.tsx
@@ -107,7 +107,6 @@ const Glossary: NextPage = () => {
         >
           <Box
             backgroundColor={shouldBeFixed ? '#F9FAFB' : ''}
-            py={{ base: '4', lg: '0' }}
             _dark={{
               bg: `${shouldBeFixed ? 'gray.800' : ''} `,
             }}

--- a/src/pages/glossary/index.tsx
+++ b/src/pages/glossary/index.tsx
@@ -1,4 +1,4 @@
-import { Stack, Box, VStack, Grid } from '@chakra-ui/react'
+import { Stack, Box, VStack } from '@chakra-ui/react'
 import { GetStaticProps, NextPage } from 'next'
 import React, { useState } from 'react'
 import { glossaryAlphabetsData } from '@/data/GlossaryAlphabetsData'
@@ -7,10 +7,10 @@ import { useGetGlossaryTagWikisQuery } from '@/services/glossary'
 import { useInView } from 'react-intersection-observer'
 import { Wiki } from '@everipedia/iq-utils'
 import GlossaryHero from '@/components/Glossary/GlossaryHero'
-import GlossaryAlphabets from '@/components/Glossary/GlossaryAlphabets'
 import GlossaryIconButton from '@/components/Glossary/GlossaryIconButton'
 import GlossaryFilterSection from '@/components/Glossary/GlossaryFilterSection'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import GlossaryAlphabetSection from '@/components/Glossary/GlossaryAlphabetSection'
 interface GlossaryData {
   offset: number
   wikis: Wiki[]
@@ -105,43 +105,11 @@ const Glossary: NextPage = () => {
           position={shouldBeFixed ? 'fixed' : 'relative'}
           zIndex="sticky"
         >
-          <Box
-            backgroundColor={shouldBeFixed ? '#F9FAFB' : ''}
-            _dark={{
-              bg: `${shouldBeFixed ? 'gray.800' : ''} `,
-            }}
-          >
-            <Box
-              backgroundColor={shouldBeFixed ? 'blogPageBg' : ''}
-              _dark={{
-                bg: `${shouldBeFixed ? 'gray.700' : ''} `,
-              }}
-            >
-              <Box
-                w={shouldBeFixed ? 'min(90%, 1100px)' : ''}
-                mx={shouldBeFixed ? 'auto' : ''}
-              >
-                <Grid
-                  templateColumns={{
-                    base: 'repeat(9,1fr)',
-                    md: 'repeat(20,1fr)',
-                    lg: 'repeat(27,1fr)',
-                  }}
-                  gap={3}
-                  py={{ base: '4' }}
-                >
-                  {glossaryAlphabetsData.map((item, i) => (
-                    <GlossaryAlphabets
-                      key={i}
-                      item={item}
-                      heightOfElement={heightOfElement}
-                      shouldBeFixed={shouldBeFixed}
-                    />
-                  ))}
-                </Grid>
-              </Box>
-            </Box>
-          </Box>
+          <GlossaryAlphabetSection
+            shouldBeFixed={shouldBeFixed}
+            heightOfElement={heightOfElement}
+            showAlphabetBlock={!isVisible && !shouldBeFixed}
+          />
           {!shouldBeFixed ? (
             <GlossaryFilterSection
               setSearchText={setSearchText}
@@ -154,14 +122,21 @@ const Glossary: NextPage = () => {
           ) : (
             <>
               {isVisible && (
-                <GlossaryFilterSection
-                  setSearchText={setSearchText}
-                  shouldBeFixed={shouldBeFixed}
-                  searchText={searchText}
-                  searchPage={searchPage}
-                  activeIndex={searchText === '' ? undefined : activeIndex}
-                  setActiveIndex={setActiveIndex}
-                />
+                <>
+                  <GlossaryAlphabetSection
+                    shouldBeFixed={shouldBeFixed}
+                    heightOfElement={heightOfElement}
+                    showAlphabetBlock={isVisible}
+                  />
+                  <GlossaryFilterSection
+                    setSearchText={setSearchText}
+                    shouldBeFixed={shouldBeFixed}
+                    searchText={searchText}
+                    searchPage={searchPage}
+                    activeIndex={searchText === '' ? undefined : activeIndex}
+                    setActiveIndex={setActiveIndex}
+                  />
+                </>
               )}
               <GlossaryIconButton
                 isVisible={isVisible}

--- a/src/pages/glossary/index.tsx
+++ b/src/pages/glossary/index.tsx
@@ -105,11 +105,18 @@ const Glossary: NextPage = () => {
           position={shouldBeFixed ? 'fixed' : 'relative'}
           zIndex="sticky"
         >
-          <GlossaryAlphabetSection
-            shouldBeFixed={shouldBeFixed}
-            heightOfElement={heightOfElement}
-            showAlphabetBlock={!isVisible && !shouldBeFixed}
-          />
+          <Box
+            backgroundColor={shouldBeFixed ? '#F9FAFB' : ''}
+            _dark={{
+              bg: `${shouldBeFixed ? 'gray.800' : ''} `,
+            }}
+            display={{ base: shouldBeFixed ? 'none' : 'block', md: 'block' }}
+          >
+            <GlossaryAlphabetSection
+              shouldBeFixed={shouldBeFixed}
+              heightOfElement={heightOfElement}
+            />
+          </Box>
           {!shouldBeFixed ? (
             <GlossaryFilterSection
               setSearchText={setSearchText}
@@ -123,11 +130,18 @@ const Glossary: NextPage = () => {
             <>
               {isVisible && (
                 <>
-                  <GlossaryAlphabetSection
-                    shouldBeFixed={shouldBeFixed}
-                    heightOfElement={heightOfElement}
-                    showAlphabetBlock={isVisible}
-                  />
+                  <Box
+                    backgroundColor={shouldBeFixed ? '#F9FAFB' : ''}
+                    _dark={{
+                      bg: `${shouldBeFixed ? 'gray.800' : ''} `,
+                    }}
+                    display={{ base: 'block', md: 'none' }}
+                  >
+                    <GlossaryAlphabetSection
+                      shouldBeFixed={shouldBeFixed}
+                      heightOfElement={heightOfElement}
+                    />
+                  </Box>
                   <GlossaryFilterSection
                     setSearchText={setSearchText}
                     shouldBeFixed={shouldBeFixed}

--- a/src/pages/glossary/index.tsx
+++ b/src/pages/glossary/index.tsx
@@ -120,7 +120,6 @@ const Glossary: NextPage = () => {
               w={shouldBeFixed ? 'min(90%, 1100px)' : ''}
               mx={shouldBeFixed ? 'auto' : ''}
             >
-              {shouldBeFixed && <GlossaryHero />}
               <Grid
                 templateColumns={{
                   base: 'repeat(9,1fr)',

--- a/src/pages/glossary/index.tsx
+++ b/src/pages/glossary/index.tsx
@@ -101,7 +101,7 @@ const Glossary: NextPage = () => {
           flexDirection="column"
           w="full"
           justifyContent="center"
-          top={shouldBeFixed ? '14' : '0'}
+          top={shouldBeFixed ? '70px' : '0'}
           position={shouldBeFixed ? 'fixed' : 'relative'}
           zIndex="sticky"
         >
@@ -129,7 +129,7 @@ const Glossary: NextPage = () => {
                     lg: 'repeat(27,1fr)',
                   }}
                   gap={3}
-                  py={{ base: '4', lg: '8' }}
+                  py={{ base: '4' }}
                 >
                   {glossaryAlphabetsData.map((item, i) => (
                     <GlossaryAlphabets

--- a/src/types/GlossaryType.ts
+++ b/src/types/GlossaryType.ts
@@ -6,6 +6,12 @@ export type GlossaryAlphabetsProps = {
   item: string
 }
 
+export type GlossaryAlphabetsSectionProps = {
+  shouldBeFixed: boolean
+  heightOfElement: number
+  showAlphabetBlock?: boolean
+}
+
 export type GlossaryFilterSectionProps = {
   searchText: string
   searchPage: (value: string) => void


### PR DESCRIPTION
# Improving Glossary UI Page

This PR works on improving the glossary page UI

## Notes or observations
<img width="1513" alt="image" src="https://github.com/EveripediaNetwork/ep-ui/assets/67792966/b5d69fae-438a-4964-a0c8-61f43e45cd1c">


## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/2575
