### PR TITLE
Fix inavlid url error

### DIFF
--- a/src/components/Wiki/WikiPage/InsightComponents/ProfileSummary.tsx
+++ b/src/components/Wiki/WikiPage/InsightComponents/ProfileSummary.tsx
@@ -12,11 +12,7 @@ import {
   VStack,
   Wrap,
 } from '@chakra-ui/react'
-import {
-  CommonMetaIds,
-  Wiki,
-  WikiPossibleSocialsList,
-} from '@everipedia/iq-utils'
+import { CommonMetaIds, Wiki } from '@everipedia/iq-utils'
 import { FiExternalLink } from 'react-icons/fi'
 import { shortenText } from '@/utils/textUtils'
 import { LinkType, LINK_OPTIONS } from '@/data/WikiLinks'
@@ -67,8 +63,9 @@ const ProfileListItem = ({
 
 const ProfileSummary = ({ wiki }: ProfileSummaryProps) => {
   const socialMetaData = wiki.metadata.filter((meta) =>
-    WikiPossibleSocialsList.includes(meta.id as CommonMetaIds),
+    LINK_OPTIONS.find((option) => option.id === meta.id),
   )
+
   const { t } = useTranslation('wiki')
   if (!socialMetaData.length) return null
 
@@ -82,6 +79,7 @@ const ProfileSummary = ({ wiki }: ProfileSummaryProps) => {
       LINK_OPTIONS.find((option) => option.id === item.id)?.type ===
       LinkType.EXPLORER,
   )
+
 
   const contractURL = socialMetaData.find(
     (item) => item.id === CommonMetaIds.CONTRACT_URL,
@@ -172,10 +170,11 @@ const ProfileSummary = ({ wiki }: ProfileSummaryProps) => {
             </Wrap>
           </ProfileListItem>
         )}
+
         {explorerLinksData.length > 0 && (
           <ProfileListItem title={t('Explorers')}>
-            {explorerLinksData.map((item) => (
-              <HStack>
+            {explorerLinksData.map((item, i) => (
+              <HStack key={i}>
                 <Link
                   color="brandLinkColor"
                   fontSize="14px"
@@ -195,6 +194,7 @@ const ProfileSummary = ({ wiki }: ProfileSummaryProps) => {
             ))}
           </ProfileListItem>
         )}
+
         {wiki.linkedWikis?.founders &&
           wiki.linkedWikis?.founders?.length > 0 && (
             <ProfileListItem

--- a/src/data/WikiLinks.ts
+++ b/src/data/WikiLinks.ts
@@ -233,6 +233,7 @@ export const LINK_OPTIONS = [
     type: LinkType.EXPLORER,
     label: 'Tronscan',
     icon: FaFileContract,
-    tests: [/https:\/\/(www.)?tronscan.com\/\w+/],
+    tests: [/https:\/\/(www\.)?tronscan\.org\/#\/token20\/\w+/],
+
   },
 ]

--- a/src/data/WikiLinks.ts
+++ b/src/data/WikiLinks.ts
@@ -234,6 +234,5 @@ export const LINK_OPTIONS = [
     label: 'Tronscan',
     icon: FaFileContract,
     tests: [/https:\/\/(www\.)?tronscan\.org\/#\/token20\/\w+/],
-
   },
 ]


### PR DESCRIPTION
# Fix Invalid Url error and incomplete urls on explorers List

This PR fixes the solscan url and other urls that are not been added to the explorers list. It also updates tronscan regex from tronscan.com  which throws invalid url format 

# Before
![image](https://github.com/EveripediaNetwork/ep-ui/assets/50779080/466e2e52-22b9-4432-952b-e2f375bde446)


![image](https://github.com/EveripediaNetwork/ep-ui/assets/50779080/65552497-cdfc-47bd-9a44-0db3b14ac8da)

# After


https://github.com/EveripediaNetwork/ep-ui/assets/50779080/38688684-4f73-4bb1-8163-1e3f94bafb8e


## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/2809
