### PR TITLE
refactored logic for capture edit/create wiki event

### DIFF
--- a/src/components/CreateWiki/CreateWikiTopBar/WikiPublish/WikiPublishButton.tsx
+++ b/src/components/CreateWiki/CreateWikiTopBar/WikiPublish/WikiPublishButton.tsx
@@ -158,17 +158,10 @@ export const WikiPublishButton = () => {
   }, [detectedProvider, userAddress])
 
   useEffect(() => {
-    const handleAsyncOperations = async () => {
-      if (activeStep === 3) {
-        prevEditedWiki.current.isPublished = true
-        posthog.capture('submit_wiki', {
-          wiki_slug: getWikiSlug(wiki),
-          isEdit: !isNewCreateWiki,
-        })
-        fireConfetti()
-      }
+    if (activeStep === 3) {
+      prevEditedWiki.current.isPublished = true
+      fireConfetti()
     }
-    handleAsyncOperations()
   }, [activeStep, fireConfetti])
 
   useEffect(() => {

--- a/src/components/CreateWiki/CreateWikiTopBar/WikiPublish/WikiPublishButton.tsx
+++ b/src/components/CreateWiki/CreateWikiTopBar/WikiPublish/WikiPublishButton.tsx
@@ -50,6 +50,7 @@ export type TGraphQLError = {
 export const WikiPublishButton = () => {
   const wiki = useAppSelector((state) => state.wiki)
   const { data } = useGetWikiQuery(wiki?.id || '')
+
   const [submittingWiki, setSubmittingWiki] = useBoolean()
   const { address: userAddress, isConnected: isUserConnected } = useAccount()
   const posthog = usePostHog()
@@ -157,10 +158,17 @@ export const WikiPublishButton = () => {
   }, [detectedProvider, userAddress])
 
   useEffect(() => {
-    if (activeStep === 3) {
-      prevEditedWiki.current.isPublished = true
-      fireConfetti()
+    const handleAsyncOperations = async () => {
+      if (activeStep === 3) {
+        prevEditedWiki.current.isPublished = true
+        posthog.capture('submit_wiki', {
+          wiki_slug: getWikiSlug(wiki),
+          isEdit: !isNewCreateWiki,
+        })
+        fireConfetti()
+      }
     }
+    handleAsyncOperations()
   }, [activeStep, fireConfetti])
 
   useEffect(() => {
@@ -234,10 +242,6 @@ export const WikiPublishButton = () => {
         return
       }
     }
-    posthog.capture('submit_wiki', {
-      wiki_slug: await getWikiSlug(wiki),
-      isEdit: !isNewCreateWiki,
-    })
 
     if (userAddress) {
       const ifWikiExists =

--- a/src/hooks/useGetSignedHash.ts
+++ b/src/hooks/useGetSignedHash.ts
@@ -19,6 +19,8 @@ import { domain, types } from '@/utils/CreateWikiUtils/domainType'
 import { useCreateWikiContext } from './useCreateWikiState'
 import config from '@/config'
 import { usePostHog } from 'posthog-js/react'
+import { useAppSelector } from '@/store/hook'
+import { getWikiSlug } from '@/utils/CreateWikiUtils/getWikiSlug'
 
 const getErrorMessage = (errorObject: any) => {
   if (errorObject.response?.errors && errorObject.response.errors.length > 0) {
@@ -46,6 +48,8 @@ export const useGetSignedHash = () => {
     dispatch,
   } = useCreateWikiContext()
   const posthog = usePostHog()
+
+  const wiki = useAppSelector((state) => state.wiki)
 
   const { address: userAddress, isConnected: isUserConnected } = useAccount()
   const deadline = useRef(0)
@@ -137,6 +141,10 @@ export const useGetSignedHash = () => {
                     value: '',
                   },
                 })
+              })
+              posthog.capture('submit_wiki', {
+                wiki_slug: await getWikiSlug(wiki),
+                isEdit: !isNewCreateWiki,
               })
               setCommitMessage('')
               removeDraftFromLocalStorage()


### PR DESCRIPTION
# Analysing Create/Edit Wiki Posthog Event

This PR works on investigating the event capture for create/edit wiki action.

## Issue Description
The wiki data analysis on /admin route for individual days is different from the wiki data analysis on [posthog](https://us.posthog.com/project/75413/insights/Sr5SRbfv)

## Notes or observations

- I noticed that the event was captured when the handleWikiPublish function was triggered, which does not accurately pick the wiki-created or edited events.
- The event was captured after the whole process was successful after the transactionHash had been verified.

## Linked issues

closes https://github.com/EveripediaNetwork/issues/issues/2863
