### PR TITLE
Search by username

### DIFF
--- a/src/services/search/index.ts
+++ b/src/services/search/index.ts
@@ -16,10 +16,6 @@ export type Account = {
   bio: string
   avatar: string
 }
-type AccountArgs = {
-  id: string
-  username: string
-}
 type GetWikisByTitleResponse = {
   wikisByTitle: WikiPreview[]
 }
@@ -60,10 +56,10 @@ export const navSearchApi = createApi({
       transformResponse: (response: GetCategoriesByTitleResponse) =>
         response.categoryByTitle,
     }),
-    getAccountsByTitle: builder.query<Account[], AccountArgs>({
-      query: ({ id, username }) => ({
+    getAccountsByTitle: builder.query<Account[], string>({
+      query: (username: string) => ({
         document: GET_USERNAME_BY_TITLE,
-        variables: { id, username },
+        variables: { username },
       }),
       transformResponse: (response: GetAccountsByTitleResponse) =>
         response.getProfileLikeUsername,

--- a/src/services/search/utils.ts
+++ b/src/services/search/utils.ts
@@ -23,10 +23,7 @@ export type Account = {
   bio: string
   avatar: string
 }
-type AccountArgs = {
-  id: string
-  username: string
-}
+
 type Results = {
   wikis: WikiPreview[]
   categories: CategoryDataType[]
@@ -94,7 +91,7 @@ export const fetchCategoriesList = async (query: string) => {
   return data
 }
 
-export const fetchAccountsList = async (query: AccountArgs) => {
+export const fetchAccountsList = async (query: string) => {
   const { data } = await store.dispatch(getAccountsByTitle.initiate(query))
   return data
 }
@@ -104,7 +101,7 @@ const debouncedFetchResults = debounce(
     Promise.all([
       fetchWikisList(query),
       fetchCategoriesList(query),
-      fetchAccountsList({ id: query, username: query }),
+      fetchAccountsList(query),
     ]).then((res) => {
       const [wikis = [], categories = [], accounts = []] = res
       cb({ wikis, categories, accounts })


### PR DESCRIPTION
# Search by username

This PR allows search results to display wiki account owners as opposed to just displaying by wiki titles and categories.


# Before

![image](https://github.com/user-attachments/assets/cc05946e-b161-4193-ba71-28431f14c505)

![image](https://github.com/user-attachments/assets/ba9e951d-2590-40f3-ab30-fdf51f1d3940)


# After

![image](https://github.com/user-attachments/assets/0b797e09-ad82-4ff8-8b15-b91ef6e64678)

![image](https://github.com/user-attachments/assets/87e6855b-bd80-4911-8358-20e553275afb)



closes https://github.com/EveripediaNetwork/issues/issues/2908
