### PR TITLE
added additional url for twitter input field on edit wiki dialog box

### DIFF
--- a/src/data/WikiLinks.ts
+++ b/src/data/WikiLinks.ts
@@ -70,8 +70,12 @@ export const LINK_OPTIONS = [
     type: LinkType.SOCIAL,
     label: 'Twitter',
     icon: TwitterIcon,
-    tests: [/https:\/\/(www.)?twitter.com\/\w+/],
+    tests: [
+      /https:\/\/(www\.)?twitter\.com\/\w+/,
+      /https:\/\/(www\.)?x\.com\/\w+/,
+    ],
   },
+
   {
     id: CommonMetaIds.TIKTOK_PROFILE,
     type: LinkType.SOCIAL,


### PR DESCRIPTION
# Fix Twitter url issue

_Initially only Twitter URL with twitter.com is allowed on the add Twitter URL field, added regex for x.com to allow URL containing x to be added to the field_

## How should this be tested?

1. On iq.wiki page, login
2. Click on a wiki, on the wiki details page click the edit icon which takes you to the edit wiki page
3. On the edit wiki page click on edit wiki, and a dialogue comes up, you can add Twitter URL when you select options under the link label 

https://github.com/EveripediaNetwork/ep-ui/assets/48678691/9a40ae6c-2213-49f4-9273-b9badae559a5

## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/2677
