### PR TITLE
added commits to fix an tab issue

### DIFF
--- a/src/components/Landing/AboutIqgpt.tsx
+++ b/src/components/Landing/AboutIqgpt.tsx
@@ -78,7 +78,6 @@ const AboutIqgpt = () => {
             <LinkButton
               href={'https://iqgpt.com/'}
               target="_blank"
-              rel="noopener noreferrer"
               size="lg"
               variant="solid"
               px={{ base: 5 }}
@@ -90,7 +89,6 @@ const AboutIqgpt = () => {
             <LinkButton
               href={'https://iq.wiki/wiki/iq'}
               target="_blank"
-              rel="noopener noreferrer"
               size="lg"
               px={{ base: 5 }}
               fontSize={'12px'}

--- a/src/components/Landing/AboutIqgpt.tsx
+++ b/src/components/Landing/AboutIqgpt.tsx
@@ -77,6 +77,8 @@ const AboutIqgpt = () => {
           <HStack gap={4} pb={'70px'}>
             <LinkButton
               href={'https://iqgpt.com/'}
+              target="_blank"
+              rel="noopener noreferrer"
               size="lg"
               variant="solid"
               px={{ base: 5 }}
@@ -87,6 +89,8 @@ const AboutIqgpt = () => {
             </LinkButton>
             <LinkButton
               href={'https://iq.wiki/wiki/iq'}
+              target="_blank"
+              rel="noopener noreferrer"
               size="lg"
               px={{ base: 5 }}
               fontSize={'12px'}


### PR DESCRIPTION
### Fix the tab issue on the landing page of IQ.wiki 

#### Description 
when you click about iqgpt and about iq token buttons it should open in a new tab, this pr fixes such issues 

#### steps to test 

1. login to the landing page of iq.wiki 
2. Scroll down and click on the iqgpt button and about iq token button, it should open in a way tab 





