### PR TITLE
Fix Unnecessary Toast Notification on Wiki Draft Load

### DIFF
--- a/src/components/CreateWiki/CreateWikiTopBar/WikiPublish/WikiPublishButton.tsx
+++ b/src/components/CreateWiki/CreateWikiTopBar/WikiPublish/WikiPublishButton.tsx
@@ -46,7 +46,7 @@ const NetworkErrorNotification = dynamic(
 )
 
 export const WikiPublishButton = () => {
-  const wiki = useAppSelector((state) => state.wiki)
+  const wiki = useAppSelector(state => state.wiki)
   const { data } = useGetWikiQuery(wiki?.id || '')
   const [submittingWiki, setSubmittingWiki] = useBoolean()
   const { address: userAddress, isConnected: isUserConnected } = useAccount()
@@ -133,7 +133,7 @@ export const WikiPublishButton = () => {
       const provider = (await detectEthereumProvider({
         silent: true,
       })) as ProviderDataType
-      setDetectedProvider(provider as ProviderDataType)
+      setDetectedProvider(provider)
       if (provider) getConnectedChain(provider)
     }
 
@@ -141,16 +141,15 @@ export const WikiPublishButton = () => {
       getDetectedProvider()
     } else {
       getConnectedChain(detectedProvider)
-      detectedProvider.on('chainChanged', (newlyConnectedChain) =>
+      detectedProvider.on('chainChanged', newlyConnectedChain =>
         setConnectedChainId(newlyConnectedChain),
       )
     }
 
     return () => {
       if (detectedProvider) {
-        detectedProvider.removeListener(
-          'chainChanged',
-          (newlyConnectedChain) => setConnectedChainId(newlyConnectedChain),
+        detectedProvider.removeListener('chainChanged', newlyConnectedChain =>
+          setConnectedChainId(newlyConnectedChain),
         )
       }
     }
@@ -267,7 +266,7 @@ export const WikiPublishButton = () => {
         ...wiki,
         user: { id: userAddress },
         content: sanitizeContentToPublish(String(wiki.content)),
-        metadata: wiki.metadata.filter((m) => m.value),
+        metadata: wiki.metadata.filter(m => m.value),
       }
 
       if (finalWiki.id === CreateNewWikiSlug)

--- a/src/components/CreateWiki/CreateWikiTopBar/WikiPublish/WikiPublishButton.tsx
+++ b/src/components/CreateWiki/CreateWikiTopBar/WikiPublish/WikiPublishButton.tsx
@@ -46,7 +46,7 @@ const NetworkErrorNotification = dynamic(
 )
 
 export const WikiPublishButton = () => {
-  const wiki = useAppSelector(state => state.wiki)
+  const wiki = useAppSelector((state) => state.wiki)
   const { data } = useGetWikiQuery(wiki?.id || '')
   const [submittingWiki, setSubmittingWiki] = useBoolean()
   const { address: userAddress, isConnected: isUserConnected } = useAccount()
@@ -141,15 +141,16 @@ export const WikiPublishButton = () => {
       getDetectedProvider()
     } else {
       getConnectedChain(detectedProvider)
-      detectedProvider.on('chainChanged', newlyConnectedChain =>
+      detectedProvider.on('chainChanged', (newlyConnectedChain) =>
         setConnectedChainId(newlyConnectedChain),
       )
     }
 
     return () => {
       if (detectedProvider) {
-        detectedProvider.removeListener('chainChanged', newlyConnectedChain =>
-          setConnectedChainId(newlyConnectedChain),
+        detectedProvider.removeListener(
+          'chainChanged',
+          (newlyConnectedChain) => setConnectedChainId(newlyConnectedChain),
         )
       }
     }
@@ -266,7 +267,7 @@ export const WikiPublishButton = () => {
         ...wiki,
         user: { id: userAddress },
         content: sanitizeContentToPublish(String(wiki.content)),
-        metadata: wiki.metadata.filter(m => m.value),
+        metadata: wiki.metadata.filter((m) => m.value),
       }
 
       if (finalWiki.id === CreateNewWikiSlug)

--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -50,7 +50,7 @@ const Editor = dynamic(() => import('@/components/CreateWiki/Editor'), {
 })
 
 const CreateWikiContent = () => {
-  const wiki = useAppSelector(state => state.wiki)
+  const wiki = useAppSelector((state) => state.wiki)
 
   const {
     isLoadingWiki,
@@ -151,11 +151,11 @@ const CreateWikiContent = () => {
       // (commonMetaIds) and append edit specific meta data (editMetaIds) with empty values
       const wikiDt = initWikiData
       metadata = [
-        ...Object.values(CommonMetaIds).map(mId => {
+        ...Object.values(CommonMetaIds).map((mId) => {
           const meta = getWikiMetadataById(wikiDt, mId)
           return { id: mId, value: meta?.value ?? '' }
         }),
-        ...Object.values(EditSpecificMetaIds).map(mId => ({
+        ...Object.values(EditSpecificMetaIds).map((mId) => ({
           id: mId,
           value: '',
         })),
@@ -236,7 +236,7 @@ const Page: PageWithoutFooter = authenticatedRoute(
 
 Page.noFooter = true
 
-export const getServerSideProps: GetServerSideProps = async context => {
+export const getServerSideProps: GetServerSideProps = async (context) => {
   const slug = context.params?.slug
   if (typeof slug === 'string') {
     store.dispatch(getWiki.initiate(slug))

--- a/src/pages/create-wiki/index.tsx
+++ b/src/pages/create-wiki/index.tsx
@@ -39,6 +39,7 @@ import { CreateWikiTopBar } from '../../components/CreateWiki/CreateWikiTopBar/i
 import { authenticatedRoute } from '@/components/WrapperRoutes/AuthenticatedRoute'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { WagmiWrapper } from '@/components/Layout/WagmiWrapper'
+import isDeepEqual from '@everipedia/iq-utils/build/main/lib/isDeepEqual'
 
 type PageWithoutFooter = NextPage & {
   noFooter?: boolean
@@ -49,7 +50,7 @@ const Editor = dynamic(() => import('@/components/CreateWiki/Editor'), {
 })
 
 const CreateWikiContent = () => {
-  const wiki = useAppSelector((state) => state.wiki)
+  const wiki = useAppSelector(state => state.wiki)
 
   const {
     isLoadingWiki,
@@ -71,25 +72,30 @@ const CreateWikiContent = () => {
       dispatch({
         type: 'wiki/setInitialWikiState',
         payload: {
-          content: val || ' ',
+          content: val ?? ' ',
         },
       })
     else
       dispatch({
         type: 'wiki/setContent',
-        payload: val || ' ',
+        payload: val ?? ' ',
       })
   }
 
   useCreateWikiEffects()
 
   useEffect(() => {
-    // get draft wiki if it exists
     let draft: Wiki | undefined
-    if (isNewCreateWiki) draft = getDraftFromLocalStorage()
-    else if (wikiData) draft = getDraftFromLocalStorage()
 
-    if (!toast.isActive('draft-loaded') && draft) {
+    // Load the draft from local storage if creating a new wiki or if wiki data exists
+    if (isNewCreateWiki || wikiData) {
+      draft = getDraftFromLocalStorage()
+    }
+
+    // Use the isDeepEqual function to compare the loaded draft and current wiki data
+    const isDraftDifferent = draft && !isDeepEqual(draft, wikiData)
+
+    if (!toast.isActive('draft-loaded') && draft && isDraftDifferent) {
       toast({
         id: 'draft-loaded',
         title: (
@@ -100,7 +106,6 @@ const CreateWikiContent = () => {
               variant="outline"
               onClick={() => {
                 removeDraftFromLocalStorage()
-                // reload the page to remove the draft
                 window.location.reload()
               }}
               sx={{
@@ -146,11 +151,11 @@ const CreateWikiContent = () => {
       // (commonMetaIds) and append edit specific meta data (editMetaIds) with empty values
       const wikiDt = initWikiData
       metadata = [
-        ...Object.values(CommonMetaIds).map((mId) => {
+        ...Object.values(CommonMetaIds).map(mId => {
           const meta = getWikiMetadataById(wikiDt, mId)
-          return { id: mId, value: meta?.value || '' }
+          return { id: mId, value: meta?.value ?? '' }
         }),
-        ...Object.values(EditSpecificMetaIds).map((mId) => ({
+        ...Object.values(EditSpecificMetaIds).map(mId => ({
           id: mId,
           value: '',
         })),
@@ -172,8 +177,6 @@ const CreateWikiContent = () => {
       })
     }
   }, [dispatch, revision, setCommitMessage, toast, wikiData])
-
-  // console.log({ content: wiki.content })
 
   return (
     <>
@@ -233,7 +236,7 @@ const Page: PageWithoutFooter = authenticatedRoute(
 
 Page.noFooter = true
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
+export const getServerSideProps: GetServerSideProps = async context => {
   const slug = context.params?.slug
   if (typeof slug === 'string') {
     store.dispatch(getWiki.initiate(slug))


### PR DESCRIPTION
# Fix Unnecessary Toast Notification on Wiki Draft Load

This PR addresses an issue where users were receiving toast notifications to reset the wiki content even when no changes had been made to the wiki data. We've introduced a deep equality check using the `isDeepEqual` function to compare the current wiki data against the draft stored in local storage. This ensures that the toast notification for resetting the wiki content is only shown when there are actual, meaningful differences between the stored draft and the displayed wiki data, enhancing the user experience by preventing unnecessary prompts.


Page: Create Wiki

Fixes : https://github.com/EveripediaNetwork/issues/issues/2628
