### PR TITLE
Fix optimization configuration in next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -19,9 +19,6 @@ const moduleExports = {
     config.optimization.moduleIds = 'deterministic'
     config.optimization.chunkIds = 'deterministic'
     config.optimization.minimize = true
-    config.optimization.runtimeChunk = {
-      name: (entrypoint) => `runtimechunk~${entrypoint.name}`,
-    }
     config.module.rules.push({
       test: /\.svg$/i,
       issuer: /\.[jt]sx?$/,


### PR DESCRIPTION
# Fix configuration in next config
- Reverted ```config.optimization.runtimeChunk = {
      name: (entrypoint) => `runtimechunk~${entrypoint.name}`,
    }```
