### PR TITLE
fix revision page translation issue

### DIFF
--- a/src/pages/revision/[id].tsx
+++ b/src/pages/revision/[id].tsx
@@ -143,6 +143,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
     ...(await serverSideTranslations(context.locale ?? 'en', [
       'revision',
       'common',
+      'wiki',
     ])),
   }
 


### PR DESCRIPTION
# Fix Revision translation issue
This  PR fixes the missing translation of some texts on the revision page

Before:
![image](https://github.com/EveripediaNetwork/ep-ui/assets/50779080/a43cde92-b17c-4b88-8026-b426c14539d9)


After:
![image](https://github.com/EveripediaNetwork/ep-ui/assets/50779080/8448c3fe-49cb-4ba5-b66f-0ba543879438)



## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/2740
