### PR TITLE
add warning for locked metamask

### DIFF
--- a/src/components/CreateWiki/CreateWikiTopBar/WikiPublish/WikiPublishButton.tsx
+++ b/src/components/CreateWiki/CreateWikiTopBar/WikiPublish/WikiPublishButton.tsx
@@ -302,7 +302,7 @@ export const WikiPublishButton = () => {
   return (
     <>
       <Tooltip
-        isDisabled={!!userCanEdit}
+        isDisabled={userCanEdit && isUserConnected}
         p={2}
         rounded="md"
         placement="bottom-start"
@@ -310,7 +310,11 @@ export const WikiPublishButton = () => {
         color="white"
         bg="toolTipBg"
         hasArrow
-        label="Your address is not yet whitelisted"
+        label={
+          !isUserConnected
+            ? 'Your Metamask is locked'
+            : 'Your address is not yet whitelisted'
+        }
         mt="3"
       >
         {!isNewCreateWiki ? (


### PR DESCRIPTION
# Summary
Adds a tooltip to show when a user's metamask is locked

<img width="271" alt="Screenshot 2024-05-14 at 4 10 47 PM" src="https://github.com/EveripediaNetwork/ep-ui/assets/30352484/b9c90520-bafc-4af0-8fb9-0422209628a9">

## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/2648
