### PR TITLE
just fixed the facebook link

### DIFF
--- a/src/data/SocialsData.ts
+++ b/src/data/SocialsData.ts
@@ -55,7 +55,7 @@ export const Socials: Social[] = [
   },
   {
     id: 7,
-    href: 'https://web.facebook.com/everipedia?_rdc=1&_rdr',
+    href: 'https://www.facebook.com/iqdotwiki',
     name: 'facebook',
     icon: RiFacebookFill,
   },


### PR DESCRIPTION
Updated the Facebook link at the footer section that wasn't working upon a click action. 

fixes: https://github.com/EveripediaNetwork/issues/issues/2611


