### PR TITLE
Fixes search char limit to 2

### DIFF
--- a/src/components/CreateWiki/EditorModals/EditWikiDetailsModal/LinkedWikisInput.tsx
+++ b/src/components/CreateWiki/EditorModals/EditWikiDetailsModal/LinkedWikisInput.tsx
@@ -25,6 +25,7 @@ import {
 import { store } from '@/store/store'
 import { RiArrowRightDownLine, RiCloseLine } from 'react-icons/ri'
 import { useTranslation } from 'next-i18next'
+import { CHAR_SEARCH_LIMIT } from '@/data/Constants'
 
 const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
   const dispatch = useAppDispatch()
@@ -41,8 +42,8 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
     tag?: string,
   ) => {
     const { data } = await store.dispatch(getWikisByTitle.initiate(query))
-    const filteredData = data?.filter((w) =>
-      w.tags.find((t) => t.id.toLocaleLowerCase() === tag),
+    const filteredData = data?.filter(w =>
+      w.tags.find(t => t.id.toLocaleLowerCase() === tag),
     )
     cb(filteredData ?? [])
   }
@@ -55,9 +56,9 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
   )
 
   useEffect(() => {
-    if (search.length >= 2) {
+    if (search.length >= CHAR_SEARCH_LIMIT) {
       setLoading(true)
-      debouncedFetchWikis(search, (data) => {
+      debouncedFetchWikis(search, data => {
         setResults(data.slice(0, 6))
         setLoading(false)
       })
@@ -91,18 +92,18 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
 
   const onlyLastTypeHasWikis =
     wiki.linkedWikis &&
-    Object.values(wiki.linkedWikis).filter((w) => w.length > 0).length === 1 &&
+    Object.values(wiki.linkedWikis).filter(w => w.length > 0).length === 1 &&
     Object.values(wiki.linkedWikis).reverse()[0].length > 0
 
   const containsLinkedWikis =
     wiki.linkedWikis &&
-    Object.values(wiki.linkedWikis).some((wikis) => wikis.length > 0)
+    Object.values(wiki.linkedWikis).some(wikis => wikis.length > 0)
 
   const getWikiPreviewByTitle = (
     wikiPreviews: WikiPreview[],
     wikiTitle: string,
   ): WikiPreview | undefined =>
-    wikiPreviews.find((preview) => preview.title === wikiTitle)
+    wikiPreviews.find(preview => preview.title === wikiTitle)
 
   return (
     <Stack rounded="md" _dark={{ borderColor: 'whiteAlpha.300' }} spacing="2">
@@ -115,13 +116,13 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
       >
         <Select
           value={linkType}
-          onChange={(e) => setLinkType(e.target.value as LinkedWikiKey)}
+          onChange={e => setLinkType(e.target.value as LinkedWikiKey)}
           h="40px"
           rounded="md"
           flex="5"
           placeholder={t('selectOption')}
         >
-          {Object.values(LinkedWikiKey).map((key) => (
+          {Object.values(LinkedWikiKey).map(key => (
             <chakra.option key={key} value={key}>
               {t(key)}
             </chakra.option>
@@ -131,8 +132,8 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
           <AutoComplete
             disableFilter
             suggestWhenEmpty
-            shouldRenderSuggestions={(q) => q.length >= 2}
-            openOnFocus={search.length >= 2}
+            shouldRenderSuggestions={q => q.length >= CHAR_SEARCH_LIMIT}
+            openOnFocus={search.length >= CHAR_SEARCH_LIMIT}
             emptyState={
               <Center>
                 <Text m={5} fontSize="xs" color="linkColor" textAlign="center">
@@ -141,7 +142,7 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
                 </Text>
               </Center>
             }
-            onSelectOption={(option) => {
+            onSelectOption={option => {
               const { title } = option.item.originalValue
               const wikiPreview = getWikiPreviewByTitle(results, title)
               setSelectedWiki(wikiPreview?.id ?? '')
@@ -155,7 +156,7 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
               disabled={!linkType}
               placeholder={t('searchWiki')}
               value={(search || selectedWiki) ?? ''}
-              onChange={(e) => {
+              onChange={e => {
                 setSearch(e.target.value)
               }}
               type="text"
@@ -170,7 +171,7 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
                 p={2}
                 px={0}
               >
-                {results.map((result) => (
+                {results.map(result => (
                   <AutoCompleteItem
                     px={4}
                     py={1}
@@ -220,7 +221,7 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
                   <Text fontSize="sm">{key}</Text>
                 </HStack>
                 <Wrap>
-                  {value.map((wikiId) => (
+                  {value.map(wikiId => (
                     <Button
                       key={`${wikiId}-${key}`}
                       display="flex"

--- a/src/components/CreateWiki/EditorModals/EditWikiDetailsModal/LinkedWikisInput.tsx
+++ b/src/components/CreateWiki/EditorModals/EditWikiDetailsModal/LinkedWikisInput.tsx
@@ -41,8 +41,8 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
     tag?: string,
   ) => {
     const { data } = await store.dispatch(getWikisByTitle.initiate(query))
-    const filteredData = data?.filter(w =>
-      w.tags.find(t => t.id.toLocaleLowerCase() === tag),
+    const filteredData = data?.filter((w) =>
+      w.tags.find((t) => t.id.toLocaleLowerCase() === tag),
     )
     cb(filteredData ?? [])
   }
@@ -57,7 +57,7 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
   useEffect(() => {
     if (search.length >= 2) {
       setLoading(true)
-      debouncedFetchWikis(search, data => {
+      debouncedFetchWikis(search, (data) => {
         setResults(data.slice(0, 6))
         setLoading(false)
       })
@@ -91,18 +91,18 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
 
   const onlyLastTypeHasWikis =
     wiki.linkedWikis &&
-    Object.values(wiki.linkedWikis).filter(w => w.length > 0).length === 1 &&
+    Object.values(wiki.linkedWikis).filter((w) => w.length > 0).length === 1 &&
     Object.values(wiki.linkedWikis).reverse()[0].length > 0
 
   const containsLinkedWikis =
     wiki.linkedWikis &&
-    Object.values(wiki.linkedWikis).some(wikis => wikis.length > 0)
+    Object.values(wiki.linkedWikis).some((wikis) => wikis.length > 0)
 
   const getWikiPreviewByTitle = (
     wikiPreviews: WikiPreview[],
     wikiTitle: string,
   ): WikiPreview | undefined =>
-    wikiPreviews.find(preview => preview.title === wikiTitle)
+    wikiPreviews.find((preview) => preview.title === wikiTitle)
 
   return (
     <Stack rounded="md" _dark={{ borderColor: 'whiteAlpha.300' }} spacing="2">
@@ -115,13 +115,13 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
       >
         <Select
           value={linkType}
-          onChange={e => setLinkType(e.target.value as LinkedWikiKey)}
+          onChange={(e) => setLinkType(e.target.value as LinkedWikiKey)}
           h="40px"
           rounded="md"
           flex="5"
           placeholder={t('selectOption')}
         >
-          {Object.values(LinkedWikiKey).map(key => (
+          {Object.values(LinkedWikiKey).map((key) => (
             <chakra.option key={key} value={key}>
               {t(key)}
             </chakra.option>
@@ -131,7 +131,7 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
           <AutoComplete
             disableFilter
             suggestWhenEmpty
-            shouldRenderSuggestions={q => q.length >= 2}
+            shouldRenderSuggestions={(q) => q.length >= 2}
             openOnFocus={search.length >= 2}
             emptyState={
               <Center>
@@ -141,7 +141,7 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
                 </Text>
               </Center>
             }
-            onSelectOption={option => {
+            onSelectOption={(option) => {
               const { title } = option.item.originalValue
               const wikiPreview = getWikiPreviewByTitle(results, title)
               setSelectedWiki(wikiPreview?.id ?? '')
@@ -155,7 +155,7 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
               disabled={!linkType}
               placeholder={t('searchWiki')}
               value={(search || selectedWiki) ?? ''}
-              onChange={e => {
+              onChange={(e) => {
                 setSearch(e.target.value)
               }}
               type="text"
@@ -170,7 +170,7 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
                 p={2}
                 px={0}
               >
-                {results.map(result => (
+                {results.map((result) => (
                   <AutoCompleteItem
                     px={4}
                     py={1}
@@ -220,7 +220,7 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
                   <Text fontSize="sm">{key}</Text>
                 </HStack>
                 <Wrap>
-                  {value.map(wikiId => (
+                  {value.map((wikiId) => (
                     <Button
                       key={`${wikiId}-${key}`}
                       display="flex"

--- a/src/components/CreateWiki/EditorModals/EditWikiDetailsModal/LinkedWikisInput.tsx
+++ b/src/components/CreateWiki/EditorModals/EditWikiDetailsModal/LinkedWikisInput.tsx
@@ -41,8 +41,8 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
     tag?: string,
   ) => {
     const { data } = await store.dispatch(getWikisByTitle.initiate(query))
-    const filteredData = data?.filter((w) =>
-      w.tags.find((t) => t.id.toLocaleLowerCase() === tag),
+    const filteredData = data?.filter(w =>
+      w.tags.find(t => t.id.toLocaleLowerCase() === tag),
     )
     cb(filteredData ?? [])
   }
@@ -55,9 +55,9 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
   )
 
   useEffect(() => {
-    if (search.length >= 3) {
+    if (search.length >= 2) {
       setLoading(true)
-      debouncedFetchWikis(search, (data) => {
+      debouncedFetchWikis(search, data => {
         setResults(data.slice(0, 6))
         setLoading(false)
       })
@@ -91,18 +91,18 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
 
   const onlyLastTypeHasWikis =
     wiki.linkedWikis &&
-    Object.values(wiki.linkedWikis).filter((w) => w.length > 0).length === 1 &&
+    Object.values(wiki.linkedWikis).filter(w => w.length > 0).length === 1 &&
     Object.values(wiki.linkedWikis).reverse()[0].length > 0
 
   const containsLinkedWikis =
     wiki.linkedWikis &&
-    Object.values(wiki.linkedWikis).some((wikis) => wikis.length > 0)
+    Object.values(wiki.linkedWikis).some(wikis => wikis.length > 0)
 
   const getWikiPreviewByTitle = (
     wikiPreviews: WikiPreview[],
     wikiTitle: string,
   ): WikiPreview | undefined =>
-    wikiPreviews.find((preview) => preview.title === wikiTitle)
+    wikiPreviews.find(preview => preview.title === wikiTitle)
 
   return (
     <Stack rounded="md" _dark={{ borderColor: 'whiteAlpha.300' }} spacing="2">
@@ -115,13 +115,13 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
       >
         <Select
           value={linkType}
-          onChange={(e) => setLinkType(e.target.value as LinkedWikiKey)}
+          onChange={e => setLinkType(e.target.value as LinkedWikiKey)}
           h="40px"
           rounded="md"
           flex="5"
           placeholder={t('selectOption')}
         >
-          {Object.values(LinkedWikiKey).map((key) => (
+          {Object.values(LinkedWikiKey).map(key => (
             <chakra.option key={key} value={key}>
               {t(key)}
             </chakra.option>
@@ -131,8 +131,8 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
           <AutoComplete
             disableFilter
             suggestWhenEmpty
-            shouldRenderSuggestions={(q) => q.length >= 3}
-            openOnFocus={search.length >= 3}
+            shouldRenderSuggestions={q => q.length >= 2}
+            openOnFocus={search.length >= 2}
             emptyState={
               <Center>
                 <Text m={5} fontSize="xs" color="linkColor" textAlign="center">
@@ -141,7 +141,7 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
                 </Text>
               </Center>
             }
-            onSelectOption={(option) => {
+            onSelectOption={option => {
               const { title } = option.item.originalValue
               const wikiPreview = getWikiPreviewByTitle(results, title)
               setSelectedWiki(wikiPreview?.id ?? '')
@@ -155,7 +155,7 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
               disabled={!linkType}
               placeholder={t('searchWiki')}
               value={(search || selectedWiki) ?? ''}
-              onChange={(e) => {
+              onChange={e => {
                 setSearch(e.target.value)
               }}
               type="text"
@@ -170,7 +170,7 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
                 p={2}
                 px={0}
               >
-                {results.map((result) => (
+                {results.map(result => (
                   <AutoCompleteItem
                     px={4}
                     py={1}
@@ -220,7 +220,7 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
                   <Text fontSize="sm">{key}</Text>
                 </HStack>
                 <Wrap>
-                  {value.map((wikiId) => (
+                  {value.map(wikiId => (
                     <Button
                       key={`${wikiId}-${key}`}
                       display="flex"

--- a/src/components/CreateWiki/EditorModals/EditWikiDetailsModal/LinkedWikisInput.tsx
+++ b/src/components/CreateWiki/EditorModals/EditWikiDetailsModal/LinkedWikisInput.tsx
@@ -42,8 +42,8 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
     tag?: string,
   ) => {
     const { data } = await store.dispatch(getWikisByTitle.initiate(query))
-    const filteredData = data?.filter(w =>
-      w.tags.find(t => t.id.toLocaleLowerCase() === tag),
+    const filteredData = data?.filter((w) =>
+      w.tags.find((t) => t.id.toLocaleLowerCase() === tag),
     )
     cb(filteredData ?? [])
   }
@@ -58,7 +58,7 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
   useEffect(() => {
     if (search.length >= CHAR_SEARCH_LIMIT) {
       setLoading(true)
-      debouncedFetchWikis(search, data => {
+      debouncedFetchWikis(search, (data) => {
         setResults(data.slice(0, 6))
         setLoading(false)
       })
@@ -92,18 +92,18 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
 
   const onlyLastTypeHasWikis =
     wiki.linkedWikis &&
-    Object.values(wiki.linkedWikis).filter(w => w.length > 0).length === 1 &&
+    Object.values(wiki.linkedWikis).filter((w) => w.length > 0).length === 1 &&
     Object.values(wiki.linkedWikis).reverse()[0].length > 0
 
   const containsLinkedWikis =
     wiki.linkedWikis &&
-    Object.values(wiki.linkedWikis).some(wikis => wikis.length > 0)
+    Object.values(wiki.linkedWikis).some((wikis) => wikis.length > 0)
 
   const getWikiPreviewByTitle = (
     wikiPreviews: WikiPreview[],
     wikiTitle: string,
   ): WikiPreview | undefined =>
-    wikiPreviews.find(preview => preview.title === wikiTitle)
+    wikiPreviews.find((preview) => preview.title === wikiTitle)
 
   return (
     <Stack rounded="md" _dark={{ borderColor: 'whiteAlpha.300' }} spacing="2">
@@ -116,13 +116,13 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
       >
         <Select
           value={linkType}
-          onChange={e => setLinkType(e.target.value as LinkedWikiKey)}
+          onChange={(e) => setLinkType(e.target.value as LinkedWikiKey)}
           h="40px"
           rounded="md"
           flex="5"
           placeholder={t('selectOption')}
         >
-          {Object.values(LinkedWikiKey).map(key => (
+          {Object.values(LinkedWikiKey).map((key) => (
             <chakra.option key={key} value={key}>
               {t(key)}
             </chakra.option>
@@ -132,7 +132,7 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
           <AutoComplete
             disableFilter
             suggestWhenEmpty
-            shouldRenderSuggestions={q => q.length >= CHAR_SEARCH_LIMIT}
+            shouldRenderSuggestions={(q) => q.length >= CHAR_SEARCH_LIMIT}
             openOnFocus={search.length >= CHAR_SEARCH_LIMIT}
             emptyState={
               <Center>
@@ -142,7 +142,7 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
                 </Text>
               </Center>
             }
-            onSelectOption={option => {
+            onSelectOption={(option) => {
               const { title } = option.item.originalValue
               const wikiPreview = getWikiPreviewByTitle(results, title)
               setSelectedWiki(wikiPreview?.id ?? '')
@@ -156,7 +156,7 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
               disabled={!linkType}
               placeholder={t('searchWiki')}
               value={(search || selectedWiki) ?? ''}
-              onChange={e => {
+              onChange={(e) => {
                 setSearch(e.target.value)
               }}
               type="text"
@@ -171,7 +171,7 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
                 p={2}
                 px={0}
               >
-                {results.map(result => (
+                {results.map((result) => (
                   <AutoCompleteItem
                     px={4}
                     py={1}
@@ -221,7 +221,7 @@ const LinkedWikisInput = ({ wiki }: { wiki: Wiki }) => {
                   <Text fontSize="sm">{key}</Text>
                 </HStack>
                 <Wrap>
-                  {value.map(wikiId => (
+                  {value.map((wikiId) => (
                     <Button
                       key={`${wikiId}-${key}`}
                       display="flex"

--- a/src/components/Layout/Navbar/NavSearch/index.tsx
+++ b/src/components/Layout/Navbar/NavSearch/index.tsx
@@ -32,7 +32,7 @@ import { useRouter } from 'next/router'
 import config from '@/config'
 import { LinkButton } from '@/components/Elements'
 import SearchSEO from '@/components/SEO/Search'
-import { WIKI_IMAGE_ASPECT_RATIO } from '@/data/Constants'
+import { CHAR_SEARCH_LIMIT, WIKI_IMAGE_ASPECT_RATIO } from '@/data/Constants'
 import { WikiImage } from '@/components/WikiImage'
 import DisplayAvatar from '@/components/Elements/Avatar/DisplayAvatar'
 import { logEvent } from '@/utils/googleAnalytics'
@@ -85,7 +85,7 @@ const NavSearch = (props: NavSearchProps) => {
 
   const inputRef = useRef<HTMLInputElement | null>(null)
 
-  useEventListener('keydown', (event) => {
+  useEventListener('keydown', event => {
     const isMac = /(Mac|iPhone|iPod|iPad)/i.test(navigator?.userAgent)
     const hotkey = isMac ? 'metaKey' : 'ctrlKey'
     const el = event.target as Element | undefined
@@ -146,7 +146,7 @@ const NavSearch = (props: NavSearchProps) => {
 
   const wikisSearchList = (
     <>
-      {results.wikis?.slice(0, WIKIS_LIMIT).map((wiki) => {
+      {results.wikis?.slice(0, WIKIS_LIMIT).map(wiki => {
         const wikiImage = `${config.pinataBaseUrl}${wiki.images?.[0].id}`
         const value = fillType(wiki, SEARCH_TYPES.WIKI)
         // This negates the bug that is caused by two wikis with the same title.
@@ -155,7 +155,7 @@ const NavSearch = (props: NavSearchProps) => {
           <AutoCompleteItem
             key={wiki.id}
             value={value}
-            getValue={(art) => art.title}
+            getValue={art => art.title}
             label={wiki.title}
             onClick={() => setHamburger(false)}
             {...generalItemStyles}
@@ -184,7 +184,7 @@ const NavSearch = (props: NavSearchProps) => {
               maxWidth="fit-content"
               display={wiki.tags.length > 0 ? 'flex' : 'none'}
             >
-              {wiki.tags?.map((tag) => (
+              {wiki.tags?.map(tag => (
                 <chakra.div
                   key={`${wiki.id}-${tag.id}`}
                   fontWeight="medium"
@@ -211,13 +211,13 @@ const NavSearch = (props: NavSearchProps) => {
 
   const accountsSearchList = (
     <>
-      {results.accounts?.slice(0, ACCOUNTS_LIMIT).map((account) => {
+      {results.accounts?.slice(0, ACCOUNTS_LIMIT).map(account => {
         const value = fillType(account, SEARCH_TYPES.ACCOUNT)
         return (
           <AutoCompleteItem
             key={account.id}
             value={value}
-            getValue={(acc) => acc.username}
+            getValue={acc => acc.username}
             label={account.bio}
             onClick={() => setHamburger(false)}
             {...generalItemStyles}
@@ -243,13 +243,13 @@ const NavSearch = (props: NavSearchProps) => {
 
   const categoriesSearchList = (
     <>
-      {results.categories?.slice(0, CATEGORIES_LIMIT).map((category) => {
+      {results.categories?.slice(0, CATEGORIES_LIMIT).map(category => {
         const value = fillType(category, SEARCH_TYPES.CATEGORY)
         return (
           <AutoCompleteItem
             key={category.id}
             value={value}
-            getValue={(art) => art.title}
+            getValue={art => art.title}
             label={category.title}
             onClick={() => setHamburger(false)}
             {...generalItemStyles}
@@ -294,9 +294,9 @@ const NavSearch = (props: NavSearchProps) => {
         disableFilter
         suggestWhenEmpty
         emptyState={!isLoading && noResults && emptyState}
-        shouldRenderSuggestions={(q) => q.length >= 3}
-        openOnFocus={query.length >= 3}
-        onSelectOption={(option) => {
+        shouldRenderSuggestions={q => q.length >= CHAR_SEARCH_LIMIT}
+        openOnFocus={query.length >= CHAR_SEARCH_LIMIT}
+        onSelectOption={option => {
           const { id, type } = option.item.originalValue
           router.push(ItemPaths[type as SearchItem] + id)
           logEvent({
@@ -324,7 +324,7 @@ const NavSearch = (props: NavSearchProps) => {
             maxW={{ base: 'unset', md: '600px' }}
             ml={{ base: '15px', xl: 'unset' }}
             value={query}
-            onChange={(e) => setQuery(e.target.value)}
+            onChange={e => setQuery(e.target.value)}
             placeholder={t('SearchWikiPlaceholder')}
             _placeholderShown={{
               textOverflow: 'ellipsis',

--- a/src/components/Layout/Navbar/NavSearch/index.tsx
+++ b/src/components/Layout/Navbar/NavSearch/index.tsx
@@ -85,7 +85,7 @@ const NavSearch = (props: NavSearchProps) => {
 
   const inputRef = useRef<HTMLInputElement | null>(null)
 
-  useEventListener('keydown', event => {
+  useEventListener('keydown', (event) => {
     const isMac = /(Mac|iPhone|iPod|iPad)/i.test(navigator?.userAgent)
     const hotkey = isMac ? 'metaKey' : 'ctrlKey'
     const el = event.target as Element | undefined
@@ -146,7 +146,7 @@ const NavSearch = (props: NavSearchProps) => {
 
   const wikisSearchList = (
     <>
-      {results.wikis?.slice(0, WIKIS_LIMIT).map(wiki => {
+      {results.wikis?.slice(0, WIKIS_LIMIT).map((wiki) => {
         const wikiImage = `${config.pinataBaseUrl}${wiki.images?.[0].id}`
         const value = fillType(wiki, SEARCH_TYPES.WIKI)
         // This negates the bug that is caused by two wikis with the same title.
@@ -155,7 +155,7 @@ const NavSearch = (props: NavSearchProps) => {
           <AutoCompleteItem
             key={wiki.id}
             value={value}
-            getValue={art => art.title}
+            getValue={(art) => art.title}
             label={wiki.title}
             onClick={() => setHamburger(false)}
             {...generalItemStyles}
@@ -184,7 +184,7 @@ const NavSearch = (props: NavSearchProps) => {
               maxWidth="fit-content"
               display={wiki.tags.length > 0 ? 'flex' : 'none'}
             >
-              {wiki.tags?.map(tag => (
+              {wiki.tags?.map((tag) => (
                 <chakra.div
                   key={`${wiki.id}-${tag.id}`}
                   fontWeight="medium"
@@ -211,13 +211,13 @@ const NavSearch = (props: NavSearchProps) => {
 
   const accountsSearchList = (
     <>
-      {results.accounts?.slice(0, ACCOUNTS_LIMIT).map(account => {
+      {results.accounts?.slice(0, ACCOUNTS_LIMIT).map((account) => {
         const value = fillType(account, SEARCH_TYPES.ACCOUNT)
         return (
           <AutoCompleteItem
             key={account.id}
             value={value}
-            getValue={acc => acc.username}
+            getValue={(acc) => acc.username}
             label={account.bio}
             onClick={() => setHamburger(false)}
             {...generalItemStyles}
@@ -243,13 +243,13 @@ const NavSearch = (props: NavSearchProps) => {
 
   const categoriesSearchList = (
     <>
-      {results.categories?.slice(0, CATEGORIES_LIMIT).map(category => {
+      {results.categories?.slice(0, CATEGORIES_LIMIT).map((category) => {
         const value = fillType(category, SEARCH_TYPES.CATEGORY)
         return (
           <AutoCompleteItem
             key={category.id}
             value={value}
-            getValue={art => art.title}
+            getValue={(art) => art.title}
             label={category.title}
             onClick={() => setHamburger(false)}
             {...generalItemStyles}
@@ -294,9 +294,9 @@ const NavSearch = (props: NavSearchProps) => {
         disableFilter
         suggestWhenEmpty
         emptyState={!isLoading && noResults && emptyState}
-        shouldRenderSuggestions={q => q.length >= CHAR_SEARCH_LIMIT}
+        shouldRenderSuggestions={(q) => q.length >= CHAR_SEARCH_LIMIT}
         openOnFocus={query.length >= CHAR_SEARCH_LIMIT}
-        onSelectOption={option => {
+        onSelectOption={(option) => {
           const { id, type } = option.item.originalValue
           router.push(ItemPaths[type as SearchItem] + id)
           logEvent({
@@ -324,7 +324,7 @@ const NavSearch = (props: NavSearchProps) => {
             maxW={{ base: 'unset', md: '600px' }}
             ml={{ base: '15px', xl: 'unset' }}
             value={query}
-            onChange={e => setQuery(e.target.value)}
+            onChange={(e) => setQuery(e.target.value)}
             placeholder={t('SearchWikiPlaceholder')}
             _placeholderShown={{
               textOverflow: 'ellipsis',

--- a/src/components/Settings/Notification/SearchWikiNotifications.tsx
+++ b/src/components/Settings/Notification/SearchWikiNotifications.tsx
@@ -29,7 +29,7 @@ import {
 import { LinkButton } from '@/components/Elements'
 import { logEvent } from '@/utils/googleAnalytics'
 import config from '@/config'
-import { WIKI_IMAGE_ASPECT_RATIO } from '@/data/Constants'
+import { CHAR_SEARCH_LIMIT, WIKI_IMAGE_ASPECT_RATIO } from '@/data/Constants'
 import { WikiImage } from '@/components/WikiImage'
 import {
   RemoveWikiSubscriptionHandler,
@@ -80,7 +80,7 @@ const WikiSubscriptionButton = ({
         alignItems={{ base: 'center' }}
         justifyContent={{ base: 'center' }}
         fontWeight={500}
-        onClick={(e) => {
+        onClick={e => {
           e.stopPropagation()
           SubscribeWikiHandler(email, wiki, userAddress, toast)
         }}
@@ -105,7 +105,7 @@ const WikiSubscriptionButton = ({
       alignItems={{ base: 'center' }}
       justifyContent={{ base: 'center' }}
       fontWeight={500}
-      onClick={(e) => {
+      onClick={e => {
         e.stopPropagation()
         RemoveWikiSubscriptionHandler(email, wiki.id, userAddress!, toast)
       }}
@@ -137,7 +137,7 @@ const SearchWikiNotifications = () => {
   const unrenderedWikis = results.wikis.length - ARTICLES_LIMIT
   const totalUnrenderedWikis = unrenderedWikis > 0 ? unrenderedWikis : 0
 
-  useEventListener('keydown', (event) => {
+  useEventListener('keydown', event => {
     const isMac = /(Mac|iPhone|iPod|iPad)/i.test(navigator?.userAgent)
     const hotkey = isMac ? 'metaKey' : 'ctrlKey'
     const el = event.target as Element | undefined
@@ -171,14 +171,14 @@ const SearchWikiNotifications = () => {
 
   const articlesSearchList = results.wikis
     .slice(0, ARTICLES_LIMIT)
-    .map((wiki) => {
+    .map(wiki => {
       const articleImage = `${config.pinataBaseUrl}${wiki.images?.[0].id}`
       const value = fillType(wiki, SEARCH_TYPES.WIKI)
       return (
         <AutoCompleteItem
           key={wiki.id}
           value={value}
-          getValue={(art) => art.title}
+          getValue={art => art.title}
           label={wiki.title}
           m={0}
           rounded="none"
@@ -232,9 +232,9 @@ const SearchWikiNotifications = () => {
         disableFilter
         suggestWhenEmpty
         emptyState={!isLoading && noResults && emptyState}
-        openOnFocus={query.length >= 3}
-        shouldRenderSuggestions={(q) => q.length >= 3}
-        onSelectOption={(option) => {
+        openOnFocus={query.length >= CHAR_SEARCH_LIMIT}
+        shouldRenderSuggestions={q => q.length >= CHAR_SEARCH_LIMIT}
+        onSelectOption={option => {
           const { id, type } = option.item.originalValue
           router.push(ItemPaths[type as SearchItem] + id)
           logEvent({
@@ -248,7 +248,7 @@ const SearchWikiNotifications = () => {
         <form
           key={JSON.stringify(router.query.q) || ''}
           action=""
-          onSubmit={(e) => {
+          onSubmit={e => {
             e.preventDefault()
             router.push({
               pathname: '/settings/account',
@@ -273,7 +273,7 @@ const SearchWikiNotifications = () => {
                 placeholder="Search to add wikis to your list"
                 variant="unstyled"
                 value={query || router.query.q}
-                onChange={(e) => {
+                onChange={e => {
                   setQuery(() => {
                     return e.target.value
                   })

--- a/src/components/Settings/Notification/SearchWikiNotifications.tsx
+++ b/src/components/Settings/Notification/SearchWikiNotifications.tsx
@@ -80,7 +80,7 @@ const WikiSubscriptionButton = ({
         alignItems={{ base: 'center' }}
         justifyContent={{ base: 'center' }}
         fontWeight={500}
-        onClick={e => {
+        onClick={(e) => {
           e.stopPropagation()
           SubscribeWikiHandler(email, wiki, userAddress, toast)
         }}
@@ -105,7 +105,7 @@ const WikiSubscriptionButton = ({
       alignItems={{ base: 'center' }}
       justifyContent={{ base: 'center' }}
       fontWeight={500}
-      onClick={e => {
+      onClick={(e) => {
         e.stopPropagation()
         RemoveWikiSubscriptionHandler(email, wiki.id, userAddress!, toast)
       }}
@@ -137,7 +137,7 @@ const SearchWikiNotifications = () => {
   const unrenderedWikis = results.wikis.length - ARTICLES_LIMIT
   const totalUnrenderedWikis = unrenderedWikis > 0 ? unrenderedWikis : 0
 
-  useEventListener('keydown', event => {
+  useEventListener('keydown', (event) => {
     const isMac = /(Mac|iPhone|iPod|iPad)/i.test(navigator?.userAgent)
     const hotkey = isMac ? 'metaKey' : 'ctrlKey'
     const el = event.target as Element | undefined
@@ -171,14 +171,14 @@ const SearchWikiNotifications = () => {
 
   const articlesSearchList = results.wikis
     .slice(0, ARTICLES_LIMIT)
-    .map(wiki => {
+    .map((wiki) => {
       const articleImage = `${config.pinataBaseUrl}${wiki.images?.[0].id}`
       const value = fillType(wiki, SEARCH_TYPES.WIKI)
       return (
         <AutoCompleteItem
           key={wiki.id}
           value={value}
-          getValue={art => art.title}
+          getValue={(art) => art.title}
           label={wiki.title}
           m={0}
           rounded="none"
@@ -233,8 +233,8 @@ const SearchWikiNotifications = () => {
         suggestWhenEmpty
         emptyState={!isLoading && noResults && emptyState}
         openOnFocus={query.length >= CHAR_SEARCH_LIMIT}
-        shouldRenderSuggestions={q => q.length >= CHAR_SEARCH_LIMIT}
-        onSelectOption={option => {
+        shouldRenderSuggestions={(q) => q.length >= CHAR_SEARCH_LIMIT}
+        onSelectOption={(option) => {
           const { id, type } = option.item.originalValue
           router.push(ItemPaths[type as SearchItem] + id)
           logEvent({
@@ -248,7 +248,7 @@ const SearchWikiNotifications = () => {
         <form
           key={JSON.stringify(router.query.q) || ''}
           action=""
-          onSubmit={e => {
+          onSubmit={(e) => {
             e.preventDefault()
             router.push({
               pathname: '/settings/account',
@@ -273,7 +273,7 @@ const SearchWikiNotifications = () => {
                 placeholder="Search to add wikis to your list"
                 variant="unstyled"
                 value={query || router.query.q}
-                onChange={e => {
+                onChange={(e) => {
                   setQuery(() => {
                     return e.target.value
                   })

--- a/src/data/Constants.ts
+++ b/src/data/Constants.ts
@@ -11,3 +11,4 @@ export const WIKI_SUMMARY_GEN_RATE_LIMIT_MAX_REQUESTS = 5
 export const GPT3_COST_PER_1K_TOKENS = 0.02
 export const GPT3_MAX_TRIES = 3
 export const IMAGE_BOX_SIZE = 150
+export const CHAR_SEARCH_LIMIT = 2

--- a/src/editor-plugins/wikiLink/frame/index.tsx
+++ b/src/editor-plugins/wikiLink/frame/index.tsx
@@ -11,6 +11,7 @@ import {
   getWikiSummary,
   WikiSummarySize,
 } from '@/utils/WikiUtils/getWikiSummary'
+import { CHAR_SEARCH_LIMIT } from '@/data/Constants'
 
 const DISPLAY_LIMIT = 10
 
@@ -48,7 +49,7 @@ const WikiLinkFrame = ({ editorContext }: { editorContext: PluginContext }) => {
     setTimeout(() => {
       const popupBtn = document.querySelector('.wikiLink__popupBtn')
       popupBtn?.addEventListener('click', () => {
-        setTriggerCleanup((p) => !p)
+        setTriggerCleanup(p => !p)
       })
     }, 500)
   }, [])
@@ -58,11 +59,11 @@ const WikiLinkFrame = ({ editorContext }: { editorContext: PluginContext }) => {
     setResults([])
     setWikiSelected(null)
     const windowSelection = window.getSelection()?.toString()
-    setUserSelectedText(windowSelection || null)
-    setSearch(windowSelection || '')
-    if (windowSelection && windowSelection.length > 3) {
+    setUserSelectedText(windowSelection ?? null)
+    setSearch(windowSelection ?? '')
+    if (windowSelection && windowSelection.length > CHAR_SEARCH_LIMIT) {
       setLoading(true)
-      debouncedFetchWikis(windowSelection, (data) => {
+      debouncedFetchWikis(windowSelection, data => {
         setResults(data)
         setOffset(0)
         setWikiList(data.slice(0, DISPLAY_LIMIT))
@@ -72,9 +73,9 @@ const WikiLinkFrame = ({ editorContext }: { editorContext: PluginContext }) => {
   }, [triggerCleanup])
 
   useEffect(() => {
-    if (search.length >= 3) {
+    if (search.length >= CHAR_SEARCH_LIMIT) {
       setLoading(true)
-      debouncedFetchWikis(search, (data) => {
+      debouncedFetchWikis(search, data => {
         setResults(data)
         setWikiList(data.slice(0, DISPLAY_LIMIT))
         setOffset(0)
@@ -91,7 +92,7 @@ const WikiLinkFrame = ({ editorContext }: { editorContext: PluginContext }) => {
 
     const payload = {
       url: `${config.publicDomain}/wiki/${wikiSelected.id}`,
-      text: userSelectedText || wikiSelected.title,
+      text: userSelectedText ?? wikiSelected.title,
     }
 
     eventEmitter.emit('command', 'wikiLink', payload)
@@ -108,7 +109,7 @@ const WikiLinkFrame = ({ editorContext }: { editorContext: PluginContext }) => {
         <input
           className="wikiLink__input"
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={e => setSearch(e.target.value)}
           type="text"
           placeholder="Search Wiki"
         />
@@ -119,7 +120,7 @@ const WikiLinkFrame = ({ editorContext }: { editorContext: PluginContext }) => {
             {shortenText(wikiSelected.title, 30)}
           </h3>
           <div className="wikiLink__previewTagsContainer">
-            {wikiSelected.tags?.map((tag) => (
+            {wikiSelected.tags?.map(tag => (
               <span
                 style={{
                   backgroundColor: `hsl(${Math.floor(
@@ -151,7 +152,7 @@ const WikiLinkFrame = ({ editorContext }: { editorContext: PluginContext }) => {
       )}
       {wikiList.length > 0 && !wikiSelected && (
         <div className="wikiLink__resultsContainer">
-          {wikiList.map((wiki) => (
+          {wikiList.map(wiki => (
             <button
               key={wiki.id}
               type="button"

--- a/src/editor-plugins/wikiLink/frame/index.tsx
+++ b/src/editor-plugins/wikiLink/frame/index.tsx
@@ -49,7 +49,7 @@ const WikiLinkFrame = ({ editorContext }: { editorContext: PluginContext }) => {
     setTimeout(() => {
       const popupBtn = document.querySelector('.wikiLink__popupBtn')
       popupBtn?.addEventListener('click', () => {
-        setTriggerCleanup(p => !p)
+        setTriggerCleanup((p) => !p)
       })
     }, 500)
   }, [])
@@ -63,7 +63,7 @@ const WikiLinkFrame = ({ editorContext }: { editorContext: PluginContext }) => {
     setSearch(windowSelection ?? '')
     if (windowSelection && windowSelection.length > CHAR_SEARCH_LIMIT) {
       setLoading(true)
-      debouncedFetchWikis(windowSelection, data => {
+      debouncedFetchWikis(windowSelection, (data) => {
         setResults(data)
         setOffset(0)
         setWikiList(data.slice(0, DISPLAY_LIMIT))
@@ -75,7 +75,7 @@ const WikiLinkFrame = ({ editorContext }: { editorContext: PluginContext }) => {
   useEffect(() => {
     if (search.length >= CHAR_SEARCH_LIMIT) {
       setLoading(true)
-      debouncedFetchWikis(search, data => {
+      debouncedFetchWikis(search, (data) => {
         setResults(data)
         setWikiList(data.slice(0, DISPLAY_LIMIT))
         setOffset(0)
@@ -109,7 +109,7 @@ const WikiLinkFrame = ({ editorContext }: { editorContext: PluginContext }) => {
         <input
           className="wikiLink__input"
           value={search}
-          onChange={e => setSearch(e.target.value)}
+          onChange={(e) => setSearch(e.target.value)}
           type="text"
           placeholder="Search Wiki"
         />
@@ -120,7 +120,7 @@ const WikiLinkFrame = ({ editorContext }: { editorContext: PluginContext }) => {
             {shortenText(wikiSelected.title, 30)}
           </h3>
           <div className="wikiLink__previewTagsContainer">
-            {wikiSelected.tags?.map(tag => (
+            {wikiSelected.tags?.map((tag) => (
               <span
                 style={{
                   backgroundColor: `hsl(${Math.floor(
@@ -152,7 +152,7 @@ const WikiLinkFrame = ({ editorContext }: { editorContext: PluginContext }) => {
       )}
       {wikiList.length > 0 && !wikiSelected && (
         <div className="wikiLink__resultsContainer">
-          {wikiList.map(wiki => (
+          {wikiList.map((wiki) => (
             <button
               key={wiki.id}
               type="button"

--- a/src/services/search/utils.ts
+++ b/src/services/search/utils.ts
@@ -16,6 +16,7 @@ import {
   getEventByLocation,
   getEventsByTags,
 } from '../event'
+import { CHAR_SEARCH_LIMIT } from '@/data/Constants'
 
 export type Account = {
   id: string
@@ -124,7 +125,7 @@ export const useNavSearch = () => {
   })
 
   useEffect(() => {
-    if (query && query.length >= 3) {
+    if (query && query.length >= CHAR_SEARCH_LIMIT) {
       setIsLoading(true)
       debouncedFetchResults(query, (res) => {
         if (!res.accounts && !res.wikis && !res.categories) {


### PR DESCRIPTION
# Fixes search char limit to 2

This pull request updates the search functionality in our application by modifying the `CHAR_SEARCH_LIMIT` constant. Previously, the search would only initiate when a user had typed at least 3 characters. This limit has been reduced to 2 characters, allowing the search to begin sooner and potentially improving user experience by providing faster feedback when users are searching with shorter queries.

### Changes:
- Changed the `CHAR_SEARCH_LIMIT` from a hardcoded number to a constant for better clarity and maintainability.
- Reduced the `CHAR_SEARCH_LIMIT` from 3 to 2.

## How should this be tested?

1. **Initial Setup**: Ensure that the code changes are correctly implemented in your local or staging environment.
2. **Search Functionality Test**:
   - Navigate to [iq.wiki](https://iq.wiki) and use the navigation search bar.
   - Begin typing a search term. Notice that the search should now activate and begin fetching results as soon as you type 2 characters.
   - Test with a variety of inputs to ensure that the search triggers correctly at 2 characters and that results are relevant and accurate.
3. **Edge Case Handling**:
   - Test with single-character inputs to confirm that no search is triggered.
   - Test with special characters and numbers to assess how the search handles less typical input.

## Linked issues


Fixes: https://github.com/EveripediaNetwork/issues/issues/2745