### PR TITLE
fix homepage navigation issue

### DIFF
--- a/src/components/Landing/WikiCategories.tsx
+++ b/src/components/Landing/WikiCategories.tsx
@@ -55,24 +55,26 @@ export default function WikiCategories() {
         {randomCategories.map((category) => {
           return (
             <Link
-              href={`/categories/${category.id}`}
-              key={category.id}
+              href={`/categories/${category?.id}`}
+              key={category?.id}
               className="border-b border-gray-200 dark:border-gray-700 hover:bg-gray100 dark:hover:bg-alpha-100 cursor-pointer px-4 py-3.5 transition-all duration-300 ease-in-out delay-200 last:border-b-0 last:rounded-b-xl flex flex-row gap-3 items-center"
             >
               <div className="w-[68px] h-[46px] aspect-square rounded-md">
                 <Image
                   className="w-full h-full object-cover rounded-md"
-                  src={category.cardImage}
-                  alt={category.title}
+                  src={category?.cardImage}
+                  alt={category?.title}
                   width={450}
                   height={450}
                 />
               </div>
 
               <div className="flex-1 flex flex-col gap-1.5">
-                <div className="text-sm font-semibold">{t(category.title)}</div>
+                <div className="text-sm font-semibold">
+                  {t(category?.title)}
+                </div>
                 <h3 className="text-xs font-medium line-clamp-2">
-                  {t(category.description)}
+                  {t(category?.description)}
                 </h3>
               </div>
             </Link>

--- a/src/components/Layout/Navbar/Navbar.tsx
+++ b/src/components/Layout/Navbar/Navbar.tsx
@@ -69,14 +69,18 @@ const Navbar = () => {
       }}
     >
       <div className="flex gap-8 lg:gap-40 xl:gap-8 h-16 items-center justify-between px-4 lg:px-8 border-b lg:border-b-0 dark:border-alpha-200 border-gray-200">
-        <Link prefetch={false} href="/">
+        <div
+          onClick={() => router.push('/')}
+          onKeyDown={() => router.push('/')}
+          className="cursor-pointer"
+        >
           <div className="flex flex-row gap-2 items-center">
             <Logo />
             <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
               IQ.wiki
             </h1>
           </div>
-        </Link>
+        </div>
         <DesktopNav />
         <div className="hidden lg:block w-full">
           <Suspense>

--- a/src/components/Layout/Navbar/Navbar.tsx
+++ b/src/components/Layout/Navbar/Navbar.tsx
@@ -69,18 +69,14 @@ const Navbar = () => {
       }}
     >
       <div className="flex gap-8 lg:gap-40 xl:gap-8 h-16 items-center justify-between px-4 lg:px-8 border-b lg:border-b-0 dark:border-alpha-200 border-gray-200">
-        <div
-          onClick={() => router.push('/')}
-          onKeyDown={() => router.push('/')}
-          className="cursor-pointer"
-        >
+        <button onClick={() => router.push('/')} type="button">
           <div className="flex flex-row gap-2 items-center">
             <Logo />
             <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
               IQ.wiki
             </h1>
           </div>
-        </div>
+        </button>
         <DesktopNav />
         <div className="hidden lg:block w-full">
           <Suspense>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -214,7 +214,7 @@ export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
     )
   }
   let sortedPromotedWikis: PromotedWikisBuilder[] = []
-  if (promotedWikis) {
+  if (promotedWikis?.length) {
     sortedPromotedWikis = [...promotedWikis]
     sortedPromotedWikis?.sort((a, b) => a.promoted - b.promoted)
   }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -77,7 +77,6 @@ export const Index = ({
   trending,
   categories,
 }: HomePageProps) => {
-  console.log(leaderboards)
   return (
     <section>
       <Hero />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -77,6 +77,7 @@ export const Index = ({
   trending,
   categories,
 }: HomePageProps) => {
+  console.log(leaderboards)
   return (
     <section>
       <Hero />
@@ -88,7 +89,7 @@ export const Index = ({
         <CategoriesList categories={categories} />
         <EventOverview />
       </div>
-      {leaderboards.length > 0 && <LeaderBoard leaderboards={leaderboards} />}
+      {leaderboards?.length > 0 && <LeaderBoard leaderboards={leaderboards} />}
       <DiscoverMore tagsData={popularTags} />
     </section>
   )
@@ -214,7 +215,7 @@ export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
     )
   }
   let sortedPromotedWikis: PromotedWikisBuilder[] = []
-  if (promotedWikis?.length) {
+  if (promotedWikis) {
     sortedPromotedWikis = [...promotedWikis]
     sortedPromotedWikis?.sort((a, b) => a.promoted - b.promoted)
   }


### PR DESCRIPTION
# Fix homepage navigation issue

_After a user goes to a different page and navigates back to the homepage on click of the logo, the website breaks_

## How should this be tested?

1. When on the homepage, click on any link on the navbar or any card to redirect to different page, 
2. Then click on the IQ wiki logo to reproduce the error
3. Do that repeatedly across all pages and go back to homepage by clicking on the IQ wiki logo to test properly

closes https://github.com/EveripediaNetwork/issues/issues/3019
