### PR TITLE
Remove 'person_profiles' setting from PostHog initialization

### DIFF
--- a/src/components/Layout/CSPostHogProvider.tsx
+++ b/src/components/Layout/CSPostHogProvider.tsx
@@ -9,7 +9,6 @@ if (typeof window !== 'undefined') {
   posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
     api_host: '/ingest',
     ui_host: 'https://us.posthog.com',
-    person_profiles: 'identified_only',
   })
 }
 


### PR DESCRIPTION
# Changes
- Remove 'person_profiles' setting from PostHog initialization