### PR TITLE
Fixes editing wiki slug gets removed from url.

### DIFF
--- a/src/lib/magic/connectors/dedicatedWalletConnector.ts
+++ b/src/lib/magic/connectors/dedicatedWalletConnector.ts
@@ -262,9 +262,15 @@ export function dedicatedWalletConnector({
         }
 
         const isLoggedIn = await magic.user.isLoggedIn()
-        if (isLoggedIn) return true
 
         const result = await magic.oauth.getRedirectResult()
+
+        if (result) {
+          localStorage.setItem('magicRedirectResult', JSON.stringify(result))
+        }
+
+        if (isLoggedIn) return true
+
         return result !== null
       } catch (error) {
         console.error('Error in isAuthorized:', error)

--- a/src/lib/magic/connectors/dedicatedWalletConnector.ts
+++ b/src/lib/magic/connectors/dedicatedWalletConnector.ts
@@ -75,7 +75,7 @@ type WagmiStoreState = {
 
 const isMagicConnected = () => {
   const localStorageData = JSON.parse(
-    localStorage.getItem('wagmi.store') || '',
+    localStorage.getItem('wagmi.store') ?? '',
   ) as WagmiStoreState
 
   if (localStorageData?.state?.connections?.value) {
@@ -83,13 +83,9 @@ const isMagicConnected = () => {
     const connections = localStorageData.state.connections.value
 
     // Check if any of the connections have a connector ID of "magic"
-    return connections.some(([, { connector }]) => {
-      if (connector) {
-        const { id } = connector // Destructure connector
-        return id?.toLowerCase() === 'magic'
-      }
-      return false
-    })
+    return connections.some(
+      ([, { connector }]) => connector?.id?.toLowerCase() === 'magic',
+    )
   }
   return false
 }


### PR DESCRIPTION
# Fixes editing wiki slug gets removed from url.

This pull request addresses the issue where editing the wiki slug removes it from the URL. The problem was due to a missing condition that preserves the wiki slug during editing. By adding this fix, the wiki slug remains intact in the URL after editing.

## How should this be tested?

- Visit any wiki: Navigate to any wiki page in the application.
- Click edit: Click on the edit button to enter the editing mode for the wiki content.
- Check URL slug: After entering the editing mode, observe the URL in the browser's address bar. Ensure that the URL slug, representing the wiki page being edited, remains unchanged. Verify that editing the wiki content does not cause the URL slug to be removed or altered unintentionally.

## Linked issues

Fixes https://github.com/EveripediaNetwork/issues/issues/2605
