### PR TITLE
update regex to verify urls for wiki details

### DIFF
--- a/src/data/WikiLinks.ts
+++ b/src/data/WikiLinks.ts
@@ -156,7 +156,7 @@ export const LINK_OPTIONS = [
     type: LinkType.CONTRACT,
     label: 'Contract URL',
     icon: FaFileContract,
-    tests: [/i/],
+    tests: [/[a-z]/],
   },
   {
     id: CommonMetaIds.ETHERSCAN_PROFILE,
@@ -205,7 +205,7 @@ export const LINK_OPTIONS = [
     type: LinkType.EXPLORER,
     label: 'FTMScan',
     icon: FaFileContract,
-    tests: [/https:\/\/(www.)?ftmscan.com\/\w+/],
+    tests: [/https:\/\/((www.)?ftmscan.com|explorer.fantom.network)\/\w+/],
   },
   {
     id: CommonMetaIds.SOLSCAN_PROFILE,


### PR DESCRIPTION
# Regex Test for urls on edit wiki details

This PR fixes regex for contract  urls and  phantom network 




# Notes 
Test urls for:
- Phantom Network: https://explorer.fantom.network/address/0xe7798097e7171b2922bd953180ac8c3bd3421b3b, https://ftmscan.com/tx/0x1f363d3da4d1225f48fd8ee9720e51b37f5b81c2be35138b96625183ee784a2c

Go to Edit Wiki Details as attached below to test
![image](https://github.com/EveripediaNetwork/ep-ui/assets/50779080/bd10e8d2-7987-4d85-8834-8215e84a060e)



## Linked issues

 closes https://github.com/EveripediaNetwork/issues/issues/2840
